### PR TITLE
2 small fixes to ubuntu build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,11 @@ https://github.com/KhronosGroup/OpenCL-Headers/tree/master/opencl22/)
     git clone https://github.com/gcp/leela-zero
     cd leela-zero/src
     sudo apt install libboost-all-dev libopenblas-dev opencl-headers ocl-icd-libopencl1 ocl-icd-opencl-dev
+    sudo apt-get install zlib1g-dev
     make
     cd ..
     wget https://sjeng.org/zero/best_v1.txt.zip
-    unzip https://sjeng.org/zero/best_v1.txt.zip
+    unzip best_v1.txt.zip
     src/leelaz --weights weights.txt
 
 ## Example of compiling and running - macOS


### PR DESCRIPTION
I went through the instructions to build in my ubuntu VM. 
I made two small fixes to the instructions.
Without "sudo apt-get install zlib1g-dev" it will not find zlib.h and fails to compile.

I was not able to access the nvidia graphics card on my host machine from the VM, so I got a core dump when initializing OpenCL.  I guess I will be trying to build on windows next.