### PR TITLE
Add "selfplay" option

### DIFF
--- a/autogtp/Game.cpp
+++ b/autogtp/Game.cpp
@@ -35,7 +35,7 @@ Game::Game(const QString& weights, QTextStream& out) :
 #endif
     cmdLine.append(" -g -q -n -d -m 30 -r 0 -w ");
     cmdLine.append(weights);
-    cmdLine.append(" -p 1000 --noponder");
+    cmdLine.append(" -p 1000 -s --noponder");
     fileName = QUuid::createUuid().toRfc4122().toHex();
 }
 

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -61,6 +61,7 @@ std::string cfg_weightsfile;
 std::string cfg_logfile;
 FILE* cfg_logfile_handle;
 bool cfg_quiet;
+bool cfg_selfplay;
 
 void GTP::setup_default_parameters() {
     cfg_allow_pondering = true;
@@ -663,7 +664,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
         cmdstream >> tmp;   // eat printsgf
         cmdstream >> filename;
 
-        auto sgf_text = SGFTree::state_to_string(game, 0);
+        auto sgf_text = SGFTree::state_to_string(game, 0, cfg_selfplay);
 
         if (cmdstream.fail()) {
             gtp_printf(id, "%s\n", sgf_text.c_str());

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -31,6 +31,7 @@ extern int cfg_resignpct;
 extern int cfg_noise;
 extern int cfg_random_cnt;
 extern bool cfg_dumbpass;
+extern bool cfg_selfplay;
 #ifdef USE_OPENCL
 extern std::vector<int> cfg_gpus;
 extern int cfg_rowtiles;

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -69,6 +69,7 @@ void parse_commandline(int argc, char *argv[], bool & gtp_mode) {
         ("logfile,l", po::value<std::string>(), "File to log input/output to.")
         ("quiet,q", "Disable all diagnostic output.")
         ("noponder", "Disable thinking on opponent's time.")
+        ("selfplay,s", "Self-play game.  Only modifies the sgf output.")
 #ifdef USE_OPENCL
         ("gpu",  po::value<std::vector<int> >(),
                 "ID of the OpenCL device(s) to use (disables autodetection).")
@@ -202,6 +203,10 @@ void parse_commandline(int argc, char *argv[], bool & gtp_mode) {
             myprintf("Using per-move time margin of %.2fs.\n", lagbuffer/100.0f);
             cfg_lagbuffer_cs = lagbuffer;
         }
+    }
+
+    if (vm.count("selfplay")) {
+      cfg_selfplay = true;
     }
 
 #ifdef USE_OPENCL

--- a/src/SGFTree.cpp
+++ b/src/SGFTree.cpp
@@ -398,7 +398,7 @@ std::vector<int> SGFTree::get_mainline() {
     return moves;
 }
 
-std::string SGFTree::state_to_string(GameState& pstate, int compcolor) {
+std::string SGFTree::state_to_string(GameState& pstate, int compcolor, bool selfplay) {
     auto state = std::make_unique<GameState>();
 
     // make a working copy
@@ -425,7 +425,10 @@ std::string SGFTree::state_to_string(GameState& pstate, int compcolor) {
         leela_name.append(" " + cfg_weightsfile);
     }
 
-    if (compcolor == FastBoard::WHITE) {
+    if (selfplay) {
+        header.append("PB[" + leela_name + "]");
+        header.append("PW[" + leela_name + "]");
+    } else if (compcolor == FastBoard::WHITE) {
         header.append("PW[" + leela_name + "]");
         header.append("PB[Human]");
     } else {

--- a/src/SGFTree.h
+++ b/src/SGFTree.h
@@ -51,7 +51,7 @@ public:
     };
     FastBoard::square_t get_winner();
 
-    static std::string state_to_string(GameState& state, int compcolor);
+    static std::string state_to_string(GameState& state, int compcolor, bool selfplay);
 
 private:
     void populate_states(void);


### PR DESCRIPTION
Add "selfplay" option, whose sole purpose is to output the correct data in the SGF file.

There's probably a better way to handle this.  But I didn't want to screw with the Fastboard enum just in case something else was relying on this.

