### PR TITLE
Retry instead of quitting in case of server problems

### DIFF
--- a/autogtp/Game.h
+++ b/autogtp/Game.h
@@ -21,12 +21,15 @@
 
 #include <QProcess>
 #include <QTextStream>
+#include <tuple>
+
+using VersionTuple = std::tuple<int, int>;
 
 class Game : QProcess {
 public:
     Game(const QString& weights, QTextStream& out);
     ~Game() = default;
-    bool gameStart();
+    bool gameStart(const VersionTuple& min_version);
     void move();
     bool waitForMove() { return waitReady(); }
     bool readMove();
@@ -40,7 +43,8 @@ private:
     enum {
         NO_LEELAZ = 1,
         PROCESS_DIED,
-        WRONG_GTP
+        WRONG_GTP,
+        LAUNCH_FAILURE
     };
 
     QTextStream& output;
@@ -54,6 +58,7 @@ private:
     int passes;
     int moveNum;
     bool sendGtpCommand(QString cmd);
+    void checkVersion(const VersionTuple &min_version);
     bool waitReady();
     bool eatNewLine();
     void error(int errnum);

--- a/autogtp/main.cpp
+++ b/autogtp/main.cpp
@@ -29,7 +29,10 @@
 #include <iostream>
 #include "Game.h"
 
-constexpr int AUTOGTP_VERSION = 3;
+constexpr int AUTOGTP_VERSION = 4;
+
+// Minimal Leela Zero version we expect to see
+const VersionTuple min_leelaz_version{0, 6};
 
 bool fetch_best_network_hash(QTextStream& cerr, QString& nethash) {
     QString prog_cmdline("curl");
@@ -156,7 +159,7 @@ bool upload_data(QTextStream& cerr, const QString& netname, QString sgf_output_p
 bool run_one_game(QTextStream& cerr, const QString& weightsname) {
 
     Game game(weightsname, cerr);
-    if(!game.gameStart()) {
+    if(!game.gameStart(min_leelaz_version)) {
         return false;
     }
     do {

--- a/src/config.h
+++ b/src/config.h
@@ -39,7 +39,7 @@
 //#define USE_TUNER
 
 #define PROGRAM_NAME "Leela Zero"
-#define PROGRAM_VERSION "0.5"
+#define PROGRAM_VERSION "0.6"
 
 // OpenBLAS limitation
 #if defined(USE_BLAS) && defined(USE_OPENBLAS)


### PR DESCRIPTION
If the server gives an unexpected output try to retry instead of quitting. Maximum number of retries is limited to avoid hammering the server forever.