### PR TITLE
Simplify Im2col for the filter_size = 1 case

### DIFF
--- a/src/Im2Col.h
+++ b/src/Im2Col.h
@@ -28,11 +28,12 @@ template <unsigned int filter_size>
 void im2col(const int channels,
             const std::vector<float>& input,
             std::vector<float>& output) {
-    assert
+    // Not implemented
+    exit(EXIT_FAILURE);
 }
 
 template <>
-void im2col_test(const int channels,
+void im2col<1>(const int channels,
             const std::vector<float>& input,
             std::vector<float>& output) {
     constexpr unsigned int boardsize = 19;

--- a/src/Im2Col.h
+++ b/src/Im2Col.h
@@ -19,46 +19,23 @@
 #ifndef IM2COL_H_INCLUDED
 #define IM2COL_H_INCLUDED
 
-#include "config.h"
+#include <cassert>
 #include <vector>
-#include <algorithm>
-#include "Utils.h"
 
 template <unsigned long filter_size>
 void im2col(const int channels,
             const std::vector<float>& input,
             std::vector<float>& output) {
+    if (filter_size != 1) {
+        exit(EXIT_FAILURE);
+    }
+
     constexpr unsigned int height = 19;
     constexpr unsigned int width = 19;
-    constexpr unsigned int channel_size = height * width;
+    unsigned int outSize = height * width * channels;
+    assert(output.size() == outSize);
 
-    constexpr int pad = (filter_size / 2);
-    constexpr unsigned int output_h = height + 2 * pad - filter_size  + 1;
-    constexpr unsigned int output_w = width + 2 * pad - filter_size + 1;
-
-    const float* data_im = input.data();
-    float* data_col = output.data();
-
-    for (int channel = 0; channel < channels; channel++, data_im += channel_size) {
-        for (unsigned int kernel_row = 0; kernel_row < filter_size; kernel_row++) {
-            for (unsigned int kernel_col = 0; kernel_col < filter_size; kernel_col++) {
-                int input_row = -pad + kernel_row;
-                for (int output_rows = output_h; output_rows; output_rows--) {
-                    int input_col = -pad + kernel_col;
-                    for (int output_col = output_w; output_col; output_col--) {
-                        if (input_row > 0 && input_row < (signed) height &&
-                            input_col > 0 && input_col < (signed) width) {
-                            *(data_col++) = data_im[input_row * width + input_col];
-                        } else {
-                            *(data_col++) = 0;
-                        }
-                        input_col++;
-                    }
-                    input_row++;
-                }
-            }
-        }
-    }
+    std::copy(input.begin(), input.begin() + outSize, output.data());
 }
 
 

--- a/src/Im2Col.h
+++ b/src/Im2Col.h
@@ -46,8 +46,8 @@ void im2col(const int channels,
                 for (int output_rows = output_h; output_rows; output_rows--) {
                     int input_col = -pad + kernel_col;
                     for (int output_col = output_w; output_col; output_col--) {
-                        if (input_row > 0 && input_row < height &&
-                            input_col > 0 && input_col < width) {
+                        if (input_row > 0 && input_row < (signed) height &&
+                            input_col > 0 && input_col < (signed) width) {
                             *(data_col++) = data_im[input_row * width + input_col];
                         } else {
                             *(data_col++) = 0;

--- a/src/Im2Col.h
+++ b/src/Im2Col.h
@@ -39,26 +39,20 @@ void im2col(const int channels,
     const float* data_im = input.data();
     float* data_col = output.data();
 
-    for (int channel = channels; channel--; data_im += channel_size) {
+    for (int channel = 0; channel < channels; channel++, data_im += channel_size) {
         for (unsigned int kernel_row = 0; kernel_row < filter_size; kernel_row++) {
             for (unsigned int kernel_col = 0; kernel_col < filter_size; kernel_col++) {
                 int input_row = -pad + kernel_row;
                 for (int output_rows = output_h; output_rows; output_rows--) {
-                    if ((unsigned)input_row < height) {
-                        int input_col = -pad + kernel_col;
-                        for (int output_col = output_w; output_col; output_col--) {
-                            if ((unsigned)input_col < width) {
-                                *(data_col++) =
-                                    data_im[input_row * width + input_col];
-                            } else {
-                                *(data_col++) = 0;
-                            }
-                            input_col++;
-                        }
-                    } else {
-                        for (int output_cols = output_w; output_cols; output_cols--) {
+                    int input_col = -pad + kernel_col;
+                    for (int output_col = output_w; output_col; output_col--) {
+                        if (input_row > 0 && input_row < height &&
+                            input_col > 0 && input_col < width) {
+                            *(data_col++) = data_im[input_row * width + input_col];
+                        } else {
                             *(data_col++) = 0;
                         }
+                        input_col++;
                     }
                     input_row++;
                 }

--- a/src/Im2Col.h
+++ b/src/Im2Col.h
@@ -19,16 +19,14 @@
 #ifndef IM2COL_H_INCLUDED
 #define IM2COL_H_INCLUDED
 
-#include "config.h"
 #include <vector>
-#include <algorithm>
-#include "Utils.h"
 
-template <unsigned int filter_size>
+template <unsigned long filter_size>
 void im2col(const int channels,
             const std::vector<float>& input,
             std::vector<float>& output) {
     // Not implemented
+    // See github.com/gcp/leela-zero/pull/104 for first pass implementation.
     exit(EXIT_FAILURE);
 }
 

--- a/src/Im2Col.h
+++ b/src/Im2Col.h
@@ -24,60 +24,19 @@
 #include <algorithm>
 #include "Utils.h"
 
-template <unsigned long filter_size>
+template <unsigned int filter_size>
 void im2col(const int channels,
             const std::vector<float>& input,
             std::vector<float>& output) {
-    constexpr unsigned int height = 19;
-    constexpr unsigned int width = 19;
-    constexpr unsigned int channel_size = height * width;
-
-    constexpr int pad = (filter_size / 2);
-    constexpr unsigned int output_h = height + 2 * pad - filter_size  + 1;
-    constexpr unsigned int output_w = width + 2 * pad - filter_size + 1;
-
-    const float* data_im = input.data();
-    float* data_col = output.data();
-
-    for (int channel = channels; channel--; data_im += channel_size) {
-        for (unsigned int kernel_row = 0; kernel_row < filter_size; kernel_row++) {
-            for (unsigned int kernel_col = 0; kernel_col < filter_size; kernel_col++) {
-                int input_row = -pad + kernel_row;
-                for (int output_rows = output_h; output_rows; output_rows--) {
-                    if ((unsigned)input_row < height) {
-                        int input_col = -pad + kernel_col;
-                        for (int output_col = output_w; output_col; output_col--) {
-                            if ((unsigned)input_col < width) {
-                                *(data_col++) =
-                                    data_im[input_row * width + input_col];
-                            } else {
-                                *(data_col++) = 0;
-                            }
-                            input_col++;
-                        }
-                    } else {
-                        for (int output_cols = output_w; output_cols; output_cols--) {
-                            *(data_col++) = 0;
-                        }
-                    }
-                    input_row++;
-                }
-            }
-        }
-    }
+    assert
 }
 
-template <unsigned long filter_size>
+template <>
 void im2col_test(const int channels,
             const std::vector<float>& input,
             std::vector<float>& output) {
-    if (filter_size != 1) {
-        exit(EXIT_FAILURE);
-    }
-
-    constexpr unsigned int height = 19;
-    constexpr unsigned int width = 19;
-    unsigned int outSize = height * width * channels;
+    constexpr unsigned int boardsize = 19;
+    unsigned int outSize = channels * boardsize * boardsize;
     assert(output.size() == outSize);
 
     std::copy(input.begin(), input.begin() + outSize, output.data());

--- a/src/Im2Col.h
+++ b/src/Im2Col.h
@@ -19,11 +19,56 @@
 #ifndef IM2COL_H_INCLUDED
 #define IM2COL_H_INCLUDED
 
-#include <cassert>
+#include "config.h"
 #include <vector>
+#include <algorithm>
+#include "Utils.h"
 
 template <unsigned long filter_size>
 void im2col(const int channels,
+            const std::vector<float>& input,
+            std::vector<float>& output) {
+    constexpr unsigned int height = 19;
+    constexpr unsigned int width = 19;
+    constexpr unsigned int channel_size = height * width;
+
+    constexpr int pad = (filter_size / 2);
+    constexpr unsigned int output_h = height + 2 * pad - filter_size  + 1;
+    constexpr unsigned int output_w = width + 2 * pad - filter_size + 1;
+
+    const float* data_im = input.data();
+    float* data_col = output.data();
+
+    for (int channel = channels; channel--; data_im += channel_size) {
+        for (unsigned int kernel_row = 0; kernel_row < filter_size; kernel_row++) {
+            for (unsigned int kernel_col = 0; kernel_col < filter_size; kernel_col++) {
+                int input_row = -pad + kernel_row;
+                for (int output_rows = output_h; output_rows; output_rows--) {
+                    if ((unsigned)input_row < height) {
+                        int input_col = -pad + kernel_col;
+                        for (int output_col = output_w; output_col; output_col--) {
+                            if ((unsigned)input_col < width) {
+                                *(data_col++) =
+                                    data_im[input_row * width + input_col];
+                            } else {
+                                *(data_col++) = 0;
+                            }
+                            input_col++;
+                        }
+                    } else {
+                        for (int output_cols = output_w; output_cols; output_cols--) {
+                            *(data_col++) = 0;
+                        }
+                    }
+                    input_row++;
+                }
+            }
+        }
+    }
+}
+
+template <unsigned long filter_size>
+void im2col_test(const int channels,
             const std::vector<float>& input,
             std::vector<float>& output) {
     if (filter_size != 1) {
@@ -37,6 +82,5 @@ void im2col(const int channels,
 
     std::copy(input.begin(), input.begin() + outSize, output.data());
 }
-
 
 #endif

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -431,7 +431,6 @@ Network::Netresult Network::get_scored_moves_internal(
 #ifdef USE_OPENCL
     opencl_net.forward(input_data, output_data);
     // Get the moves
-    // Here are the two call sites.
     convolve<1, 2>(output_data, conv_pol_w, conv_pol_b, policy_data_1);
     batchnorm<2, 361>(policy_data_1, bn_pol_w1, bn_pol_w2, policy_data_2);
     innerproduct<2*361, 362>(policy_data_2, ip_pol_w, ip_pol_b, policy_out);

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -276,6 +276,13 @@ void convolve(const std::vector<float>& input,
     std::vector<float> col(filter_dim * width * height);
     im2col<filter_size>(channels, input, col);
 
+    std::vector<float> col_test(filter_dim * width * height);
+    im2col_test<filter_size>(channels, input, col_test);
+
+    for(int i = 0; i < col.size(); i++) {
+        assert(col[i] == col_test[i]);
+    }
+
     // Weight shape (output, input, filter_size, filter_size)
     // 96 22 5 5
     // outputs[96,19x19] = weights[96,22x9] x col[22x9,19x19]
@@ -431,6 +438,7 @@ Network::Netresult Network::get_scored_moves_internal(
 #ifdef USE_OPENCL
     opencl_net.forward(input_data, output_data);
     // Get the moves
+    // Here are the two call sites.
     convolve<1, 2>(output_data, conv_pol_w, conv_pol_b, policy_data_1);
     batchnorm<2, 361>(policy_data_1, bn_pol_w1, bn_pol_w2, policy_data_2);
     innerproduct<2*361, 362>(policy_data_2, ip_pol_w, ip_pol_b, policy_out);

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -276,13 +276,6 @@ void convolve(const std::vector<float>& input,
     std::vector<float> col(filter_dim * width * height);
     im2col<filter_size>(channels, input, col);
 
-    std::vector<float> col_test(filter_dim * width * height);
-    im2col_test<filter_size>(channels, input, col_test);
-
-    for(int i = 0; i < col.size(); i++) {
-        assert(col[i] == col_test[i]);
-    }
-
     // Weight shape (output, input, filter_size, filter_size)
     // 96 22 5 5
     // outputs[96,19x19] = weights[96,22x9] x col[22x9,19x19]


### PR DESCRIPTION
im2Col is overly complicated*, I'm a proponent of You Ain't Gonna Need It.
let's replaced this potentially buggy code with an assert(filter_size = 1) + copy till a larger filter size is needed at that point this can be reverted or less buggy code written.



*uses many different for loop styles, has a host of extra variables, performs an unsafe signed to unsigned conversion and ultimately doesn't do anything.