### PR TITLE
Retry in case of network error instead of quitting

### DIFF
--- a/autogtp/Production.cpp
+++ b/autogtp/Production.cpp
@@ -45,16 +45,18 @@ void ProductionWorker::run() {
          auto end = std::chrono::high_resolution_clock::now();
          auto gameDuration =
             std::chrono::duration_cast<std::chrono::seconds>(end - start).count();
-         emit resultReady(game.getFile(), gameDuration);
+         emit resultReady(game.getFile(), gameDuration, m_index);
     } while (true);
 }
 
-void ProductionWorker::init(const QString& gpuIndex, const QString& net) {
+void ProductionWorker::init(const QString& gpuIndex, const QString& net,
+                            const int index) {
     m_option = " -g -q -n -d -m 30 -r 0 -w ";
     if(!gpuIndex.isEmpty()) {
         m_option.prepend(" -gpu=" + gpuIndex + " ");
     }
     m_network = net;
+    m_index = index;
 }
 
 Production::Production(const int gpus,
@@ -82,7 +84,7 @@ void Production::startGames() {
     QString myGpu;
     for(int gpu = 0; gpu < m_gpus; ++gpu) {
         for(int game = 0; game < m_games; ++game) {
-            auto thread_index = gpu * m_games + game;
+            int thread_index = gpu * m_games + game;
             connect(&m_gamesThreads[thread_index],
                     &ProductionWorker::resultReady,
                     this,
@@ -93,21 +95,20 @@ void Production::startGames() {
             } else {
                 myGpu = m_gpusList.at(gpu);
             }
-            m_gamesThreads[thread_index].init(myGpu, m_network);
+            m_gamesThreads[thread_index].init(myGpu, m_network, thread_index);
             m_gamesThreads[thread_index].start();
         }
     }
 }
 
-void Production::getResult(const QString& file, float duration) {
+void Production::getResult(const QString& file, float duration, int index) {
     m_syncMutex.lock();
     m_gamesPlayed++;
     printTimingInfo(duration);
     uploadData(file);
     if (!fetchBestNetworkHash()) {
         fetchBestNetwork();
-        ProductionWorker *w = qobject_cast<ProductionWorker*>(sender());
-        w->newNetwork(m_network);
+        m_gamesThreads[index].newNetwork(m_network);
     }
     m_syncMutex.unlock();
 }

--- a/autogtp/Production.cpp
+++ b/autogtp/Production.cpp
@@ -216,8 +216,7 @@ bool Production::networkExists() {
             }
         } else {
             QTextStream(stdout) << "Unable to open network file for reading." << endl;
-            QFile file(m_network);
-            if(file.remove()) {
+            if(f.remove()) {
                 return false;
             }
             QTextStream(stdout) << "Unable to delete the network file. " \
@@ -225,9 +224,10 @@ bool Production::networkExists() {
             exit(EXIT_FAILURE);
         }
         QTextStream(stdout) << "Downloaded network hash doesn't match." << endl;
-        QFile file(m_network);
-        file.remove();
+        f.remove();
+
     }
+
     return false;
 }
 
@@ -235,6 +235,13 @@ void Production::fetchBestNetwork() {
     if (networkExists()) {
         QTextStream(stdout) << "Already downloaded network." << endl;
         return;
+    }
+
+    if (QFileInfo::exists(m_network+".gz")) {
+        QFile f_gz(m_network+".gz");
+        //Curl refuses to overwrite, so make sure to delete the gzipped network
+        //if it exists
+        f_gz.remove();
     }
 
     QString prog_cmdline("curl");
@@ -264,9 +271,9 @@ void Production::fetchBestNetwork() {
     QString outfile = outlst[0];
     QTextStream(stdout) << "Curl filename: " << outfile << endl;
 #ifdef WIN32
-    QProcess::execute("gzip.exe -d -k -q " + outfile);
+    QProcess::execute("gzip.exe -d -q " + outfile);
 #else
-    QProcess::execute("gunzip -k -q " + outfile);
+    QProcess::execute("gunzip -q " + outfile);
 #endif
     // Remove extension (.gz)
     outfile.chop(3);

--- a/autogtp/Production.h
+++ b/autogtp/Production.h
@@ -27,13 +27,6 @@
 #include <chrono>
 #include <stdexcept>
 
-struct NetworkException: public std::runtime_error
-{
-    NetworkException(std::string const& message)
-        : std::runtime_error("NetworkException: " + message)
-    {}
-};
-
 class ProductionWorker : public QThread {
     Q_OBJECT
 public:
@@ -69,6 +62,15 @@ public slots:
     void getResult(const QString& file, float duration, int index);
 
 private:
+
+    struct NetworkException: public std::runtime_error
+    {
+        NetworkException(std::string const& message)
+            : std::runtime_error("NetworkException: " + message)
+        {}
+    };
+
+
     QMutex* m_mainMutex;
     QMutex m_syncMutex;
     QVector<ProductionWorker> m_gamesThreads;

--- a/autogtp/Production.h
+++ b/autogtp/Production.h
@@ -32,15 +32,16 @@ public:
     ProductionWorker() = default;
     ProductionWorker(const ProductionWorker& w) : QThread(w.parent()) {}
     ~ProductionWorker() = default;
-    void init(const QString& gpuIndex, const QString& net);
+    void init(const QString& gpuIndex, const QString& net, const int index);
     void newNetwork(const QString& net) { m_network = net; }
     void run() override;
 
 signals:
-    void resultReady(const QString& file, float duration);
+    void resultReady(const QString& file, float duration, int index);
 private:
     QString m_network;
     QString m_option;
+    int m_index;
 };
 
 class Production : public QObject {
@@ -57,7 +58,7 @@ public:
     void startGames();
 
 public slots:
-    void getResult(const QString& file, float duration);
+    void getResult(const QString& file, float duration, int index);
 
 private:
     QMutex* m_mainMutex;


### PR DESCRIPTION
Refactored pull request #95. Now checks the curl exit code too. The goal is to keep the clients running waiting for the server to come back if there is a server outage.

I removed the offline game playing from the commit to keep it smaller.

@marcocalignano can you take a look too?

fetchBestNetwork() is called even if fetchBestNetworkHash() reported that the hash has not changed to make sure that the file exists if there were previously any issues with the download.