### PR TITLE
small optimization: avoid calculating PV in quiet mode

### DIFF
--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -99,11 +99,11 @@ SearchResult UCTSearch::play_simulation(GameState & currstate, UCTNode* const no
 }
 
 void UCTSearch::dump_stats(KoState & state, UCTNode & parent) {
-    const int color = state.get_to_move();
-
-    if (!parent.has_children()) {
+    if (cfg_quiet || !parent.has_children()) {
         return;
     }
+
+    const int color = state.get_to_move();
 
     // sort children, put best move on top
     m_root.sort_root_children(color);
@@ -294,6 +294,10 @@ std::string UCTSearch::get_pv(KoState & state, UCTNode & parent) {
 }
 
 void UCTSearch::dump_analysis(int playouts) {
+    if (cfg_quiet) {
+        return;
+    }
+
     GameState tempstate = m_rootstate;
     int color = tempstate.board.get_to_move();
 


### PR DESCRIPTION
screenshot of hotspot profile: https://i.imgur.com/wNZVTNG.png
vtune shows 2.8% of time spent calculating PV for dump_stats
this is unneeded because autogtp runs leelaz in quite mode which suppress output of any extra stats.

before: 1302 moves = 611 ms/move (it would be nice if you would pull [PR113](https://github.com/gcp/leela-zero/pull/113))
after: 1601 moves = 602 ms/move