### PR TITLE
small optimization: simplify get_pv

### DIFF
--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -512,11 +512,9 @@ UCTNode::sortnode_t get_sortnode(int color, UCTNode* child) {
 
 UCTNode* UCTNode::best_root_child(int color) {
     LOCK(get_mutex(), lock);
-
     assert(m_firstchild != nullptr);
 
     NodeComp compare;
-
     auto child = m_firstchild;
     auto best_child = get_sortnode(color, child);
     while (child != nullptr) {
@@ -524,6 +522,7 @@ UCTNode* UCTNode::best_root_child(int color) {
         if (compare(test, best_child)) {
             best_child = test;
         }
+        child = child->m_nextsibling;
     }
     return std::get<3>(best_child);
 }

--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -72,6 +72,7 @@ public:
 
     void sort_root_children(int color);
     void sort_children();
+    UCTNode* best_root_child(int color);
     SMP::Mutex & get_mutex();
 
 private:

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -268,28 +268,16 @@ std::string UCTSearch::get_pv(KoState & state, UCTNode & parent) {
         return std::string();
     }
 
-    // This temporarily breaks any best probability = first in tree assumptions
-    parent.sort_root_children(state.get_to_move());
+    UCTNode * best_child = parent.best_root_child(state.get_to_move());
+    int best_move = best_child->get_move();
+    std::string res = state.move_to_text(best_move);
 
-    LOCK(parent.get_mutex(), lock);
-    UCTNode * bestchild = parent.get_first_child();
-    int bestmove = bestchild->get_move();
-    lock.unlock();
+    state.play_move(best_move);
 
-    std::string tmp = state.move_to_text(bestmove);
-
-    std::string res(tmp);
-    res.append(" ");
-
-    state.play_move(bestmove);
-
-    std::string next = get_pv(state, *bestchild);
-    res.append(next);
-
-    // Resort according to move probability
-    lock.lock();
-    parent.sort_children();
-
+    std::string next = get_pv(state, *best_child);
+    if (!next.empty()) {
+        res.append(" ").append(next);
+    }
     return res;
 }
 


### PR DESCRIPTION
Add a new function to get the "best" child (as determined by NodeComp)

this avoids sorting and linking all children x2

Intel VTune says impact is ~0.5% CPU