### PR TITLE
Update Production.cpp to fix dependency

### DIFF
--- a/autogtp/Production.cpp
+++ b/autogtp/Production.cpp
@@ -16,6 +16,7 @@
     along with Leela Zero.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <cmath>
 #include <QDir>
 #include <QFileInfo>
 #include <QThread>

--- a/autogtp/Production.h
+++ b/autogtp/Production.h
@@ -26,7 +26,6 @@
 #include <QTextStream>
 #include <chrono>
 #include <stdexcept>
-#include <cmath>
 
 class ProductionWorker : public QThread {
     Q_OBJECT

--- a/autogtp/Production.h
+++ b/autogtp/Production.h
@@ -26,6 +26,7 @@
 #include <QTextStream>
 #include <chrono>
 #include <stdexcept>
+#include <cmath>
 
 class ProductionWorker : public QThread {
     Q_OBJECT


### PR DESCRIPTION
Fixed compile time error because cmath isn't included (dependency for std::pow)