### PR TITLE
Add optional autogtp param for specifying leelaz path

### DIFF
--- a/autogtp/Game.cpp
+++ b/autogtp/Game.cpp
@@ -19,10 +19,10 @@
 #include <QUuid>
 #include "Game.h"
 
-Game::Game(const QString& weights, QTextStream& out) :
+Game::Game(const QString& weights, QTextStream& out, const QString& leela_path) :
     QProcess(),
     output(out),
-    cmdLine("./leelaz"),
+    cmdLine(leela_path),
     timeSettings("time_settings 0 1 0"),
     resignation(false),
     blackToMove(true),

--- a/autogtp/Game.h
+++ b/autogtp/Game.h
@@ -27,7 +27,7 @@ using VersionTuple = std::tuple<int, int>;
 
 class Game : QProcess {
 public:
-    Game(const QString& weights, QTextStream& out);
+    Game(const QString& weights, QTextStream& out, const QString& leela_path);
     ~Game() = default;
     bool gameStart(const VersionTuple& min_version);
     void move();

--- a/autogtp/main.cpp
+++ b/autogtp/main.cpp
@@ -156,9 +156,9 @@ bool upload_data(QTextStream& cerr, const QString& netname, QString sgf_output_p
     return true;
 }
 
-bool run_one_game(QTextStream& cerr, const QString& weightsname) {
+bool run_one_game(QTextStream& cerr, const QString& weightsname, const QString& leela_path) {
 
-    Game game(weightsname, cerr);
+    Game game(weightsname, cerr, leela_path);
     if(!game.gameStart(min_leelaz_version)) {
         return false;
     }
@@ -206,10 +206,15 @@ int main(int argc, char *argv[])
     QCommandLineOption keep_sgf_option(
         { "k", "keep-sgf" }, "Save SGF files after each self-play game.",
                              "output directory");
+    QCommandLineOption leela_path_option(
+        { "p", "leela-path" }, "Path to version of leelaz to use",
+                               "leelaz binary",
+                               "./leelaz");
     QCommandLineParser parser;
     parser.addHelpOption();
     parser.addVersionOption();
     parser.addOption(keep_sgf_option);
+    parser.addOption(leela_path_option);
     parser.process(app);
 
     // Map streams
@@ -246,7 +251,7 @@ int main(int argc, char *argv[])
         QString netname;
         success &= fetch_best_network_hash(cerr, netname);
         success &= fetch_best_network(cerr, netname);
-        success &= run_one_game(cerr, netname);
+        success &= run_one_game(cerr, netname, parser.value(leela_path_option));
         success &= upload_data(cerr, netname, parser.value(keep_sgf_option));
         games_played++;
         print_timing_info(cerr, games_played, start, game_start);


### PR DESCRIPTION
I am packaging leela-zero up for AUR to make it easy to set up on Arch Linux. In that context, I cannot assume the user's current working directory, so autogtp's behaviour of requiring leelaz in the same directory is a blocker.

This PR simply adds an optional argument to autogtp, `-p /path/to/leelaz`, which can allow autogtp and leelaz to be installed to a standard path like `/usr/bin` by packagers.