### PR TITLE
Add functionality to start training from existing weights

### DIFF
--- a/training/tf/net_to_model.py
+++ b/training/tf/net_to_model.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+import tensorflow as tf
+import os
+import sys
+from tfprocess import TFProcess
+
+with open(sys.argv[1], 'r') as f:
+    weights = []
+    for e, line in enumerate(f):
+        if e == 0:
+            #Version
+            print("Version", line.strip())
+            if line != '1\n':
+                raise ValueError("Unknown version {}".format(line.strip()))
+        else:
+            weights.append(list(map(float, line.split(' '))))
+        if e == 2:
+            channels = len(line.split(' '))
+            print("Channels", channels)
+    blocks = e - (4 + 14)
+    if blocks % 8 != 0:
+        raise ValueError("Inconsistent number of weights in the file")
+    blocks /= 8
+    print("Blocks", blocks)
+
+x = [
+    tf.placeholder(tf.float32, [None, 18, 19 * 19]),
+    tf.placeholder(tf.float32, [None, 362]),
+    tf.placeholder(tf.float32, [None, 1])
+    ]
+
+tfprocess = TFProcess(x)
+tfprocess.replace_weights(weights)
+path = os.path.join(os.getcwd(), "leelaz-model")
+save_path = tfprocess.saver.save(tfprocess.session, path, global_step=0)


### PR DESCRIPTION
This change allows creating a tensorflow checkpoint after initialization that uses an existing network file for weights.

First call "net_to_model.py <weights.txt>". This creates a checkpoint "leelaz-model-0", which can be used as a restore point in training using parse.py. If there's an error about assignment make sure that network file blocks/channels are same as in tfprocess.py.

Fixes #183.