### PR TITLE
Set resignpct=10 in 90% of autogtp games

### DIFF
--- a/autogtp/Production.cpp
+++ b/autogtp/Production.cpp
@@ -17,6 +17,7 @@
 */
 
 #include <cmath>
+#include <random>
 #include <QDir>
 #include <QFileInfo>
 #include <QThread>
@@ -29,10 +30,13 @@ constexpr int RETRY_DELAY_MAX_SEC = 60 * 60;  // 1 hour
 constexpr int MAX_RETRIES = 4 * 24;           // Stop retrying after 4 days
 
 void ProductionWorker::run() {
+    std::random_device rd;
+    std::ranlux48 gen(rd());
+    std::uniform_real_distribution<> rand_dist(0.0, 1.0);
     do {
         auto start = std::chrono::high_resolution_clock::now();
         auto option = m_option;
-        float pick = static_cast <float> (rand()) / static_cast <float> (RAND_MAX);
+        auto pick = rand_dist(gen);
         // For now must manually check the resign rate
         // for new networks with resign_analysis.py
         QString resignpct = (pick < 0.2) ? "0" : "5";

--- a/autogtp/Production.cpp
+++ b/autogtp/Production.cpp
@@ -31,6 +31,14 @@ constexpr int MAX_RETRIES = 4 * 24;           // Stop retrying after 4 days
 void ProductionWorker::run() {
     do {
         auto start = std::chrono::high_resolution_clock::now();
+        auto option = m_option;
+        float pick = static_cast <float> (rand()) / static_cast <float> (RAND_MAX);
+        // For now must manually check the resign rate
+        // for new networks with resign_analysis.py
+        QString resignpct = (pick < 0.1) ? "0" : "10";
+        // Prepend because option must have "-w " on the end
+        option = " -r " + resignpct + option;
+        QTextStream(stdout) << "option=" << option << endl;
         m_mutex.lock();
         Game game(m_network, m_option);
         m_mutex.unlock();
@@ -77,7 +85,7 @@ void ProductionWorker::run() {
 }
 
 void ProductionWorker::init(const QString& gpuIndex, const QString& net) {
-    m_option = " -g -q -d -n -m 30 -r 0 -w ";
+    m_option = " -g -q -d -n -m 30 -w ";
     if (!gpuIndex.isEmpty()) {
         m_option.prepend(" --gpu=" + gpuIndex + " ");
     }

--- a/autogtp/Production.cpp
+++ b/autogtp/Production.cpp
@@ -383,6 +383,7 @@ void Production::uploadData(const QString& file) {
         QTextStream(stdout) << outstr;
         dir.remove(sgf_file);
         dir.remove(data_file);
+        dir.remove(debug_data_file);
     }
     return;
 }

--- a/autogtp/Production.cpp
+++ b/autogtp/Production.cpp
@@ -35,7 +35,7 @@ void ProductionWorker::run() {
         float pick = static_cast <float> (rand()) / static_cast <float> (RAND_MAX);
         // For now must manually check the resign rate
         // for new networks with resign_analysis.py
-        QString resignpct = (pick < 0.1) ? "0" : "10";
+        QString resignpct = (pick < 0.2) ? "0" : "5";
         // Prepend because option must have "-w " on the end
         option = " -r " + resignpct + option;
         QTextStream(stdout) << "option=" << option << endl;

--- a/autogtp/Production.cpp
+++ b/autogtp/Production.cpp
@@ -90,6 +90,7 @@ Production::Production(const int gpus,
                        const QStringList& gpuslist,
                        const int ver,
                        const QString& keep,
+                       const QString& debug,
                        QMutex* mutex)
     : m_mainMutex(mutex),
     m_syncMutex(),
@@ -99,6 +100,7 @@ Production::Production(const int gpus,
     m_gpusList(gpuslist),
     m_gamesPlayed(0),
     m_keepPath(keep),
+    m_debugPath(debug),
     m_version(ver) {
 }
 
@@ -324,13 +326,19 @@ void Production::uploadData(const QString& file) {
         QFileInfo fileInfo = list.at(i);
         QString sgf_file = fileInfo.fileName();
         QString data_file = sgf_file;
-        // Save first if requested
-        if (!m_keepPath.isEmpty()) {
-            QFile(sgf_file).copy(m_keepPath + '/' + fileInfo.fileName());
-        }
         // Cut .sgf, add .txt.0.gz
         data_file.chop(4);
+        QString debug_data_file = data_file;
         data_file += ".txt.0.gz";
+        debug_data_file += ".txt.debug.0.gz";
+        // Save first if requested
+        if (!m_keepPath.isEmpty()) {
+            QFile(sgf_file).copy(m_keepPath + '/' + sgf_file);
+        }
+        if (!m_debugPath.isEmpty()) {
+            QFile(data_file).copy(m_debugPath + '/' + data_file);
+            QFile(debug_data_file).copy(m_debugPath + '/' + debug_data_file);
+        }
         // Gzip up the sgf too
 #ifdef WIN32
         QProcess::execute("gzip.exe " + sgf_file);

--- a/autogtp/Production.cpp
+++ b/autogtp/Production.cpp
@@ -40,7 +40,7 @@ void ProductionWorker::run() {
         option = " -r " + resignpct + option;
         QTextStream(stdout) << "option=" << option << endl;
         m_mutex.lock();
-        Game game(m_network, m_option);
+        Game game(m_network, option);
         m_mutex.unlock();
         if (!game.gameStart(min_leelaz_version)) {
             return;

--- a/autogtp/Production.h
+++ b/autogtp/Production.h
@@ -64,6 +64,7 @@ public:
                const QStringList& gpuslist,
                const int ver,
                const QString& keep,
+               const QString& debug,
                QMutex* mutex);
     ~Production() = default;
     void startGames();
@@ -90,6 +91,7 @@ private:
     int m_gamesPlayed;
     QString m_network;
     QString m_keepPath;
+    QString m_debugPath;
     int m_version;
     std::chrono::high_resolution_clock::time_point m_start;
     bool fetchBestNetworkHash();

--- a/autogtp/main.cpp
+++ b/autogtp/main.cpp
@@ -113,12 +113,18 @@ int main(int argc, char *argv[]) {
             return EXIT_FAILURE;
         }
     }
+    if (parser.isSet(keepDebugOption)) {
+        if (!QDir().mkpath(parser.value(keepDebugOption))) {
+            cerr << "Couldn't create output directory for self-play Debug files!"
+                 << endl;
+            return EXIT_FAILURE;
+        }
+    }
     QMutex mutex;
     if(competition) {
         Validation validate(gpusNum, gamesNum, gpusList,
                             netList.at(0), netList.at(1),
                             parser.value(keepSgfOption),
-                            parser.value(keepDebugOption),
                             &mutex);
         validate.startGames();
         mutex.lock();

--- a/autogtp/main.cpp
+++ b/autogtp/main.cpp
@@ -66,12 +66,16 @@ int main(int argc, char *argv[]) {
         {"k", "keepSgf" },
             "Save SGF files after each self-play game.",
             "output directory");
+    QCommandLineOption keepDebugOption(
+        { "d", "debug" }, "Save training and extra debug files after each self-play game.",
+                             "output directory");
 
     parser.addOption(competitionOption);
     parser.addOption(gamesNumOption);
     parser.addOption(gpusOption);
     parser.addOption(networkOption);
     parser.addOption(keepSgfOption);
+    parser.addOption(keepDebugOption);
 
     // Process the actual command line arguments given by the user
     parser.process(app);
@@ -113,13 +117,17 @@ int main(int argc, char *argv[]) {
     if(competition) {
         Validation validate(gpusNum, gamesNum, gpusList,
                             netList.at(0), netList.at(1),
-                            parser.value(keepSgfOption), &mutex);
+                            parser.value(keepSgfOption),
+                            parser.value(keepDebugOption),
+                            &mutex);
         validate.startGames();
         mutex.lock();
         validate.wait();
     } else {
         Production prod(gpusNum, gamesNum, gpusList, AUTOGTP_VERSION,
-                        parser.value(keepSgfOption), &mutex);
+                        parser.value(keepSgfOption),
+                        parser.value(keepDebugOption),
+                        &mutex);
         prod.startGames();
         mutex.lock();
     }

--- a/resign_analysis/resign_analysis.py
+++ b/resign_analysis/resign_analysis.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+#
+#    This file is part of Leela Zero.
+#    Copyright (C) 2017 Andy Olsen
+#
+#    Leela Zero is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Leela Zero is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with Leela Zero.  If not, see <http://www.gnu.org/licenses/>.
+
+
+# Usage:
+#
+# Run autogtp with debug on:
+# autogtp -k savedir -d savedir
+#
+# Unzip training and debug files:
+# gunzip savedir/*.gz
+#
+# Analyze results with this script:
+# ./resign_analysis.py savedir/*debug*
+#
+
+import sys
+import argparse
+
+class Best:
+    def __init__(self):
+        self.value = None
+        self.movenum = None
+        self.bestmovevisits = None
+    def update(self, value, movenum, bestmovevisits):
+        if self.value == None or value < self.value:
+            self.value = value
+            self.movenum = movenum
+            self.bestmovevisits = bestmovevisits
+    def tostr(self):
+        s = "%f %d %d" % (self.value, self.movenum, self.bestmovevisits)
+        return s
+
+class GameStats:
+    def __init__(self, filename):
+        self.filename = filename
+        self.w_best_netwinrate = Best()
+        self.w_best_uctwinrate = Best()
+        self.w_best_bestmovevisits = Best()
+        self.total_moves = None
+        self.resign_movenum = None
+        self.resign_type = None     # "Correct", "Incorrect"
+
+def parseLabelValue(line, exp_label):
+    (label, value) = line.split()
+    assert label == exp_label
+    return value
+
+def parseGames(filenames, resignrate, verbose):
+    gsd = {}
+    for filename in filenames:
+        training_filename = filename.replace(".debug", "")
+        gs = GameStats(filename)
+        gsd[filename] = gs
+        with open(filename) as fh, open(training_filename) as tfh:
+            movenum = 0
+            version = fh.readline()
+            assert version == "1\n"
+            while 1:
+                movenum += 1
+                for _ in range(16):
+                    line = tfh.readline()               # Board input planes
+                if not line: break
+                to_move = int(tfh.readline())           # 0 = black, 1 = white
+                policy_weights = tfh.readline()         # 361 moves + 1 pass
+                side_to_move_won = int(tfh.readline())  # 1 = side to move won, -1 = lost
+                netwinrate = float(parseLabelValue(fh.readline(), "netwinrate"))
+                root_uctwinrate = float(parseLabelValue(fh.readline(), "root_uctwinrate"))
+                child_uctwinrate = float(parseLabelValue(fh.readline(), "child_uctwinrate"))
+                bestmovevisits = int(parseLabelValue(fh.readline(), "bestmovevisits"))
+                if side_to_move_won == 1:
+                    if verbose: print("+", to_move, movenum, netwinrate, child_uctwinrate, bestmovevisits)
+                    gs.w_best_netwinrate.update(netwinrate, movenum, bestmovevisits)
+                    gs.w_best_uctwinrate.update(child_uctwinrate, movenum, bestmovevisits)
+                    gs.w_best_bestmovevisits.update(bestmovevisits, movenum, bestmovevisits)
+                    if not gs.resign_type and child_uctwinrate < resignrate:
+                        if verbose: print("Incorrect resign")
+                        gs.resign_type = "Incorrect"
+                        gs.resign_movenum = movenum
+                else:
+                    if verbose: print("-", to_move, movenum, netwinrate, child_uctwinrate, bestmovevisits)
+                    if not gs.resign_type and child_uctwinrate < resignrate:
+                        if verbose: print("Correct resign")
+                        gs.resign_type = "Correct"
+                        gs.resign_movenum = movenum
+            gs.total_moves = movenum
+        if verbose: print(filename, gs.w_best_netwinrate.tostr(), gs.w_best_uctwinrate.tostr(), gs.total_moves)
+    return gsd
+
+def resignStats(gsd, resignrate):
+    print("Resign rate: %0.2f" % (resignrate))
+    num_games = len(gsd)
+    no_resign_count = 0
+    correct_resign_count = 0
+    incorrect_resign_count = 0
+    game_len_sum = 0
+    resigned_game_len_sum = 0
+    for gs in gsd.values():
+        if not gs.resign_type:
+            no_resign_count += 1
+            resigned_game_len_sum += gs.total_moves
+        elif gs.resign_type == "Correct":
+            correct_resign_count += 1
+            resigned_game_len_sum += gs.resign_movenum
+        else:
+            assert gs.resign_type == "Incorrect"
+            incorrect_resign_count += 1
+            resigned_game_len_sum += gs.resign_movenum
+        game_len_sum += gs.total_moves
+    avg_len = 1.0*game_len_sum/num_games
+    resigned_avg_len = 1.0*resigned_game_len_sum/num_games
+    avg_reduction = 1.0*(avg_len-resigned_avg_len)/avg_len
+    print("Incorrect uct resigns = %d/%d (%0.2f%%)" % (incorrect_resign_count, num_games, 100.0 * incorrect_resign_count / num_games))
+    print("Average game length = %d. Average game length with resigns = %d (%0.2f%% reduction)" % (avg_len, resigned_avg_len, avg_reduction*100))
+    print()
+
+if __name__ == "__main__":
+    usage_str = """
+This script analyzes the debug output from leelaz
+to determine the impact of various resign thresholds.
+
+Process flow:
+  Run autogtp with debug on:
+    autogtp -k savedir -d savedir
+
+  Unzip training and debug files:
+    gunzip savedir/*.gz
+
+  Analyze results with this script:
+    ./resign_analysis.py savedir/*debug*"""
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter, description=usage_str)
+    default_resignrates="0.5,0.2,0.15,0.1,0.05"
+    parser.add_argument("--r", metavar="Resign rates", dest="resignrates", type=str, default=default_resignrates, help="comma separated resign thresholds (default %s)" % (default_resignrates))
+    parser.add_argument("--v", metavar="Verbose", dest="verbose", type=bool, default=False)
+    parser.add_argument("data", metavar="files", type=str, nargs="+", help="Debug data files (*.txt.debug.0)")
+    args = parser.parse_args()
+    resignrates = [float(i) for i in args.resignrates.split(",")]
+    for resignrate in (resignrates):
+        gs = parseGames(args.data, resignrate, args.verbose)
+        resignStats(gs, resignrate)

--- a/resign_analysis/resign_analysis.py
+++ b/resign_analysis/resign_analysis.py
@@ -16,19 +16,6 @@
 #    You should have received a copy of the GNU General Public License
 #    along with Leela Zero.  If not, see <http://www.gnu.org/licenses/>.
 
-
-# Usage:
-#
-# Run autogtp with debug on:
-# autogtp -k savedir -d savedir
-#
-# Unzip training and debug files:
-# gunzip savedir/*.gz
-#
-# Analyze results with this script:
-# ./resign_analysis.py savedir/*debug*
-#
-
 import sys
 import argparse
 
@@ -55,11 +42,7 @@ class GameStats:
         self.total_moves = None
         self.resign_movenum = None
         self.resign_type = None     # "Correct", "Incorrect"
-
-def parseLabelValue(line, exp_label):
-    (label, value) = line.split()
-    assert label == exp_label
-    return value
+        self.winner = None
 
 def parseGames(filenames, resignrate, verbose):
     gsd = {}
@@ -79,10 +62,14 @@ def parseGames(filenames, resignrate, verbose):
                 to_move = int(tfh.readline())           # 0 = black, 1 = white
                 policy_weights = tfh.readline()         # 361 moves + 1 pass
                 side_to_move_won = int(tfh.readline())  # 1 = side to move won, -1 = lost
-                netwinrate = float(parseLabelValue(fh.readline(), "netwinrate"))
-                root_uctwinrate = float(parseLabelValue(fh.readline(), "root_uctwinrate"))
-                child_uctwinrate = float(parseLabelValue(fh.readline(), "child_uctwinrate"))
-                bestmovevisits = int(parseLabelValue(fh.readline(), "bestmovevisits"))
+                if not gs.winner:
+                    if side_to_move_won == 1: gs.winner = to_move
+                    else : gs.winner = 1 - to_move
+                (netwinrate, root_uctwinrate, child_uctwinrate, bestmovevisits) = fh.readline().split()
+                netwinrate = float(netwinrate)
+                root_uctwinrate = float(root_uctwinrate)
+                child_uctwinrate = float(child_uctwinrate)
+                bestmovevisits = int(bestmovevisits)
                 if side_to_move_won == 1:
                     if verbose: print("+", to_move, movenum, netwinrate, child_uctwinrate, bestmovevisits)
                     gs.w_best_netwinrate.update(netwinrate, movenum, bestmovevisits)
@@ -110,6 +97,7 @@ def resignStats(gsd, resignrate):
     incorrect_resign_count = 0
     game_len_sum = 0
     resigned_game_len_sum = 0
+    black_wins = 0
     for gs in gsd.values():
         if not gs.resign_type:
             no_resign_count += 1
@@ -122,9 +110,12 @@ def resignStats(gsd, resignrate):
             incorrect_resign_count += 1
             resigned_game_len_sum += gs.resign_movenum
         game_len_sum += gs.total_moves
+        if gs.winner == 0:
+            black_wins += 1
     avg_len = 1.0*game_len_sum/num_games
     resigned_avg_len = 1.0*resigned_game_len_sum/num_games
     avg_reduction = 1.0*(avg_len-resigned_avg_len)/avg_len
+    print("Black won %d/%d (%0.2f%%)" % (black_wins, num_games, 100.0 * black_wins / num_games))
     print("Incorrect uct resigns = %d/%d (%0.2f%%)" % (incorrect_resign_count, num_games, 100.0 * incorrect_resign_count / num_games))
     print("Average game length = %d. Average game length with resigns = %d (%0.2f%% reduction)" % (avg_len, resigned_avg_len, avg_reduction*100))
     print()
@@ -142,7 +133,11 @@ Process flow:
     gunzip savedir/*.gz
 
   Analyze results with this script:
-    ./resign_analysis.py savedir/*debug*"""
+    ./resign_analysis.py savedir/*.txt.debug.0
+
+Note the script takes the debug files hash.txt.debug.0
+as the input arguments, but it also expects the training
+files hash.txt.0 to be in the same directory."""
     parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter, description=usage_str)
     default_resignrates="0.5,0.2,0.15,0.1,0.05"
     parser.add_argument("--r", metavar="Resign rates", dest="resignrates", type=str, default=default_resignrates, help="comma separated resign thresholds (default %s)" % (default_resignrates))

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -704,6 +704,8 @@ bool GTP::execute(GameState & game, std::string xinput) {
         }
 
         Training::dump_training(who_won, filename);
+        filename += ".debug";
+        Training::dump_stats(filename);
 
         if (!cmdstream.fail()) {
             gtp_printf(id, "");

--- a/src/Training.cpp
+++ b/src/Training.cpp
@@ -195,10 +195,7 @@ void Training::dump_stats(OutputChunker& outchunk) {
     outchunk.append(out.str());
     for (const auto& step : m_data) {
         auto out = std::stringstream{};
-        out << "netwinrate " << step.netwinrate << std::endl;
-        out << "root_uctwinrate " << step.root_uctwinrate << std::endl;
-        out << "child_uctwinrate " << step.child_uctwinrate << std::endl;
-        out << "bestmovevisits " << step.bestmovevisits << std::endl;
+        out << step.netwinrate << " " << step.root_uctwinrate << " " << step.child_uctwinrate << " " << step.bestmovevisits << std::endl;
         outchunk.append(out.str());
     }
 }

--- a/src/Training.h
+++ b/src/Training.h
@@ -30,6 +30,10 @@ public:
     Network::NNPlanes planes;
     std::vector<float> probabilities;
     int to_move;
+    float netwinrate;
+    float root_uctwinrate;
+    float child_uctwinrate;
+    int bestmovevisits;
 };
 
 class OutputChunker {
@@ -55,6 +59,7 @@ public:
     static void clear_training();
     static void dump_training(int winner_color,
                               const std::string& out_filename);
+    static void dump_stats(const std::string& out_filename);
     static void record(GameState& state, const UCTNode& node);
 
     static void dump_supervised(const std::string& sgf_file,
@@ -69,6 +74,7 @@ private:
                              OutputChunker& outchunker);
     static void dump_training(int winner_color,
                               OutputChunker& outchunker);
+    static void dump_stats(OutputChunker& outchunker);
     static std::vector<TimeStep> m_data;
 };
 

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -247,7 +247,7 @@ int UCTSearch::get_best_move(passflag_t passflag) {
         }
     }
 
-    int visits = m_root.get_first_child()->get_visits();
+    int visits = m_root.get_visits();
 
     // if we aren't passing, should we consider resigning?
     if (bestmove != FastBoard::PASS) {
@@ -257,7 +257,7 @@ int UCTSearch::get_best_move(passflag_t passflag) {
                                 * m_rootstate.board.get_boardsize()) / 4;
             // bad score and visited enough
             if (bestscore < ((float)cfg_resignpct / 100.0f)
-                && visits > 100
+                && visits > 500
                 && m_rootstate.m_movenum > movetresh) {
                 myprintf("Score looks bad. Resigning.\n");
                 bestmove = FastBoard::RESIGN;


### PR DESCRIPTION
The first two commits just add resign_analysis.py and make changes to autogtp and leela src to support analyzing what the resign threshold should be. The last commit actually implements resignpct=10 in 90% of autogtp games. This should be pretty conservative because stats show there are only 2.13% incorrect resigns with this threshold, and we still get a 42% reduction in game length.

I wasn't sure how I should be generating random numbers, certainly the code I have in now is bad because it doesn't initialize the seed. Can someone show how I should do it? 

Here are the statistics using the latest net (22373747):
```
Resign rate: 0.50
Black won 467/516 (90.50%)
Incorrect uct resigns = 46/516 (8.91%)
Average game length = 285. Average game length with resigns = 2 (99.30% reduction)

Resign rate: 0.20
Black won 467/516 (90.50%)
Incorrect uct resigns = 18/516 (3.49%)
Average game length = 285. Average game length with resigns = 128 (55.00% reduction)

Resign rate: 0.15
Black won 467/516 (90.50%)
Incorrect uct resigns = 14/516 (2.71%)
Average game length = 285. Average game length with resigns = 147 (48.37% reduction)

Resign rate: 0.10
Black won 467/516 (90.50%)
Incorrect uct resigns = 11/516 (2.13%)
Average game length = 285. Average game length with resigns = 166 (41.77% reduction)

Resign rate: 0.05
Black won 467/516 (90.50%)
Incorrect uct resigns = 8/516 (1.55%)
Average game length = 285. Average game length with resigns = 193 (32.25% reduction)
```