### PR TITLE
Add optional iterations parameter to netbench GTP command

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -652,7 +652,18 @@ bool GTP::execute(GameState & game, std::string xinput) {
         }
         return true;
     } else if (command.find("netbench") == 0) {
-        Network::benchmark(&game);
+        std::istringstream cmdstream(command);
+        std::string tmp;
+        int iterations;
+
+        cmdstream >> tmp;  // eat netbench
+        cmdstream >> iterations;
+
+        if (!cmdstream.fail()) {
+            Network::benchmark(&game, iterations);
+        } else {
+            Network::benchmark(&game);
+        }
         gtp_printf(id, "");
         return true;
 

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -84,28 +84,26 @@ std::array<float, 256> ip2_val_w;
 std::array<float, 1> ip2_val_b;
 
 void Network::benchmark(GameState * state, int iterations) {
-    {
-        int cpus = cfg_num_threads;
-        int iters_per_thread = (iterations + (cpus - 1)) / cpus;
+    int cpus = cfg_num_threads;
+    int iters_per_thread = (iterations + (cpus - 1)) / cpus;
 
-        Time start;
+    Time start;
 
-        ThreadGroup tg(thread_pool);
-        for (int i = 0; i < cpus; i++) {
-            tg.add_task([iters_per_thread, state]() {
-                GameState mystate = *state;
-                for (int loop = 0; loop < iters_per_thread; loop++) {
-                    auto vec = get_scored_moves(&mystate, Ensemble::RANDOM_ROTATION);
-                }
-            });
-        };
-        tg.wait_all();
+    ThreadGroup tg(thread_pool);
+    for (int i = 0; i < cpus; i++) {
+        tg.add_task([iters_per_thread, state]() {
+            GameState mystate = *state;
+            for (int loop = 0; loop < iters_per_thread; loop++) {
+                auto vec = get_scored_moves(&mystate, Ensemble::RANDOM_ROTATION);
+            }
+        });
+    };
+    tg.wait_all();
 
-        Time end;
-        auto centiseconds = Time::timediff(start,end) / 100.0;
-        myprintf("%5d evaluations in %5.2f seconds -> %d n/s\n",
-                 iterations, centiseconds, (int)(iterations / centiseconds));
-    }
+    Time end;
+    auto centiseconds = Time::timediff(start,end) / 100.0;
+    myprintf("%5d evaluations in %5.2f seconds -> %d n/s\n",
+             iterations, centiseconds, (int)(iterations / centiseconds));
 }
 
 void Network::initialize(void) {

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -83,11 +83,10 @@ std::array<float, 256> ip1_val_b;
 std::array<float, 256> ip2_val_w;
 std::array<float, 1> ip2_val_b;
 
-void Network::benchmark(GameState * state) {
+void Network::benchmark(GameState * state, int iterations) {
     {
-        int BENCH_AMOUNT = 1600;
         int cpus = cfg_num_threads;
-        int iters_per_thread = (BENCH_AMOUNT + (cpus - 1)) / cpus;
+        int iters_per_thread = (iterations + (cpus - 1)) / cpus;
 
         Time start;
 
@@ -103,11 +102,9 @@ void Network::benchmark(GameState * state) {
         tg.wait_all();
 
         Time end;
-
+        auto centiseconds = Time::timediff(start,end) / 100.0;
         myprintf("%5d evaluations in %5.2f seconds -> %d n/s\n",
-                 BENCH_AMOUNT,
-                 (float)Time::timediff(start,end)/100.0,
-                 (int)((float)BENCH_AMOUNT/((float)Time::timediff(start,end)/100.0)));
+                 iterations, centiseconds, (int)(iterations / centiseconds));
     }
 }
 

--- a/src/Network.h
+++ b/src/Network.h
@@ -52,7 +52,7 @@ public:
     static constexpr int INPUT_CHANNELS = 18;
 
     static void initialize();
-    static void benchmark(GameState * state);
+    static void benchmark(GameState * state, int iterations = 1600);
     static void show_heatmap(FastState * state, Netresult & netres, bool topmoves);
     static void softmax(const std::vector<float>& input,
                         std::vector<float>& output,

--- a/src/OpenCL.cpp
+++ b/src/OpenCL.cpp
@@ -441,7 +441,7 @@ void OpenCL_Network::forward(const std::vector<net_t>& input,
     cl::Buffer & residualBuffer = opencl_thread_data.m_residualBuffer;
     cl::CommandQueue & queue = opencl_thread_data.m_commandqueue;
 
-    const auto inSize = sizeof(float) * input.size();
+    const auto inSize = sizeof(net_t) * input.size();
     queue.enqueueWriteBuffer(inBuffer, CL_FALSE, 0, inSize, input.data());
 
     for (auto& layer : m_layers) {


### PR DESCRIPTION
the 1600 default is nice for understanding how long it might take for one move under normal circumstances.

But sometimes I want to run more (or less) when testing on different platforms (GTX 1080, my old 970, and historic 560) and when profiling test code. it would be nice not to have to modify Network.cpp as often as I find myself doing :)


-----