### PR TITLE
Small tfprocess improvements

### DIFF
--- a/training/tf/tfprocess.py
+++ b/training/tf/tfprocess.py
@@ -74,10 +74,10 @@ class TFProcess:
         # Regularizer
         regularizer = tf.contrib.layers.l2_regularizer(scale=0.0001)
         reg_variables = tf.trainable_variables()
-        reg_term = \
+        self.reg_term = \
             tf.contrib.layers.apply_regularization(regularizer, reg_variables)
 
-        loss = 1.0 * self.policy_loss + 1.0 * self.mse_loss + reg_term
+        loss = 1.0 * self.policy_loss + 1.0 * self.mse_loss + self.reg_term
 
         opt_op = tf.train.MomentumOptimizer(
             learning_rate=0.05, momentum=0.9, use_nesterov=True)
@@ -94,6 +94,7 @@ class TFProcess:
 
         self.avg_policy_loss = None
         self.avg_mse_loss = None
+        self.avg_reg_term = None
         self.time_start = None
 
         # Summary part
@@ -148,8 +149,9 @@ class TFProcess:
 
     def process(self, batch_size):
         # Run training for this batch
-        policy_loss, mse_loss, _, _ = self.session.run(
-            [self.policy_loss, self.mse_loss, self.train_op, self.next_batch],
+        policy_loss, mse_loss, reg_term, _, _ = self.session.run(
+            [self.policy_loss, self.mse_loss, self.reg_term, self.train_op,
+                self.next_batch],
             feed_dict={self.training: True})
         steps = tf.train.global_step(self.session, self.global_step)
         # Keep running averages
@@ -157,22 +159,27 @@ class TFProcess:
         # Google's paper scales MSE by 1/4 to a [0, 1] range, so do the same to
         # get comparable values.
         mse_loss = mse_loss / 4.0
+        decay = 0.999
         if self.avg_policy_loss:
-            self.avg_policy_loss = 0.99 * self.avg_policy_loss + 0.01 * policy_loss
+            self.avg_policy_loss = decay * self.avg_policy_loss + (1 - decay) * policy_loss
         else:
             self.avg_policy_loss = policy_loss
         if self.avg_mse_loss:
-            self.avg_mse_loss = 0.99 * self.avg_mse_loss + 0.01 * mse_loss
+            self.avg_mse_loss = decay * self.avg_mse_loss + (1 - decay) * mse_loss
         else:
             self.avg_mse_loss = mse_loss
+        if self.avg_reg_term:
+            self.avg_reg_term = decay * self.avg_reg_term + (1 - decay) * reg_term
+        else:
+            self.avg_reg_term = reg_term
         if steps % 100 == 0:
             time_end = time.time()
             speed = 0
             if self.time_start:
                 elapsed = time_end - self.time_start
                 speed = batch_size * (100.0 / elapsed)
-            print("step {}, policy loss={:g} mse={:g} ({:g} pos/s)".format(
-                steps, self.avg_policy_loss, self.avg_mse_loss, speed))
+            print("step {}, policy loss={:g} mse={:g} reg={:g} ({:g} pos/s)".format(
+                steps, self.avg_policy_loss, self.avg_mse_loss, self.avg_reg_term, speed))
             train_summaries = tf.Summary(value=[
                 tf.Summary.Value(tag="Policy Loss", simple_value=self.avg_policy_loss),
                 tf.Summary.Value(tag="MSE Loss", simple_value=self.avg_mse_loss)])
@@ -183,11 +190,8 @@ class TFProcess:
             sum_accuracy = 0
             sum_mse = 0
             for _ in range(0, 10):
-                train_accuracy, _ = self.session.run(
-                    [self.accuracy, self.next_batch],
-                    feed_dict={self.training: False})
-                train_mse, _ = self.session.run(
-                    [self.mse_loss, self.next_batch],
+                train_accuracy, train_mse, _ = self.session.run(
+                    [self.accuracy, self.mse_loss, self.next_batch],
                     feed_dict={self.training: False})
                 sum_accuracy += train_accuracy
                 sum_mse += train_mse

--- a/training/tf/tfprocess.py
+++ b/training/tf/tfprocess.py
@@ -22,7 +22,9 @@ import time
 import tensorflow as tf
 
 def weight_variable(shape):
-    initial = tf.truncated_normal(shape, stddev=0.1)
+    """Xavier initialization"""
+    stddev = np.sqrt(2.0 / (sum(shape)))
+    initial = tf.truncated_normal(shape, stddev=stddev)
     return tf.Variable(initial)
 
 # Bias weights for layers not followed by BatchNorm


### PR DESCRIPTION
Change weight initialization from constant stddev to Xavier initialization. In my testing this converges much quicker at the beginning:

![xavier_policy](https://user-images.githubusercontent.com/544240/33556384-68824510-d90c-11e7-8778-4ab16336541b.png)

Decay value of 0.99 was too noisy in my opinion so I changed it to 0.999. Also added printing of the regularization term.

train_accuracy and train_mse can be calculated from single session.run() call.