### PR TITLE
nopass 10%

### DIFF
--- a/autogtp/Production.cpp
+++ b/autogtp/Production.cpp
@@ -42,6 +42,8 @@ void ProductionWorker::run() {
         QString resignpct = (pick < 0.2) ? "0" : "5";
         // Prepend because option must have "-w " on the end
         option = " -r " + resignpct + option;
+        QString nopassbeforestep = (rand_dist(gen) > 0.1) ? "0" : "300";
+        option = " --nopassbefore " + nopassbeforestep + " " + option;
         QTextStream(stdout) << "option=" << option << endl;
         m_mutex.lock();
         Game game(m_network, option);

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -46,6 +46,7 @@ int cfg_num_threads;
 int cfg_max_playouts;
 int cfg_lagbuffer_cs;
 int cfg_resignpct;
+int cfg_nopassbefore;
 int cfg_noise;
 int cfg_random_cnt;
 bool cfg_dumbpass;
@@ -76,6 +77,7 @@ void GTP::setup_default_parameters() {
     cfg_cutoff_offset = 25.0f;
     cfg_cutoff_ratio = 5.0f;
     cfg_resignpct = 10;
+    cfg_nopassbefore = 0;
     cfg_noise = false;
     cfg_random_cnt = 0;
     cfg_dumbpass = false;
@@ -327,7 +329,12 @@ bool GTP::execute(GameState & game, std::string xinput) {
             {
                 auto search = std::make_unique<UCTSearch>(game);
 
-                int move = search->think(who);
+                int move;
+                if (game.get_movenum() < cfg_nopassbefore) {
+                    move = search->think(who, UCTSearch::NOPASS);
+                } else {
+                    move = search->think(who);
+                }
                 game.play_move(who, move);
 
                 std::string vertex = game.move_to_text(move);

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -28,6 +28,7 @@ extern int cfg_num_threads;
 extern int cfg_max_playouts;
 extern int cfg_lagbuffer_cs;
 extern int cfg_resignpct;
+extern int cfg_nopassbefore;
 extern int cfg_noise;
 extern int cfg_random_cnt;
 extern bool cfg_dumbpass;

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -61,6 +61,8 @@ void parse_commandline(int argc, char *argv[], bool & gtp_mode) {
                         "Safety margin for time usage in centiseconds.")
         ("resignpct,r", po::value<int>()->default_value(cfg_resignpct),
                         "Resign when winrate is less than x%.")
+        ("nopassbefore", po::value<int>()->default_value(cfg_nopassbefore),
+                        "Do not pass before move N.")
         ("randomcnt,m", po::value<int>()->default_value(cfg_random_cnt),
                         "Play more randomly the first x moves.")
         ("noise,n", "Enable policy network randomization.")
@@ -190,6 +192,10 @@ void parse_commandline(int argc, char *argv[], bool & gtp_mode) {
 
     if (vm.count("resignpct")) {
         cfg_resignpct = vm["resignpct"].as<int>();
+    }
+
+    if (vm.count("nopassbefore")) {
+        cfg_nopassbefore = vm["nopassbefore"].as<int>();
     }
 
     if (vm.count("randomcnt")) {


### PR DESCRIPTION
10% games will be played without passing before 300 moves as proposed in #265. `--nopassbefore N` is added to Leela Zero to control passing. This argument only changes the behavior of genmove.

I hope that no pass will generate more white wins and reduce the bias towards black in the training dataset.

As @isty2e pointed out, it is essentially adding human knowledge. I hope that we can remove this from training later once the net is balanced.

Currently, I only run 13 self-played games and 2 of them are white wins after played through end game. I don't know whether this is enough for correcting the imbalance. If no, the percentage (10%) may be increased.
