### PR TITLE
Cleanup gcc warnings

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -724,7 +724,6 @@ bool GTP::execute(GameState & game, std::string xinput) {
     } else if (command.find("dump_debug") == 0) {
         std::istringstream cmdstream(command);
         std::string tmp, filename;
-        int who_won;
 
         // tmp will eat "dump_debug"
         cmdstream >> tmp >> filename;

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -531,8 +531,8 @@ void Network::show_heatmap(FastState * state, Netresult& result, bool topmoves) 
             int vtx = state->board.get_vertex(x, y);
 
             auto item = std::find_if(moves.cbegin(), moves.cend(),
-                [&vtx](scored_node const & item) {
-                return item.second == vtx;
+                [&vtx](scored_node const & test_item) {
+                return test_item.second == vtx;
             });
 
             float score = 0.0f;

--- a/src/half/half.hpp
+++ b/src/half/half.hpp
@@ -642,10 +642,10 @@ namespace half_float
 			if(exp > 16)
 			{
 				if(R == std::round_toward_infinity)
-					return hbits | 0x7C00 - (hbits>>15);
+					return hbits | (0x7C00 - (hbits>>15));
 				else if(R == std::round_toward_neg_infinity)
-					return hbits | 0x7BFF + (hbits>>15);
-				return hbits | 0x7BFF + (R!=std::round_toward_zero);
+					return hbits | (0x7BFF + (hbits>>15));
+				return hbits | (0x7BFF + (R != std::round_toward_zero));
 			}
 			if(exp < -13)
 				value = std::ldexp(value, 24);


### PR DESCRIPTION
CL2.hpp has warnings with gcc 5, 6, and 7.
```
In file included from OpenCL.h:27:0,
                 from UCTNode.cpp:42:
./CL/cl2.hpp:1831:5: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
     const cl_type get() const { return object_; }
     ^~~~~
In file included from OpenCL.h:27:0,
                 from UCTSearch.cpp:40:
./CL/cl2.hpp:5857:63: warning: ignoring attributes on template argument ‘cl_int {aka int}’ [-Wignored-attributes]
     typename std::enable_if<!std::is_pointer<T>::value, cl_int>::type
                                                               ^

In file included from OpenCL.h:27:0,
                 from UCTSearch.cpp:40:
./CL/cl2.hpp:6157:22: warning: ignoring attributes on template argument ‘cl_int {aka int}’ [-Wignored-attributes]
         vector<cl_int>* binaryStatus = NULL,
                      ^

```

I have a [pull request](https://github.com/KhronosGroup/OpenCL-CLHPP/pull/34) open to fix the warning at 1831 (-Wignored-qualifiers).

The others (-Wignored-attributes) have been patched in similar ways in other repos [[1]](http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1221), [[2]](https://github.com/ethereum/libethereum/pull/256/commits/15e056a159a6fd0cc0fc3a0f41662771ba47cb89)