### PR TITLE
AutoGTP: Line break after Score in case of Resign.

### DIFF
--- a/autogtp/Game.cpp
+++ b/autogtp/Game.cpp
@@ -247,10 +247,10 @@ bool Game::getScore() {
     if(m_resignation) {
         if (m_blackResigned) {
             m_winner = QString(QStringLiteral("white"));
-            QTextStream(stdout) << "Score: W+Resign ";
+            QTextStream(stdout) << "Score: W+Resign" << endl;
         } else {
             m_winner = QString(QStringLiteral("black"));
-            QTextStream(stdout) << "Score: B+Resign ";
+            QTextStream(stdout) << "Score: B+Resign" << endl;
         }
     } else{
         write("final_score\n");


### PR DESCRIPTION
Before this change, "Score:" and "Winner:" were printed on one unique line in case of Resign.