### PR TITLE
Fix bug in dirichlet noise, re-normalize legal move policy priors.

### DIFF
--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -127,9 +127,12 @@ bool UCTNode::create_children(std::atomic<int> & nodecount,
         }
     }
 
-    // re-normalize after removing illegal moves.
-    for (auto& node : nodelist) {
-        node.first /= legal_sum;
+    // If the sum is 0 or a denormal, then don't try to normalize.
+    if (legal_sum > std::numeric_limits<float>::min()) {
+        // re-normalize after removing illegal moves.
+        for (auto& node : nodelist) {
+            node.first /= legal_sum;
+        }
     }
 
     link_nodelist(nodecount, nodelist, net_eval);


### PR DESCRIPTION
Dirichlet noise was only using the first value of the vector.
Policy priors should be re-normalized after removing illegal moves
so that they are on the same scale as dirichlet noise.

Fixes https://github.com/gcp/leela-zero/issues/282

I also have a debug version of the same thing here that prints more information.
https://github.com/killerducky/leela-zero/commit/c5801d3263bb45a8bbdaa0721eb59adc5d50800d

I took a position on move 293, the legal moves add up to 0.92 so the re-normalization isn't too bad there, but it might be worse in other positions, leading to the dirichlet noise overwhelming the policy priors.
