### PR TITLE
Fix #290: Use clock instead of time for seeding random

### DIFF
--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -33,7 +33,7 @@ Random::Random(int seed) {
     if (seed == -1) {
         size_t thread_id =
             std::hash<std::thread::id>()(std::this_thread::get_id());
-        seedrandom((uint32)time(0) ^ (uint32)thread_id);
+        seedrandom((uint32)clock() ^ (uint32)thread_id);
     } else {
         seedrandom(seed);
     }


### PR DESCRIPTION
Fix #290 r?@gcp 
Before:
```
$ ./autogtp -g 4
AutoGTP v7
Using 4 thread(s).
Best network hash: 2184b7500795533b97a40cc83bdfd51d1f18183c6e76d7cca3053237e0f18c7c
Required client version: 4 (OK)
Already downloaded network.
./leelaz -r 1 -g -t 1 -q -d -n -m 30 -w 2184b7500795533b97a40cc83bdfd51d1f18183c6e76d7cca3053237e0f18c7c -p 1600 --noponder
./leelaz -r 1 -g -t 1 -q -d -n -m 30 -w 2184b7500795533b97a40cc83bdfd51d1f18183c6e76d7cca3053237e0f18c7c -p 1600 --noponder
./leelaz -r 1 -g -t 1 -q -d -n -m 30 -w 2184b7500795533b97a40cc83bdfd51d1f18183c6e76d7cca3053237e0f18c7c -p 1600 --noponder
./leelaz -r 1 -g -t 1 -q -d -n -m 30 -w 2184b7500795533b97a40cc83bdfd51d1f18183c6e76d7cca3053237e0f18c7c -p 1600 --noponder
Engine has started.
Infinite thinking time set.
Engine has started.
Infinite thinking time set.
Engine has started.
Infinite thinking time set.
Engine has started.
Infinite thinking time set.
1 (S9) 1 (S9) 1 (S9) 1 (S9)
```
After:
```
$ ./autogtp -g 4
AutoGTP v7
Using 4 thread(s).
Best network hash: 2184b7500795533b97a40cc83bdfd51d1f18183c6e76d7cca3053237e0f18c7c
Required client version: 4 (OK)
Already downloaded network.
./leelaz -r 1 -g -t 1 -q -d -n -m 30 -w 2184b7500795533b97a40cc83bdfd51d1f18183c6e76d7cca3053237e0f18c7c -p 1600 --noponder
./leelaz -r 1 -g -t 1 -q -d -n -m 30 -w 2184b7500795533b97a40cc83bdfd51d1f18183c6e76d7cca3053237e0f18c7c -p 1600 --noponder
./leelaz -r 1 -g -t 1 -q -d -n -m 30 -w 2184b7500795533b97a40cc83bdfd51d1f18183c6e76d7cca3053237e0f18c7c -p 1600 --noponder
./leelaz -r 1 -g -t 1 -q -d -n -m 30 -w 2184b7500795533b97a40cc83bdfd51d1f18183c6e76d7cca3053237e0f18c7c -p 1600 --noponder
Engine has started.
Infinite thinking time set.
Engine has started.
Infinite thinking time set.
Engine has started.
Infinite thinking time set.
Engine has started.
Infinite thinking time set.
1 (R2) 1 (K3) 1 (C2) 1 (D8)
```