### PR TITLE
Implements reuse of search subtree as described in AlphaGo Zero paper…

### DIFF
--- a/src/FastBoard.h
+++ b/src/FastBoard.h
@@ -60,6 +60,8 @@ public:
     */
     static constexpr int RESIGN = -2;
 
+    static constexpr int ROOT = -3;
+
     /*
         possible contents of a square
     */

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -65,6 +65,34 @@ std::string cfg_logfile;
 FILE* cfg_logfile_handle;
 bool cfg_quiet;
 
+UCTNode * root_subtree;
+
+void cull_tree(UCTNode ** root, int move, bool reset=false) {
+  if (reset || (move == FastBoard::RESIGN) || (*root == nullptr)) {
+    delete *root; *root = nullptr;
+  }
+  else {
+    //advance root to subtree of move
+    UCTNode * subtree = (*root)->remove_child(move);
+    if (subtree != nullptr) {
+      UCTNode * oldRoot = *root;
+      subtree->subtree_adjust_children();
+      *root = subtree;
+      myprintf("[SUBTREE REUSE] nodes: deleted[%d] preserved[%d]\n",
+	       oldRoot->calc_subtree_size(),
+	       subtree->calc_subtree_size());
+      delete oldRoot;
+      //deletes all old history except subtree of move
+    }
+    else {
+      myprintf("[SUBTREE REUSE] nodes: deleted all[%d] no subtree for move[%d]\n",
+	       (*root)->calc_subtree_size(),
+               move);
+      delete *root; *root = nullptr;
+    }
+  }
+}
+
 void GTP::setup_default_parameters() {
     cfg_allow_pondering = true;
     int num_cpus = std::thread::hardware_concurrency();
@@ -272,6 +300,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
     } else if (command.find("clear_board") == 0) {
         Training::clear_training();
         game.reset_game();
+        cull_tree(&root_subtree,0,true);
         gtp_printf(id, "");
         return true;
     } else if (command.find("komi") == 0) {
@@ -299,6 +328,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
             gtp_printf(id, "");
         } else if (command.find("pass") != std::string::npos) {
             game.play_pass();
+            cull_tree(&root_subtree, FastBoard::PASS);
             gtp_printf(id, "");
         } else {
             std::istringstream cmdstream(command);
@@ -314,6 +344,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
                     gtp_fail_printf(id, "illegal move");
                 } else {
                     gtp_printf(id, "");
+                    cull_tree(&root_subtree, game.get_last_move());
                 }
             } else {
                 gtp_fail_printf(id, "syntax not understood");
@@ -339,11 +370,12 @@ bool GTP::execute(GameState & game, std::string xinput) {
             }
             // start thinking
             {
-                auto search = std::make_unique<UCTSearch>(game);
+                auto search = std::make_unique<UCTSearch>(game, &root_subtree);
 
                 game.set_to_move(who);
                 int move = search->think(who);
                 game.play_move(move);
+                cull_tree(&root_subtree, move);
 
                 std::string vertex = game.move_to_text(move);
                 gtp_printf(id, "%s", vertex.c_str());
@@ -351,7 +383,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
             if (cfg_allow_pondering) {
                 // now start pondering
                 if (!game.has_resigned()) {
-                    auto search = std::make_unique<UCTSearch>(game);
+                    auto search = std::make_unique<UCTSearch>(game, &root_subtree);
                     search->ponder();
                 }
             }
@@ -383,6 +415,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
                 game.set_to_move(who);
                 int move = search->think(who, UCTSearch::NOPASS);
                 game.play_move(move);
+                cull_tree(&root_subtree, move);
 
                 std::string vertex = game.move_to_text(move);
                 gtp_printf(id, "%s", vertex.c_str());
@@ -390,7 +423,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
             if (cfg_allow_pondering) {
                 // now start pondering
                 if (!game.has_resigned()) {
-                    auto search = std::make_unique<UCTSearch>(game);
+                    auto search = std::make_unique<UCTSearch>(game, &root_subtree);
                     search->ponder();
                 }
             }
@@ -401,6 +434,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
     } else if (command.find("undo") == 0) {
         if (game.undo_move()) {
             gtp_printf(id, "");
+            cull_tree(&root_subtree, 0, true);
         } else {
             gtp_fail_printf(id, "cannot undo");
         }
@@ -474,7 +508,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
                 // KGS sends this after our move
                 // now start pondering
                 if (!game.has_resigned()) {
-                    auto search = std::make_unique<UCTSearch>(game);
+                    auto search = std::make_unique<UCTSearch>(game, &root_subtree);
                     search->ponder();
                 }
             }
@@ -484,20 +518,22 @@ bool GTP::execute(GameState & game, std::string xinput) {
         return true;
     } else if (command.find("auto") == 0) {
         do {
-            auto search = std::make_unique<UCTSearch>(game);
+            auto search = std::make_unique<UCTSearch>(game, &root_subtree);
 
             int move = search->think(game.get_to_move(), UCTSearch::NORMAL);
             game.play_move(move);
+            cull_tree(&root_subtree, move);
             game.display_state();
 
         } while (game.get_passes() < 2 && !game.has_resigned());
 
         return true;
     } else if (command.find("go") == 0) {
-        auto search = std::make_unique<UCTSearch>(game);
+        auto search = std::make_unique<UCTSearch>(game, &root_subtree);
 
         int move = search->think(game.get_to_move());
         game.play_move(move);
+        cull_tree(&root_subtree, move);
 
         std::string vertex = game.move_to_text(move);
         myprintf("%s\n", vertex.c_str());

--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -68,10 +68,14 @@ public:
     UCTNode* uct_select_child(int color);
     UCTNode* get_first_child() const;
     UCTNode* get_nopass_child(FastState& state) const;
+    UCTNode* remove_child(int move);
     const std::vector<node_ptr_t>& get_children() const;
 
     void sort_root_children(int color);
     UCTNode& get_best_root_child(int color);
+
+    int calc_subtree_size();
+    void subtree_adjust_children();
 
 private:
     void link_nodelist(std::atomic<int>& nodecount,

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -41,8 +41,22 @@ using namespace Utils;
 
 UCTSearch::UCTSearch(GameState & g)
     : m_rootstate(g) {
+    m_root_uptr = std::make_unique<UCTNode>(FastBoard::ROOT, 0.0f, 0.5f);
+    m_root = m_root_uptr.get();
     set_playout_limit(cfg_max_playouts);
 }
+
+UCTSearch::UCTSearch(GameState & g, UCTNode ** r)
+  : m_rootstate(g) {
+    set_playout_limit(cfg_max_playouts);
+    if (*r == nullptr)
+        *r = new UCTNode(FastBoard::ROOT, 0.0f, 0.5f);
+    m_root = *r;
+    //recalc m_nodes, due to subtree reuse
+    m_nodes = m_root->calc_subtree_size();
+}
+
+
 
 SearchResult UCTSearch::play_simulation(GameState & currstate, UCTNode* const node) {
     const auto color = currstate.get_to_move();
@@ -108,7 +122,7 @@ void UCTSearch::dump_stats(KoState & state, UCTNode & parent) {
     const int color = state.get_to_move();
 
     // sort children, put best move on top
-    m_root.sort_root_children(color);
+    m_root->sort_root_children(color);
 
 
     if (parent.get_first_child()->first_visit()) {
@@ -141,31 +155,31 @@ int UCTSearch::get_best_move(passflag_t passflag) {
     int color = m_rootstate.board.get_to_move();
 
     // Make sure best is first
-    m_root.sort_root_children(color);
+    m_root->sort_root_children(color);
 
     // Check whether to randomize the best move proportional
     // to the playout counts, early game only.
     auto movenum = int(m_rootstate.get_movenum());
     if (movenum < cfg_random_cnt) {
-        m_root.randomize_first_proportionally();
+        m_root->randomize_first_proportionally();
     }
 
-    int bestmove = m_root.get_first_child()->get_move();
+    int bestmove = m_root->get_first_child()->get_move();
 
     // do we have statistics on the moves?
-    if (m_root.get_first_child() != nullptr) {
-        if (m_root.get_first_child()->first_visit()) {
+    if (m_root->get_first_child() != nullptr) {
+        if (m_root->get_first_child()->first_visit()) {
             return bestmove;
         }
     }
 
-    float bestscore = m_root.get_first_child()->get_eval(color);
+    float bestscore = m_root->get_first_child()->get_eval(color);
 
     // do we want to fiddle with the best move because of the rule set?
     if (passflag & UCTSearch::NOPASS) {
         // were we going to pass?
         if (bestmove == FastBoard::PASS) {
-            UCTNode * nopass = m_root.get_nopass_child(m_rootstate);
+            UCTNode * nopass = m_root->get_nopass_child(m_rootstate);
 
             if (nopass != nullptr) {
                 myprintf("Preferring not to pass.\n");
@@ -206,7 +220,7 @@ int UCTSearch::get_best_move(passflag_t passflag) {
                 (score < 0.0f && color == FastBoard::BLACK)) {
                 myprintf("Passing loses :-(\n");
                 // Find a valid non-pass move.
-                UCTNode * nopass = m_root.get_nopass_child(m_rootstate);
+                UCTNode * nopass = m_root->get_nopass_child(m_rootstate);
                 if (nopass != nullptr) {
                     myprintf("Avoiding pass because it loses.\n");
                     bestmove = nopass->get_move();
@@ -239,7 +253,7 @@ int UCTSearch::get_best_move(passflag_t passflag) {
         }
     }
 
-    int visits = m_root.get_visits();
+    int visits = m_root->get_visits();
 
     // if we aren't passing, should we consider resigning?
     if (bestmove != FastBoard::PASS) {
@@ -286,8 +300,8 @@ void UCTSearch::dump_analysis(int playouts) {
     GameState tempstate = m_rootstate;
     int color = tempstate.board.get_to_move();
 
-    std::string pvstring = get_pv(tempstate, m_root);
-    float winrate = 100.0f * m_root.get_eval(color);
+    std::string pvstring = get_pv(tempstate, *m_root);
+    float winrate = 100.0f * m_root->get_eval(color);
     myprintf("Playouts: %d, Win: %5.2f%%, PV: %s\n",
              playouts, winrate, pvstring.c_str());
 }
@@ -335,10 +349,10 @@ int UCTSearch::think(int color, passflag_t passflag) {
     // create a sorted list off legal moves (make sure we
     // play something legal and decent even in time trouble)
     float root_eval;
-    m_root.create_children(m_nodes, m_rootstate, root_eval);
-    m_root.kill_superkos(m_rootstate);
+    m_root->create_children(m_nodes, m_rootstate, root_eval);
+    m_root->kill_superkos(m_rootstate);
     if (cfg_noise) {
-        m_root.dirichlet_noise(0.25f, 0.03f);
+        m_root->dirichlet_noise(0.25f, 0.03f);
     }
 
     myprintf("NN eval=%f\n",
@@ -348,7 +362,7 @@ int UCTSearch::think(int color, passflag_t passflag) {
     int cpus = cfg_num_threads;
     ThreadGroup tg(thread_pool);
     for (int i = 1; i < cpus; i++) {
-        tg.add_task(UCTWorker(m_rootstate, this, &m_root));
+        tg.add_task(UCTWorker(m_rootstate, this, m_root));
     }
 
     bool keeprunning = true;
@@ -356,7 +370,7 @@ int UCTSearch::think(int color, passflag_t passflag) {
     do {
         auto currstate = std::make_unique<GameState>(m_rootstate);
 
-        auto result = play_simulation(*currstate, &m_root);
+        auto result = play_simulation(*currstate, m_root);
         if (result.valid()) {
             increment_playouts();
         }
@@ -379,21 +393,21 @@ int UCTSearch::think(int color, passflag_t passflag) {
     m_run = false;
     tg.wait_all();
     m_rootstate.stop_clock(color);
-    if (!m_root.has_children()) {
+    if (!m_root->has_children()) {
         return FastBoard::PASS;
     }
 
     // display search info
     myprintf("\n");
 
-    dump_stats(m_rootstate, m_root);
-    Training::record(m_rootstate, m_root);
+    dump_stats(m_rootstate, *m_root);
+    Training::record(m_rootstate, *m_root);
 
     Time elapsed;
     int elapsed_centis = Time::timediff_centis(start, elapsed);
     if (elapsed_centis > 0) {
         myprintf("%d visits, %d nodes, %d playouts, %d n/s\n\n",
-                 m_root.get_visits(),
+                 m_root->get_visits(),
                  static_cast<int>(m_nodes),
                  static_cast<int>(m_playouts),
                  (m_playouts * 100) / (elapsed_centis+1));
@@ -410,11 +424,11 @@ void UCTSearch::ponder() {
     int cpus = cfg_num_threads;
     ThreadGroup tg(thread_pool);
     for (int i = 1; i < cpus; i++) {
-        tg.add_task(UCTWorker(m_rootstate, this, &m_root));
+      tg.add_task(UCTWorker(m_rootstate, this, m_root));
     }
     do {
         auto currstate = std::make_unique<GameState>(m_rootstate);
-        auto result = play_simulation(*currstate, &m_root);
+        auto result = play_simulation(*currstate, m_root);
         if (result.valid()) {
             increment_playouts();
         }
@@ -425,9 +439,9 @@ void UCTSearch::ponder() {
     tg.wait_all();
     // display search info
     myprintf("\n");
-    dump_stats(m_rootstate, m_root);
+    dump_stats(m_rootstate, *m_root);
 
-    myprintf("\n%d visits, %d nodes\n\n", m_root.get_visits(), (int)m_nodes);
+    myprintf("\n%d visits, %d nodes\n\n", m_root->get_visits(), (int)m_nodes);
 }
 
 void UCTSearch::set_playout_limit(int playouts) {

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -72,7 +72,8 @@ public:
     */
     static constexpr auto MAX_TREE_SIZE = 40'000'000;
 
-    UCTSearch(GameState& g);
+    UCTSearch(GameState & g);
+    UCTSearch(GameState & g, UCTNode ** r);
     int think(int color, passflag_t passflag = NORMAL);
     void set_playout_limit(int playouts);
     void set_analyzing(bool flag);
@@ -90,7 +91,8 @@ private:
     int get_best_move(passflag_t passflag);
 
     GameState & m_rootstate;
-    UCTNode m_root{FastBoard::PASS, 0.0f, 0.5f};
+    UCTNode * m_root;
+    std::unique_ptr<UCTNode> m_root_uptr;
     std::atomic<int> m_nodes{0};
     std::atomic<int> m_playouts{0};
     std::atomic<bool> m_run{false};


### PR DESCRIPTION
… (Methods,Search Algorithm,Play section):

   "The search tree is reused at subsequent time-steps: the child node corresponding to the played action becomes the new root node; the subtree below this child is retained along with all its statistics, while the remainder of the tree is discarded."

MCTS continues the search with subtree's root node, skipping neural network evaluations on previously expanded nodes.  More efficiently using current turn's resources on unexplored nodes/paths.

Compatible with commands at GTP layer.  Ponder will continue to expand the search tree for opportunistic reuse on next enemy move.  Legal play moves trigger the search tree culling.  Clear_board/undo moves resets search tree.

Edited:  TTable serves additional purpose as explained by @gcp, for transpositions in unexplored paths 
<del>Disable TTable calls, reused subtree contains all the info TTable syncs.</del> Re-enabled

Experiments show improved visit counts vs configured playouts.  No signs of memory leaks.
Attached a debug log showing behavior of visits, nodes pruned/preserved each iteration for a -p 1600 run.
[log.reuse.debug.txt](https://github.com/gcp/leela-zero/files/1544456/log.reuse.debug.txt)
