### PR TITLE
Write log file

### DIFF
--- a/autogtp/Game.h
+++ b/autogtp/Game.h
@@ -20,6 +20,8 @@
 #define GAME_H
 
 #include <QProcess>
+#include <QTextStream>
+#include <QFile>
 #include <tuple>
 
 using VersionTuple = std::tuple<int, int>;
@@ -49,6 +51,7 @@ public:
     QString getWinnerName() const { return m_winner; }
     int getMovesCount() const { return m_moveNum; }
     QString getResult() const { return m_result.trimmed(); }
+    bool setOutputFile(QString& filename);
     enum {
         BLACK = 0,
         WHITE = 1,
@@ -77,6 +80,9 @@ private:
     bool waitReady();
     bool eatNewLine();
     void error(int errnum);
+    QFile m_logfile;
+    QTextStream m_log;
+    bool m_islogopen;
 };
 
 #endif /* GAME_H */

--- a/autogtp/Job.h
+++ b/autogtp/Job.h
@@ -36,7 +36,7 @@ public:
         Production = 0,
         Validation
     };
-    Job(QString gpu);
+    Job(QString gpu, const int index);
     ~Job() = default;
     virtual Result execute() = 0;
     virtual void init(const QMap<QString,QString> &l);
@@ -47,13 +47,14 @@ protected:
     QString m_option;
     QString m_gpu;
     VersionTuple m_leelazMinVersion;
+    int m_index;
 };
 
 
 class ProductionJob : public Job {
     Q_OBJECT
 public:
-    ProductionJob(QString gpu);
+    ProductionJob(QString gpu, const int index);
     ~ProductionJob() = default;
     void init(const QMap<QString,QString> &l);
     Result execute();
@@ -65,7 +66,7 @@ private:
 class ValidationJob : public Job {
     Q_OBJECT
 public:
-    ValidationJob(QString gpu);
+    ValidationJob(QString gpu, const int index);
     ~ValidationJob() = default;
     void init(const QMap<QString,QString> &l);
     Result execute();

--- a/autogtp/Worker.cpp
+++ b/autogtp/Worker.cpp
@@ -55,10 +55,10 @@ void Worker::createJob(int type) {
     }
     switch(type) {
     case Order::Production:
-        m_job = new ProductionJob(m_gpu);
+        m_job = new ProductionJob(m_gpu, m_index);
         break;
     case Order::Validation:
-        m_job = new ValidationJob(m_gpu);
+        m_job = new ValidationJob(m_gpu, m_index);
         break;
     }
 }


### PR DESCRIPTION
Each Game instance writes its own log file. In validation mode, two leelaz write two different log files.

The console (stdout) is changed to erase the previous move with a carriage return, so people won't worry about the mixed output. I don't know whether people like this idea or not... If not, I can revert it to the old fashion. The effect of the carriage return needs to be tested on Mac. Linux and windows should be fine.

Resolve #281