### PR TITLE
Cleanup unused m_hash_history

### DIFF
--- a/src/KoState.cpp
+++ b/src/KoState.cpp
@@ -34,10 +34,7 @@ void KoState::init_game(int size, float komi) {
     FastState::init_game(size, komi);
 
     m_ko_hash_history.clear();
-    m_hash_history.clear();
-
-    m_ko_hash_history.emplace_back(board.calc_ko_hash());
-    m_hash_history.emplace_back(board.calc_hash());
+    m_ko_hash_history.emplace_back(board.get_ko_hash());
 }
 
 bool KoState::superko(void) const {
@@ -49,30 +46,15 @@ bool KoState::superko(void) const {
     return (res != last);
 }
 
-bool KoState::superko(uint64 newhash) const {
-    auto first = crbegin(m_ko_hash_history);
-    auto last = crend(m_ko_hash_history);
-
-    auto res = std::find(first, last, newhash);
-
-    return (res != last);
-}
-
 void KoState::reset_game() {
     FastState::reset_game();
 
     m_ko_hash_history.clear();
-    m_hash_history.clear();
-
-    m_ko_hash_history.push_back(board.calc_ko_hash());
-    m_hash_history.push_back(board.calc_hash());
+    m_ko_hash_history.push_back(board.get_ko_hash());
 }
 
 void KoState::play_pass(void) {
-    FastState::play_pass();
-
-    m_ko_hash_history.push_back(board.get_ko_hash());
-    m_hash_history.push_back(board.get_hash());
+    play_move(board.get_to_move(), FastBoard::PASS);
 }
 
 void KoState::play_move(int vertex) {
@@ -83,9 +65,8 @@ void KoState::play_move(int color, int vertex) {
     if (vertex != FastBoard::PASS && vertex != FastBoard::RESIGN) {
         FastState::play_move(color, vertex);
 
-        m_ko_hash_history.push_back(board.get_ko_hash());
-        m_hash_history.push_back(board.get_hash());
     } else {
-        play_pass();
+        FastState::play_pass();
     }
+    m_ko_hash_history.push_back(board.get_ko_hash());
 }

--- a/src/KoState.h
+++ b/src/KoState.h
@@ -28,7 +28,6 @@ class KoState : public FastState {
 public:
     void init_game(int size, float komi);
     bool superko(void) const;
-    bool superko(uint64 newhash) const;
     void reset_game();
 
     void play_pass(void);
@@ -37,7 +36,6 @@ public:
 
 private:
     std::vector<uint64> m_ko_hash_history;
-    std::vector<uint64> m_hash_history;
 };
 
 #endif


### PR DESCRIPTION
This is also a small optimization (~1%) given frequency of copies (https://github.com/gcp/leela-zero/pull/89).

I have some future work hoping to convert the m_ko_hash_history from vector to set (or unordered_set) but that has proven to be complex
