### PR TITLE
FAQ: Fix hyperlink error in Tromp-Taylor rule explanation

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -64,6 +64,6 @@ This is expected. Due to randomness of self-play games, once Black choose to pas
 ## 对局结果错误 ##
 ## Wrong score? ##
 
-Leela Zero使用Tromp-Taylor规则(详见https://senseis.xmp.net/?TrompTaylorRules)。虽然与中国规则一样贴7.5目，但为计算方便，并不去除死子。因此，结果与使用中国规则计算可能有所不同。不过，不去除死子并不影响模型的训练结果，因为双方会将死子自行提掉。
+Leela Zero使用Tromp-Taylor规则(详见<https://senseis.xmp.net/?TrompTaylorRules>)。虽然与中国规则一样贴7.5目，但为计算方便，并不去除死子。因此，结果与使用中国规则计算可能有所不同。不过，不去除死子并不影响模型的训练结果，因为双方会将死子自行提掉。
 
 Leela Zero uses Tromp-Taylor rules (see https://senseis.xmp.net/?TrompTaylorRules). Although its komi is 7.5 as in Chinese rule, for simplicity, Tromp-Taylor rules do not remvoe dead stones. Thus, the result may be different from that calcuated using Chinese rule. However, keeping dead stones does not affect training results because both players are expected to capture dead stones themselves.


### PR DESCRIPTION
Fix hyperlink error under Tromp-Taylor rule part in FAQ markdown file, as it unexpectedly includes the Chinese characters in the rest of the paragraph.