### PR TITLE
Fix white player name in sgf

### DIFF
--- a/autogtp/Game.cpp
+++ b/autogtp/Game.cpp
@@ -17,6 +17,9 @@
 */
 
 #include <QUuid>
+#include <QFile>
+#include <QTextStream>
+#include <QRegularExpression>
 #include "Game.h"
 
 Game::Game(const QString& weights, const QString& opt) :
@@ -304,6 +307,30 @@ bool Game::writeSgf() {
     if (!sendGtpCommand(qPrintable("printsgf " + m_fileName + ".sgf"))) {
         return false;
     }
+    return true;
+}
+
+bool Game::fixSgfPlayerName(QString& weightFile) {
+    QFile sgfFile(m_fileName + ".sgf");
+    if (!sgfFile.open(QIODevice::Text | QIODevice::ReadOnly)) {
+        return false;
+    }
+    QString sgfData = sgfFile.readAll();
+
+    QRegularExpression re("PW\\[Human\\]");
+    QString playerName("PW[Leela Zero ");
+    playerName += weightFile.left(8);
+    playerName += "]";
+
+    sgfData.replace(re, playerName);
+
+    sgfFile.close();
+    if(sgfFile.open(QFile::WriteOnly | QFile::Truncate)) {
+        QTextStream out(&sgfFile);
+        out << sgfData;
+    }
+    sgfFile.close();
+
     return true;
 }
 

--- a/autogtp/Game.h
+++ b/autogtp/Game.h
@@ -20,7 +20,6 @@
 #define GAME_H
 
 #include <QProcess>
-#include <QTextStream>
 #include <tuple>
 
 using VersionTuple = std::tuple<int, int>;
@@ -37,6 +36,7 @@ public:
     bool nextMove();
     bool getScore();
     bool writeSgf();
+    bool fixSgfPlayerName(QString& weightFile);
     bool dumpTraining();
     void gameQuit();
     QString getMove() const { return m_moveDone; }

--- a/autogtp/Job.cpp
+++ b/autogtp/Job.cpp
@@ -69,6 +69,7 @@ Result ProdutionJob::execute(){
         QTextStream(stdout) << "Game has ended." << endl;
         if (game.getScore()) {
             game.writeSgf();
+            game.fixSgfPlayerName(m_network);
             game.dumpTraining();
         }
         res.type(Result::File);
@@ -126,6 +127,7 @@ Result ValidationJob::execute(){
            res.add("score", first.getResult());
            res.add("winner", first.getWinnerName());
            first.writeSgf();
+           first.fixSgfPlayerName(m_secondNet);
            res.add("file", first.getFile());
        }
        // Game is finished, send the result


### PR DESCRIPTION
Replaces default `Human` player name in sgf file with `Leela Zero <network>`.

Works with match and self-play games.

Currently white network name is not stored in the match sgf file making it hard to tell afterwards which one it was.