### PR TITLE
Add script to search for bad training data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ https://github.com/KhronosGroup/OpenCL-Headers/tree/master/opencl22/)
     make
     cd ..
     curl -O https://sjeng.org/zero/best_v1.txt.zip
-    unzip https://sjeng.org/zero/best_v1.txt.zip
+    unzip best_v1.txt.zip
     src/leelaz --weights weights.txt
 
 ## Example of compiling and running - Windows

--- a/autogtp/Management.cpp
+++ b/autogtp/Management.cpp
@@ -373,7 +373,10 @@ void Management::fetchNetwork(const QString &name) {
     QTextStream(stdout) << "Net filename: " << outfile << endl;
 
     if (!networkExists(name)) {
-        exit(EXIT_FAILURE);
+        //If gunzip failed remove the .gz file
+        QFile f_gz(name + ".gz");
+        f_gz.remove();
+        throw NetworkException("Failed to fetch the network");
     }
 
     return;

--- a/scripts/training_analysis/training_analysis.py
+++ b/scripts/training_analysis/training_analysis.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+#
+#    This file is part of Leela Zero.
+#    Copyright (C) 2017 Andy Olsen
+#
+#    Leela Zero is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Leela Zero is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with Leela Zero.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+import argparse
+import gzip
+import math
+import fileinput
+
+
+def findEmptyBoard(tfh, hist):
+    first_move_cnt = 0
+    zeros = "0"*math.ceil(19*19/4) + "\n"
+    while (1):
+        #print(tfh.filelineno())
+        empty_board = True
+        board = []
+        for _ in range(16):
+            line = tfh.readline()
+            if not line: break
+            line = line.decode("utf-8")               # Board input planes
+            empty_board = empty_board and line == zeros
+            board.append(line)
+            #print(empty_board, line)
+        if not line: break
+        to_move = int(tfh.readline().decode("utf-8"))           # 0 = black, 1 = white
+        policy_weights = tfh.readline().decode("utf-8")         # 361 moves + 1 pass
+        side_to_move_won = int(tfh.readline().decode("utf-8"))  # 1 = side to move won, -1 = lost
+        # Note: it can be empty_board and white to move if black passed
+        if empty_board and to_move == 0:
+            first_move_cnt += 1
+            policy_weights = policy_weights.split()
+            cnt = policy_weights.count("0")
+            if not cnt in hist: hist[cnt] = 0
+            hist[cnt] += 1
+    print(hist)
+    return first_move_cnt
+
+if __name__ == "__main__":
+    usage_str = """
+This script analyzes the training data for abnormal results,
+such as issues #359/#375. It looks for the first move of a game
+and does a histogram of how many policy training targets have 
+a value of "0". Normally there should be zero but with the bug
+there can be many. Note the bug is intermittent so there will
+be more games with bad data in them that this script can detect.
+
+Example output:
+    ../../../train_2184b750/train_2184b750_0.gz  {0: 32}
+        <snip>
+    ../../../train_2184b750/train_2184b750_9.gz  {0: 10970, 38: 1, 10: 1, 348: 1, 345: 1, 139: 1, 259: 1, 335: 1, 97: 1, 23: 1, 276: 1}
+    total first move cnt =  10980
+
+Out of 10980 games, 10970 games had no 0 in the training target.
+1 game had 38 0s
+1 game had 345 0s
+etc.
+"""
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter, description=usage_str)
+    parser.add_argument("files", metavar="files", type=str, nargs="+", help="training files (with or without *.gz)")
+    args = parser.parse_args()
+    total_first_move_cnt = 0
+    hist = {}
+    for filename in args.files:
+        tfh = fileinput.input(filename, openhook=fileinput.hook_compressed)
+        print(filename, " ", end="")
+        first_move_cnt = findEmptyBoard(tfh, hist)
+        total_first_move_cnt += first_move_cnt
+    print("total first move cnt = ", total_first_move_cnt)
+
+

--- a/scripts/training_analysis/training_analysis.py
+++ b/scripts/training_analysis/training_analysis.py
@@ -22,48 +22,47 @@ import math
 import fileinput
 import collections
 import os
+import itertools
 
-BOARDSIZE = 19
 NIBBLE = 4
+BOARDSIZE = 19
+TURNSIZE = 19
 HISTORY_PLANES = 8
+TOMOVE = 16
+POLICY = 17
+WINNER = 18
+ZERO_LINE = "0"*math.ceil((BOARDSIZE**2+1)/NIBBLE) + "\n" # 361+1 bits in hex nibbles
 
-def hook_compressed_encoded(encoding):
-    def hook_compressed(filename, mode):
-        ext = os.path.splitext(filename)[1]
-        if ext == '.gz':
-            #return gzip.open(filename, mode, encoding=encoding) # this doesn't work, why?
-            return gzip.open(filename, "rt", encoding=encoding)
-        else:
-            return open(filename, mode, encoding=encoding)
-    return hook_compressed
-
-def findEmptyBoard(tfh, hist):
-    first_move_cnt = 0
-    zeros = "0"*math.ceil((BOARDSIZE**2+1)/NIBBLE) + "\n" # 362 bits in hex nibbles
+def findEmptyBoard(tfh):
+    count = collections.Counter()
     while (1):
         empty_board = True
-        for _ in range(HISTORY_PLANES*2):
-            line = tfh.readline()
-            if not line: break
-            empty_board = empty_board and line == zeros
-        if not line: break
-        to_move = int(tfh.readline())           # 0 = black, 1 = white
-        policy_weights = tfh.readline()         # 361 moves + 1 pass
-        side_to_move_won = int(tfh.readline())  # 1 = side to move won, -1 = lost
+        turn = [line.decode("utf-8") for line in itertools.islice(tfh, TURNSIZE)]
+        if len(turn) < TURNSIZE:
+            break
+        board = turn[:HISTORY_PLANES*2]
+        to_move = int(turn[TOMOVE])              # 0 = black, 1 = white
+        policy_weights = turn[POLICY].split()    # 361 moves + 1 pass
+        side_to_move_won = int(turn[WINNER])     # 1 = side to move won, -1 = lost
+        empty_board = all(line == ZERO_LINE for line in board)
         # Note: it can be empty_board and white to move if black passed
         if empty_board and to_move == 0:
-            first_move_cnt += 1
-            policy_weights = policy_weights.split()
-            cnt = policy_weights.count("0")
-            hist[cnt] += 1
-    print(dict(hist))
-    return first_move_cnt
+            #pass_weight = float(policy_weights[-1])
+            #print("pass weight %0.2f" % (pass_weight*1000))
+            count[policy_weights.count("0")] += 1
+    return count
 
-if __name__ == "__main__":
+def main():
     usage_str = """
+Update: This method will not work on newer nets, becauase the
+newer nets are starting to narrow the search. So even a normally
+working system will have many zeros in the policy target for the
+first move. This was originally developed against net 2184b750,
+where this method did work.
+
 This script analyzes the training data for abnormal results,
 such as issues #359/#375. It looks for the first move of a game
-and does a histogram of how many policy training targets have 
+and does a histogram of how many policy training targets have
 a value of "0". Normally there should be zero but with the bug
 there can be many. Note the bug is intermittent so there will
 be more games with bad data in them that this script can detect.
@@ -83,11 +82,16 @@ etc.
     parser.add_argument("files", metavar="files", type=str, nargs="+", help="training files (with or without *.gz)")
     args = parser.parse_args()
     total_first_move_cnt = 0
-    hist = collections.defaultdict(int)
+    totalCount = collections.Counter()
     for filename in args.files:
-        tfh = fileinput.FileInput(filename, openhook=hook_compressed_encoded("utf-8"))
-        print(filename, " ", end="")
-        total_first_move_cnt += findEmptyBoard(tfh, hist)
-    print("total first move cnt = ", total_first_move_cnt)
+        tfh = fileinput.FileInput(filename, openhook=fileinput.hook_compressed)
+        fileCount = findEmptyBoard(tfh)
+        print(filename, fileCount)
+        totalCount.update(fileCount)
+    print("first move counts =", totalCount)
+    print("total first move counts =", sum(totalCount.values()))
+
+if __name__ == "__main__":
+    main()
 
 


### PR DESCRIPTION
I wrote a script to search for bad training data due to issues #359 / #375. I ran this on train_2184b750, and it only found 10 bad games out of 10980. Note there will be more bad games because the error is intermittent and my script only looks for the bug on the first move. In the heatmap experiments somewhere around 25% of them got bad results. So maybe there are around 4X more bad games, but now I am just guessing.

@gcp or @roy7 can you update the training data? I think 2184b750 has more than 10,980 games. I also want to check more recent networks. Or merge this and run it locally.


