### PR TITLE
Fixed compile error with USE_HALF

### DIFF
--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -364,6 +364,7 @@ void batchnorm(size_t channels,
     }
 }
 
+#if defined(USE_BLAS) && !defined(USE_OPENCL)
 void Network::forward(std::vector<float>& input,
                       std::vector<float>& output) {
     // Input convolution
@@ -405,6 +406,7 @@ void Network::forward(std::vector<float>& input,
     }
     std::copy(begin(conv_out), end(conv_out), begin(output));
 }
+#endif
 #endif
 
 void Network::softmax(const std::vector<float>& input,

--- a/src/Network.h
+++ b/src/Network.h
@@ -64,8 +64,10 @@ private:
     static Netresult get_scored_moves_internal(
       GameState * state, NNPlanes & planes, int rotation);
     static int rotate_nn_idx(const int vertex, int symmetry);
+#if defined(USE_BLAS) && !defined(USE_OPENCL)
     static void forward(std::vector<float>& input,
                         std::vector<float>& output);
+#endif
 };
 
 #endif

--- a/src/config.h
+++ b/src/config.h
@@ -38,8 +38,11 @@
 #endif
 //#define USE_MKL
 #define USE_OPENCL
+
 // Use 16-bit floating point storage for net calculations
+// only works for OpenCL implementations
 // #define USE_HALF
+
 //#define USE_TUNER
 
 #define PROGRAM_NAME "Leela Zero"
@@ -72,6 +75,9 @@ typedef  unsigned long long int uint64;
 #endif
 
 #ifdef USE_HALF
+#ifndef USE_OPENCL
+#error "Half-precision not supported without OpenCL"
+#endif
 #include "half/half.hpp"
 using net_t = half_float::half;
 #else


### PR DESCRIPTION
Made it explicit that half-precision without OpenCL is unsupported.
Prevented the forward() function from being defined for non-OpenCL implementations
as it is causing compilation error (due to prototype mismatch) with USE_HALF