### PR TITLE
Simpler is_suicide function

### DIFF
--- a/autogtp/Game.cpp
+++ b/autogtp/Game.cpp
@@ -306,7 +306,7 @@ bool Game::writeSgf() {
     return sendGtpCommand(qPrintable("printsgf " + m_fileName + ".sgf"));
 }
 
-bool Game::fixSgfPlayerName(QString& weightFile) {
+bool Game::fixSgf(QString& weightFile, bool resignation) {
     QFile sgfFile(m_fileName + ".sgf");
     if (!sgfFile.open(QIODevice::Text | QIODevice::ReadOnly)) {
         return false;
@@ -317,8 +317,16 @@ bool Game::fixSgfPlayerName(QString& weightFile) {
     QString playerName("PW[Leela Zero ");
     playerName += weightFile.left(8);
     playerName += "]";
-
     sgfData.replace(re, playerName);
+
+    if(resignation) {
+        QRegularExpression oldResult("RE\\[B\\+.*\\]");
+        QString newResult("RE[B+Resign] ");
+        sgfData.replace(oldResult, newResult);
+        QRegularExpression lastpass(";W\\[tt\\]\\)");
+        QString noPass(")");
+        sgfData.replace(lastpass, noPass);
+    }
 
     sgfFile.close();
     if(sgfFile.open(QFile::WriteOnly | QFile::Truncate)) {

--- a/autogtp/Game.cpp
+++ b/autogtp/Game.cpp
@@ -323,6 +323,10 @@ bool Game::fixSgf(QString& weightFile, bool resignation) {
         QRegularExpression oldResult("RE\\[B\\+.*\\]");
         QString newResult("RE[B+Resign] ");
         sgfData.replace(oldResult, newResult);
+        if(!sgfData.contains(newResult, Qt::CaseInsensitive)) {
+            QRegularExpression oldwResult("RE\\[W\\+.*\\]");
+            sgfData.replace(oldwResult, newResult);
+        }
         QRegularExpression lastpass(";W\\[tt\\]\\)");
         QString noPass(")");
         sgfData.replace(lastpass, noPass);

--- a/autogtp/Game.h
+++ b/autogtp/Game.h
@@ -36,7 +36,7 @@ public:
     bool nextMove();
     bool getScore();
     bool writeSgf();
-    bool fixSgfPlayerName(QString& weightFile);
+    bool fixSgf(QString& weightFile, bool resignation);
     bool dumpTraining();
     bool dumpDebug();
     void gameQuit();

--- a/autogtp/Job.cpp
+++ b/autogtp/Job.cpp
@@ -69,7 +69,7 @@ Result ProductionJob::execute(){
         QTextStream(stdout) << "Game has ended." << endl;
         if (game.getScore()) {
             game.writeSgf();
-            game.fixSgfPlayerName(m_network);
+            game.fixSgf(m_network, false);
             game.dumpTraining();
             if (m_debug) {
                 game.dumpDebug();
@@ -131,7 +131,7 @@ Result ValidationJob::execute(){
            res.add("score", first.getResult());
            res.add("winner", first.getWinnerName());
            first.writeSgf();
-           first.fixSgfPlayerName(m_secondNet);
+           first.fixSgf(m_secondNet, (res.parameters()["score"] == "B+Resign"));
            res.add("file", first.getFile());
        }
        // Game is finished, send the result

--- a/autogtp/Management.cpp
+++ b/autogtp/Management.cpp
@@ -394,12 +394,14 @@ void Management::archiveFiles(const QString &sgf_file, const QString &data_file,
     if (!m_debugPath.isEmpty()) {
         if(!data_file.isEmpty()) {
             QFile(data_file).copy(m_debugPath + '/' + data_file);
-            dir.remove(data_file);
         }
         if(!debug_file.isEmpty()) {
             QFile(debug_file).copy(m_debugPath + '/' + debug_file);
             dir.remove(debug_file);
         }
+    }
+    if(!data_file.isEmpty()) {
+        dir.remove(data_file);
     }
 }
 

--- a/autogtp/Management.h
+++ b/autogtp/Management.h
@@ -72,7 +72,9 @@ private:
     bool networkExists(const QString &name);
     void fetchNetwork(const QString &name);
     void printTimingInfo(float duration);
-    void archiveFiles(const QString &sgf_file, const QString &data_file, const QString &debug_file);
+    void gzipFile(const QString &fileName);
+    void archiveFiles(const QString &fileName);
+    void cleanupFiles(const QString &fileName);
     void uploadData(const QMap<QString,QString> &r, const QMap<QString,QString> &l);
     void uploadResult(const QMap<QString, QString> &r, const QMap<QString, QString> &l);
 };

--- a/autogtp/Management.h
+++ b/autogtp/Management.h
@@ -72,6 +72,7 @@ private:
     bool networkExists(const QString &name);
     void fetchNetwork(const QString &name);
     void printTimingInfo(float duration);
+    void archiveFiles(const QString &sgf_file, const QString &data_file, const QString &debug_file);
     void uploadData(const QMap<QString,QString> &r, const QMap<QString,QString> &l);
     void uploadResult(const QMap<QString, QString> &r, const QMap<QString, QString> &l);
 };

--- a/src/FastBoard.cpp
+++ b/src/FastBoard.cpp
@@ -167,12 +167,10 @@ void FastBoard::reset_board(int size) {
     m_next[MAXSQ]   = MAXSQ;
 }
 
-bool FastBoard::is_suicide(int i, int color) {
+bool FastBoard::is_suicide(int i, int color) const {
     if (count_pliberties(i)) {
         return false;
     }
-
-    bool connecting = false;
 
     for (int k = 0; k < 4; k++) {
         int ai = i + m_dirs[k];
@@ -183,7 +181,6 @@ bool FastBoard::is_suicide(int i, int color) {
                 // connecting to live group = never suicide
                 return false;
             }
-            connecting = true;
         } else {
             if (libs <= 1) {
                 // killing neighbor = never suicide
@@ -192,39 +189,16 @@ bool FastBoard::is_suicide(int i, int color) {
         }
     }
 
-    add_neighbour(i, color);
-
-    bool opps_live = true;
-    bool ours_die = true;
-
-    for (int k = 0; k < 4; k++) {
-        int ai = i + m_dirs[k];
-
-        int libs = m_libs[m_parent[ai]];
-
-        if (libs == 0 && get_square(ai) != color) {
-            opps_live = false;
-        } else if (libs != 0 && get_square(ai) == color) {
-            ours_die = false;
-        }
-    }
-
-    remove_neighbour(i, color);
-
-    if (!connecting) {
-        return opps_live;
-    } else {
-        return opps_live && ours_die;
-    }
+    return true;
 }
 
-int FastBoard::count_pliberties(const int i) {
+int FastBoard::count_pliberties(const int i) const {
     return count_neighbours(EMPTY, i);
 }
 
 // count neighbours of color c at vertex v
 // the border of the board has fake neighours of both colors
-int FastBoard::count_neighbours(const int c, const int v) {
+int FastBoard::count_neighbours(const int c, const int v) const {
     assert(c == WHITE || c == BLACK || c == EMPTY);
     return (m_neighbours[v] >> (NBR_SHIFT * c)) & 7;
 }

--- a/src/FastBoard.h
+++ b/src/FastBoard.h
@@ -80,8 +80,8 @@ public:
     void set_square(int vertex, square_t content);
     std::pair<int, int> get_xy(int vertex) const;
 
-    bool is_suicide(int i, int color);
-    int count_pliberties(const int i);
+    bool is_suicide(int i, int color) const;
+    int count_pliberties(const int i) const;
     void augment_chain(std::vector<int> & chains, int vertex);
     bool is_eye(const int color, const int vtx);
     int get_dir(int i) const;
@@ -135,7 +135,7 @@ protected:
 
     int m_boardsize;
 
-    int count_neighbours(const int color, const int i);
+    int count_neighbours(const int color, const int i) const;
     void merge_strings(const int ip, const int aip);
     int remove_string_fast(int i);
     void add_neighbour(const int i, const int color);

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -364,6 +364,7 @@ void batchnorm(size_t channels,
     }
 }
 
+#if defined(USE_BLAS) && !defined(USE_OPENCL)
 void Network::forward(std::vector<float>& input,
                       std::vector<float>& output) {
     // Input convolution
@@ -405,6 +406,7 @@ void Network::forward(std::vector<float>& input,
     }
     std::copy(begin(conv_out), end(conv_out), begin(output));
 }
+#endif
 #endif
 
 void Network::softmax(const std::vector<float>& input,

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -102,9 +102,9 @@ void Network::benchmark(GameState * state, int iterations) {
     tg.wait_all();
 
     Time end;
-    auto centiseconds = Time::timediff(start,end) / 100.0;
+    auto elapsed = Time::timediff_seconds(start,end);
     myprintf("%5d evaluations in %5.2f seconds -> %d n/s\n",
-             iterations, centiseconds, (int)(iterations / centiseconds));
+             iterations, elapsed, (int)(iterations / elapsed));
 }
 
 void Network::initialize(void) {

--- a/src/Network.h
+++ b/src/Network.h
@@ -64,8 +64,10 @@ private:
     static Netresult get_scored_moves_internal(
       GameState * state, NNPlanes & planes, int rotation);
     static int rotate_nn_idx(const int vertex, int symmetry);
+#if defined(USE_BLAS) && !defined(USE_OPENCL)
     static void forward(std::vector<float>& input,
                         std::vector<float>& output);
+#endif
 };
 
 #endif

--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -16,7 +16,6 @@
     along with Leela Zero.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <time.h>
 #include <limits.h>
 #include <thread>
 #include "config.h"

--- a/src/TimeControl.cpp
+++ b/src/TimeControl.cpp
@@ -59,17 +59,17 @@ void TimeControl::start(int color) {
 
 void TimeControl::stop(int color) {
     Time stop;
-    int elapsed = Time::timediff(m_times[color], stop);
+    int elapsed_centis = Time::timediff_centis(m_times[color], stop);
 
-    assert(elapsed >= 0);
+    assert(elapsed_centis >= 0);
 
-    m_remaining_time[color] -= elapsed;
+    m_remaining_time[color] -= elapsed_centis;
 
     if (m_inbyo[color]) {
         if (m_byostones) {
             m_stones_left[color]--;
         } else if (m_byoperiods) {
-            if (elapsed > m_byotime) {
+            if (elapsed_centis > m_byotime) {
                 m_periods_left[color]--;
             }
         }

--- a/src/Timing.cpp
+++ b/src/Timing.cpp
@@ -16,38 +16,21 @@
     along with Leela Zero.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <ctime>
-#include <cstdlib>
+#include <chrono>
 
 #include "config.h"
 #include "Timing.h"
 
 
-int Time::timediff (Time start, Time end) {
-    int diff;
+int Time::timediff_centis(Time start, Time end) {
+    return std::chrono::duration_cast<std::chrono::milliseconds>
+        (end.m_time - start.m_time).count() / 10;
+}
 
-#ifdef GETTICKCOUNT
-    diff = ((end.m_time-start.m_time)+5)/10;
-#elif (defined(GETTIMEOFDAY))
-    diff = ((end.m_time.tv_sec-start.m_time.tv_sec)*100
-           + (end.m_time.tv_usec-start.m_time.tv_usec)/10000);
-#else
-    diff = (100*(int) difftime (end.m_time, start.m_time));
-#endif
-
-    return (abs(diff));
+double Time::timediff_seconds(Time start, Time end) {
+    return std::chrono::duration<double>(end.m_time - start.m_time).count();
 }
 
 Time::Time(void) {
-
-#if defined (GETTICKCOUNT)
-    m_time = (int)(GetTickCount());
-#elif defined(GETTIMEOFDAY)
-    struct timeval tmp;
-    gettimeofday(&tmp, NULL);
-    m_time = tmp;
-#else
-    m_time = time (0);
-#endif
-
+    m_time = std::chrono::steady_clock::now();
 }

--- a/src/Timing.h
+++ b/src/Timing.h
@@ -19,28 +19,24 @@
 #ifndef TIMING_H_INCLUDED
 #define TIMING_H_INCLUDED
 
+#include <chrono>
+
 #include "config.h"
 
-#include <time.h>
-#ifdef _WIN32
-#define NOMINMAX
-#include <windows.h>
-#endif
 
 class Time {
 public:
-    /*
-        sets to current time
-    */
+    /* sets to current time */
     Time(void);
 
-    /*
-        time difference in centiseconds
-    */
-    static int timediff(Time start, Time end);
+    /* time difference in centiseconds */
+    static int timediff_centis(Time start, Time end);
+
+    /* time difference in seconds */
+    static double timediff_seconds(Time start, Time end);
 
 private:
-    rtime_t m_time;
+    std::chrono::steady_clock::time_point m_time;
 };
 
 #endif

--- a/src/Training.cpp
+++ b/src/Training.cpp
@@ -175,7 +175,7 @@ void Training::dump_training(int winner_color, OutputChunker& outchunk) {
         for (auto it = begin(step.probabilities);
             it != end(step.probabilities); ++it) {
             out << *it;
-            if (boost::next(it) != end(step.probabilities)) {
+            if (next(it) != end(step.probabilities)) {
                 out << " ";
             }
         }

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -370,16 +370,16 @@ int UCTSearch::think(int color, passflag_t passflag) {
         }
 
         Time elapsed;
-        int centiseconds_elapsed = Time::timediff(start, elapsed);
+        int elapsed_centis = Time::timediff_centis(start, elapsed);
 
         // output some stats every few seconds
         // check if we should still search
-        if (centiseconds_elapsed - last_update > 250) {
-            last_update = centiseconds_elapsed;
+        if (elapsed_centis - last_update > 250) {
+            last_update = elapsed_centis;
             dump_analysis(static_cast<int>(m_playouts));
         }
         keeprunning  = is_running();
-        keeprunning &= (centiseconds_elapsed < time_for_move);
+        keeprunning &= (elapsed_centis < time_for_move);
         keeprunning &= !playout_limit_reached();
     } while(keeprunning);
 
@@ -398,13 +398,13 @@ int UCTSearch::think(int color, passflag_t passflag) {
     Training::record(m_rootstate, m_root);
 
     Time elapsed;
-    int centiseconds_elapsed = Time::timediff(start, elapsed);
-    if (centiseconds_elapsed > 0) {
+    int elapsed_centis = Time::timediff_centis(start, elapsed);
+    if (elapsed_centis > 0) {
         myprintf("%d visits, %d nodes, %d playouts, %d n/s\n\n",
                  m_root.get_visits(),
                  static_cast<int>(m_nodes),
                  static_cast<int>(m_playouts),
-                 (m_playouts * 100) / (centiseconds_elapsed+1));
+                 (m_playouts * 100) / (elapsed_centis+1));
     }
     int bestmove = get_best_move(passflag);
     return bestmove;

--- a/src/config.h
+++ b/src/config.h
@@ -88,16 +88,4 @@ using net_t = float;
     #pragma warning(disable : 4996)
 #endif /* VC8+ */
 
-#ifdef GETTICKCOUNT
-    typedef int rtime_t;
-#else
-    #if defined(GETTIMEOFDAY)
-        #include <sys/time.h>
-        #include <time.h>
-        typedef struct timeval rtime_t;
-    #else
-        typedef time_t rtime_t;
-    #endif
-#endif
-
 #endif

--- a/src/config.h
+++ b/src/config.h
@@ -38,8 +38,11 @@
 #endif
 //#define USE_MKL
 #define USE_OPENCL
+
 // Use 16-bit floating point storage for net calculations
+// only works for OpenCL implementations
 // #define USE_HALF
+
 //#define USE_TUNER
 
 #define PROGRAM_NAME "Leela Zero"
@@ -72,6 +75,9 @@ typedef  unsigned long long int uint64;
 #endif
 
 #ifdef USE_HALF
+#ifndef USE_OPENCL
+#error "Half-precision not supported without OpenCL"
+#endif
 #include "half/half.hpp"
 using net_t = half_float::half;
 #else


### PR DESCRIPTION
My Go knowledge is very limited so perhaps I misunderstood something while reading the code:

Function `is_suicide()` does some unnecessary things.

After checking for connecting to a living group and killing a
neighbor, the result can only be true (suicide):

After the first loop, neighbors of `i` with color `color` have only one liberty,
neighbors of the other color have at least two liberties. `add_neighbour()`
decreases all liberties by one for every string. So for no neighbor stone  the
variables `opps_live` and `ours_die` are changed in the loop and the function
result can only be `true`.