### PR TITLE
Print cfg_options_str and TimeControl in comment of sgf files.

### DIFF
--- a/autogtp/Game.cpp
+++ b/autogtp/Game.cpp
@@ -312,13 +312,14 @@ bool Game::fixSgf(QString& weightFile, bool resignation) {
         return false;
     }
     QString sgfData = sgfFile.readAll();
-    QRegularExpression re("\\[Human\\]");
-    QString playerName("[Leela Zero ");
-    QRegularExpression le("\\[Leela Zero .* ");
+    QRegularExpression re("PW\\[Human\\]");
+    QString playerName("PB[Leela Zero ");
+    QRegularExpression le("PB\\[Leela Zero \\S+ ");
     QRegularExpressionMatch match = le.match(sgfData);
     if (match.hasMatch()) {
         playerName = match.captured(0);
     }
+    playerName = "PW" + playerName.remove(0, 2);
     playerName += weightFile.left(8);
     playerName += "]";
     sgfData.replace(re, playerName);

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -62,6 +62,7 @@ std::string cfg_weightsfile;
 std::string cfg_logfile;
 FILE* cfg_logfile_handle;
 bool cfg_quiet;
+std::string cfg_options_str;
 
 void GTP::setup_default_parameters() {
     cfg_allow_pondering = true;

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -42,6 +42,7 @@ extern std::string cfg_logfile;
 extern std::string cfg_weightsfile;
 extern FILE* cfg_logfile_handle;
 extern bool cfg_quiet;
+extern std::string cfg_options_str;
 
 class GTP {
 public:

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -222,6 +222,36 @@ static void parse_commandline(int argc, char *argv[], bool & gtp_mode) {
         }
     }
 #endif
+
+    auto out = std::stringstream{};
+    for (const auto& it : vm) {
+        if (it.second.defaulted()) {
+            continue;
+        }
+        auto &type = it.second.value().type();
+
+        out << "--" << it.first;
+        if (type == typeid(uint64)) {
+            out << " " << it.second.as<uint64>();
+        } else if (type == typeid(std::string)) {
+            // skip unary string options
+            if (it.second.as<std::string>() != "") {
+                // Sanitize user supplied strings
+                out << " " << it.first;
+            }
+        } else if (type == typeid(int)) {
+            out << " " << it.second.as<int>();
+        } else if (type == typeid(float)) {
+            out << " " << it.second.as<float>();
+        } else {
+            out << " unknown option type";
+        }
+        out << " ";
+    }
+    if (!vm.count("seed")) {
+        out << "--seed " << cfg_rng_seed;
+    }
+    cfg_options_str = out.str();
 }
 
 int main (int argc, char *argv[]) {

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -224,32 +224,11 @@ static void parse_commandline(int argc, char *argv[], bool & gtp_mode) {
 #endif
 
     auto out = std::stringstream{};
-    for (const auto& it : vm) {
-        if (it.second.defaulted()) {
-            continue;
-        }
-        auto &type = it.second.value().type();
-
-        out << "--" << it.first;
-        if (type == typeid(uint64)) {
-            out << " " << it.second.as<uint64>();
-        } else if (type == typeid(std::string)) {
-            // skip unary string options
-            if (it.second.as<std::string>() != "") {
-                // Sanitize user supplied strings
-                out << " " << it.first;
-            }
-        } else if (type == typeid(int)) {
-            out << " " << it.second.as<int>();
-        } else if (type == typeid(float)) {
-            out << " " << it.second.as<float>();
-        } else {
-            out << " unknown option type";
-        }
-        out << " ";
+    for (auto i=1; i < argc; i++) {
+        out << " " << argv[i];
     }
     if (!vm.count("seed")) {
-        out << "--seed " << cfg_rng_seed;
+        out << " --seed " << cfg_rng_seed;
     }
     cfg_options_str = out.str();
 }

--- a/src/SGFTree.cpp
+++ b/src/SGFTree.cpp
@@ -478,7 +478,7 @@ std::string SGFTree::state_to_string(GameState& pstate, int compcolor) {
         }
     }
 
-    header.append("\nC[LeelaZ options: " + cfg_options_str + "]");
+    header.append("\nC[" + std::string{PROGRAM_NAME} + " options:" + cfg_options_str + "]");
 
     std::string result(header);
     result.append("\n");

--- a/src/SGFTree.cpp
+++ b/src/SGFTree.cpp
@@ -402,6 +402,7 @@ std::string SGFTree::state_to_string(GameState& pstate, int compcolor) {
     header.append("DT[" + std::string(timestr) + "]");
     header.append("SZ[" + std::to_string(size) + "]");
     header.append("KM[" + str(boost::format("%.1f") % komi) + "]");
+    header.append(state->get_timecontrol().to_text_sgf());
 
     auto leela_name = std::string{PROGRAM_NAME};
     leela_name.append(" " + std::string(PROGRAM_VERSION));
@@ -477,9 +478,7 @@ std::string SGFTree::state_to_string(GameState& pstate, int compcolor) {
         }
     }
 
-    auto tc = state->get_timecontrol();
-    header.append("\nC[LeelaZ options: " + cfg_options_str + "\n");
-    header.append("LeelaZ time control: " + tc.to_string() + "]");
+    header.append("\nC[LeelaZ options: " + cfg_options_str + "]");
 
     std::string result(header);
     result.append("\n");

--- a/src/SGFTree.cpp
+++ b/src/SGFTree.cpp
@@ -477,6 +477,10 @@ std::string SGFTree::state_to_string(GameState& pstate, int compcolor) {
         }
     }
 
+    auto tc = state->get_timecontrol();
+    header.append("\nC[LeelaZ options: " + cfg_options_str + "\n");
+    header.append("LeelaZ time control: " + tc.to_string() + "]");
+
     std::string result(header);
     result.append("\n");
     result.append(moves);

--- a/src/TimeControl.cpp
+++ b/src/TimeControl.cpp
@@ -34,17 +34,22 @@ TimeControl::TimeControl(int boardsize, int maintime, int byotime,
     set_boardsize(boardsize);
 }
 
-std::string TimeControl::to_string() {
+std::string TimeControl::to_text_sgf() {
     if (m_byotime != 0 && m_byostones == 0 && m_byoperiods == 0) {
-        return "Infinite";
+        return ""; // infinite
     }
-    if (!m_byotime) {
-        return std::to_string(m_maintime/100) + "s absolute";
+    auto s = "TM[" + std::to_string(m_maintime/100) + "]";
+    if (m_byotime) {
+        if (m_byostones) {
+            s += "OT[" + std::to_string(m_byostones) + "/";
+            s += std::to_string(m_byotime/100) + " Canadian]";
+        } else {
+            assert(m_byoperiods);
+            s += "OT[" + std::to_string(m_byoperiods) + "x";
+            s += std::to_string(m_byotime/100) + " byo-yomi]";
+        }
     }
-    return "main " + std::to_string(m_maintime/100) + "s"
-        + ", byoyomi " + std::to_string(m_byotime/100) + "s"
-        + ", byo stones " + std::to_string(m_byostones)
-        + ", byo periods " + std::to_string(m_byoperiods);
+    return s;
 }
 
 void TimeControl::reset_clocks() {

--- a/src/TimeControl.cpp
+++ b/src/TimeControl.cpp
@@ -34,6 +34,19 @@ TimeControl::TimeControl(int boardsize, int maintime, int byotime,
     set_boardsize(boardsize);
 }
 
+std::string TimeControl::to_string() {
+    if (m_byotime != 0 && m_byostones == 0 && m_byoperiods == 0) {
+        return "Infinite";
+    }
+    if (!m_byotime) {
+        return std::to_string(m_maintime/100) + "s absolute";
+    }
+    return "main " + std::to_string(m_maintime/100) + "s"
+        + ", byoyomi " + std::to_string(m_byotime/100) + "s"
+        + ", byo stones " + std::to_string(m_byostones)
+        + ", byo periods " + std::to_string(m_byoperiods);
+}
+
 void TimeControl::reset_clocks() {
     m_remaining_time[0] = m_maintime;
     m_remaining_time[1] = m_maintime;

--- a/src/TimeControl.h
+++ b/src/TimeControl.h
@@ -40,6 +40,7 @@ public:
     void display_times();
     int get_remaining_time(int color);
     void reset_clocks();
+    std::string to_string();
 
 private:
     void display_color_time(int color);

--- a/src/TimeControl.h
+++ b/src/TimeControl.h
@@ -40,7 +40,7 @@ public:
     void display_times();
     int get_remaining_time(int color);
     void reset_clocks();
-    std::string to_string();
+    std::string to_text_sgf();
 
 private:
     void display_color_time(int color);


### PR DESCRIPTION
This will help users reproduce games. Also helps address #416 by making short games unique as long as they used different random seeds or other command line arguments.

Time controls is a common source of confusion for users, and it's important to set correctly.

Example sgf:
```
(;GM[1]FF[4]RU[Chinese]DT[2017-12-18]SZ[19]KM[7.5]PB[Leela Zero 0.9 /home/ao]PW[Human]RE[W+7.5]
C[LeelaZ options: --noponder --playouts 1600 --weights weights --seed 15337825387906334875
LeelaZ time control: 3600s absolute]

;B[ap];W[pp])

```

Notice my user home directory is leaking in the PB field. I didn't change that code. The way autogtp works this won't happen because it uses the local directory. Also the printsgf GTP command is hard-coded to have the computer always white, human always black. Again it seems autogtp takes care of this part for us. These two things are only issues if someone is not using a GUI that writes SGFs and instead uses the GTP command. They can probably be cleaned up later.
