### PR TITLE
Remove unused variable

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -724,7 +724,6 @@ bool GTP::execute(GameState & game, std::string xinput) {
     } else if (command.find("dump_debug") == 0) {
         std::istringstream cmdstream(command);
         std::string tmp, filename;
-        int who_won;
 
         // tmp will eat "dump_debug"
         cmdstream >> tmp >> filename;


### PR DESCRIPTION
Remove unused variable:

leela-zero/src/GTP.cpp:727:13: warning: unused variable ‘who_won’ [-Wunused-variable]
