### PR TITLE
Precompute batchnorm weights

### DIFF
--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -344,7 +344,7 @@ template <size_t spatial_size>
 void batchnorm(size_t channels,
                std::vector<float>& data,
                const float* means,
-               const float* scale_stddivs,
+               const float* stddivs,
                const float* eltwise = nullptr)
 {
     auto lambda_ReLU = [](float val) { return (val > 0.0f) ?
@@ -352,7 +352,7 @@ void batchnorm(size_t channels,
 
     for (auto c = size_t{0}; c < channels; ++c) {
         auto mean = means[c];
-        auto scale_stddiv = scale_stddivs[c];
+        auto scale_stddiv = stddivs[c];
 
         if (eltwise == nullptr) {
             // Classical BN

--- a/src/Network.h
+++ b/src/Network.h
@@ -58,6 +58,7 @@ public:
     static void gather_features(GameState* state, NNPlanes & planes);
 
 private:
+    static void process_bn_var(std::vector<float>& weights, const float epsilon=1e-5f);
     static Netresult get_scored_moves_internal(
       GameState * state, NNPlanes & planes, int rotation);
     static int rotate_nn_idx(const int vertex, int symmetry);

--- a/src/OpenCL.cpp
+++ b/src/OpenCL.cpp
@@ -335,7 +335,7 @@ static std::string sourceCode_utility = R"(
                         __global net_t * out,
                         __global const net_t * residual,
                         __constant const net_t * means,
-                        __constant const net_t * variances) {
+                        __constant const net_t * scale_stddivs) {
 
         // cl::NDRange global(outputs, 19*19);
         const int gx = get_global_id(0);
@@ -348,11 +348,8 @@ static std::string sourceCode_utility = R"(
         const unsigned int o = output;
         const unsigned int b = gy;
 
-        const float epsilon = 1e-5;
-
         const float mean = vload_net_t(o, means);
-        const float variance = epsilon + vload_net_t(o, variances);
-        const float scale_stddiv = 1.0f / sqrt(variance);
+        const float scale_stddiv = vload_net_t(o, scale_stddivs);
 
         // BN
         float sum = scale_stddiv * (vload_net_t(o * channel_size + b, in) - mean);

--- a/src/OpenCL.cpp
+++ b/src/OpenCL.cpp
@@ -335,7 +335,7 @@ static std::string sourceCode_utility = R"(
                         __global net_t * out,
                         __global const net_t * residual,
                         __constant const net_t * means,
-                        __constant const net_t * scale_stddivs) {
+                        __constant const net_t * stddivs) {
 
         // cl::NDRange global(outputs, 19*19);
         const int gx = get_global_id(0);
@@ -349,7 +349,7 @@ static std::string sourceCode_utility = R"(
         const unsigned int b = gy;
 
         const float mean = vload_net_t(o, means);
-        const float scale_stddiv = vload_net_t(o, scale_stddivs);
+        const float scale_stddiv = vload_net_t(o, stddivs);
 
         // BN
         float sum = scale_stddiv * (vload_net_t(o * channel_size + b, in) - mean);


### PR DESCRIPTION
Saves few sqrt calls, but no observable performance change in practice due to batchnorm being so fast compared to convolutions.

This should improve reproducibility as OpenCL sqrt is guaranteed to be accurate only within 3 ULP, but std::sqrt precision is 0.5 ULP.