### PR TITLE
AutoGTP: check for a minimum supported Qt5 version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,12 +25,6 @@ FIND_PACKAGE(Boost 1.58.0 REQUIRED program_options)
 FIND_PACKAGE(Threads REQUIRED)
 FIND_PACKAGE(ZLIB REQUIRED)
 FIND_PACKAGE(OpenCL REQUIRED)
-FIND_PACKAGE(Qt5Core REQUIRED)
-if (Qt5Core_VERSION VERSION_LESS 5.3.0)
-    message(FATAL_ERROR "Minimum supported Qt5 version is 5.3.0!")
-endif()
-
-MESSAGE( STATUS "Qt5Core version: " ${Qt5Core_VERSION} )
 # We need OpenBLAS for now, because we make some specific
 # calls. Ideally we'd use OpenBLAS is possible and fall back to
 # not doing those calls if it's not present.

--- a/autogtp/README.md
+++ b/autogtp/README.md
@@ -6,7 +6,7 @@ the SGF and training data at the end of the game.
 
 # Requirements
 
-* Qt 5.x with qmake
+* Qt 5.3 or later with qmake
 * C++14 capable compiler
 * curl
 * gzip and gunzip

--- a/autogtp/autogtp.pro
+++ b/autogtp/autogtp.pro
@@ -1,3 +1,9 @@
+QT_REQ_VERSION = 5.3
+
+lessThan(QT_VERSION, $$QT_REQ_VERSION) {
+    error(Minimum supported Qt5 version is $$QT_REQ_VERSION!)
+}
+
 QT  -= gui
 
 TARGET = autogtp


### PR DESCRIPTION
Qt is needed for autogtp only.
This patch removes the check from leelaz's CMakeLists.txt and adds it to the autogtp/autogtp.pro.