### PR TITLE
Do not process OpenCL.h when OpenCL is not used.

### DIFF
--- a/src/OpenCL.cpp
+++ b/src/OpenCL.cpp
@@ -17,8 +17,9 @@
 */
 
 #include "config.h"
-#include "OpenCL.h"
+
 #ifdef USE_OPENCL
+#include "OpenCL.h"
 
 #include <assert.h>
 #include <algorithm>


### PR DESCRIPTION
Fixes compilation of CPU-only leelaz after 9cf3126b2 commit