### PR TITLE
Encode resignation separately.

### DIFF
--- a/src/FastState.cpp
+++ b/src/FastState.cpp
@@ -99,7 +99,7 @@ void FastState::play_move(int vertex) {
 }
 
 void FastState::play_move(int color, int vertex) {
-    if (vertex != FastBoard::PASS && vertex != FastBoard::RESIGN) {
+    if (vertex != FastBoard::PASS) {
         int kosq = board.update_board(color, vertex);
 
         m_komove = kosq;
@@ -118,7 +118,7 @@ void FastState::play_move(int color, int vertex) {
             set_passes(0);
             board.m_hash ^= Zobrist::zobrist_pass[0];
         }
-    } else {
+    } else if (vertex == FastBoard::PASS) {
         play_pass();
     }
 }

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -293,8 +293,10 @@ bool GTP::execute(GameState & game, std::string xinput) {
 
         return true;
     } else if (command.find("play") == 0) {
-        if (command.find("pass") != std::string::npos
-            || command.find("resign") != std::string::npos) {
+        if (command.find("resign") != std::string::npos) {
+            game.play_move(FastBoard::RESIGN);
+            gtp_printf(id, "");
+        } else if (command.find("pass") != std::string::npos) {
             game.play_pass();
             gtp_printf(id, "");
         } else {

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -167,7 +167,7 @@ void GameState::display_state() {
     m_timecontrol.display_times();
 }
 
-int GameState::has_resigned() {
+int GameState::has_resigned() const {
     return m_resigned;
 }
 

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -41,8 +41,8 @@ void GameState::init_game(int size, float komi) {
     m_timecontrol.set_boardsize(board.get_boardsize());
     m_timecontrol.reset_clocks();
 
-    return;
-};
+    m_resigned = FastBoard::EMPTY;
+}
 
 void GameState::reset_game() {
     KoState::reset_game();
@@ -51,6 +51,8 @@ void GameState::reset_game() {
     game_history.emplace_back(std::make_shared<KoState>(*this));
 
     m_timecontrol.reset_clocks();
+
+    m_resigned = FastBoard::EMPTY;
 }
 
 bool GameState::forward_move(void) {
@@ -66,9 +68,6 @@ bool GameState::forward_move(void) {
 bool GameState::undo_move(void) {
     if (m_movenum > 0) {
         m_movenum--;
-
-        // don't actually delete it!
-        //game_history.pop_back();
 
         // this is not so nice, but it should work
         *(static_cast<KoState*>(this)) = *game_history[m_movenum];
@@ -96,13 +95,10 @@ void GameState::play_pass() {
 void GameState::play_move(int color, int vertex) {
     if (vertex != FastBoard::PASS && vertex != FastBoard::RESIGN) {
         KoState::play_move(color, vertex);
-    } else {
+    } else if (vertex == FastBoard::PASS) {
         KoState::play_pass();
-        if (vertex == FastBoard::RESIGN) {
-            std::rotate(rbegin(m_lastmove), rbegin(m_lastmove) + 1,
-                        rend(m_lastmove));
-            m_lastmove[0] = vertex;
-        }
+    } else if (vertex == FastBoard::RESIGN) {
+        m_resigned = color;
     }
 
     // cut off any leftover moves from navigating
@@ -169,6 +165,10 @@ void GameState::display_state() {
     FastState::display_state();
 
     m_timecontrol.display_times();
+}
+
+int GameState::has_resigned() {
+    return m_resigned;
 }
 
 TimeControl& GameState::get_timecontrol() {

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -61,12 +61,14 @@ public:
     void adjust_time(int color, int time, int stones);
 
     void display_state();
+    int has_resigned() const;
 
 private:
     bool valid_handicap(int stones);
 
     std::vector<std::shared_ptr<KoState>> game_history;
     TimeControl m_timecontrol;
+    int m_resigned{FastBoard::EMPTY};
 };
 
 #endif

--- a/src/KoState.cpp
+++ b/src/KoState.cpp
@@ -63,8 +63,7 @@ void KoState::play_move(int vertex) {
 void KoState::play_move(int color, int vertex) {
     if (vertex != FastBoard::PASS && vertex != FastBoard::RESIGN) {
         FastState::play_move(color, vertex);
-
-    } else {
+    } else if (vertex == FastBoard::PASS) {
         FastState::play_pass();
     }
     m_ko_hash_history.push_back(board.get_ko_hash());

--- a/src/SGFTree.cpp
+++ b/src/SGFTree.cpp
@@ -449,9 +449,7 @@ std::string SGFTree::state_to_string(GameState& pstate, int compcolor) {
 
     while (state->forward_move()) {
         int move = state->get_last_move();
-        if (move == FastBoard::RESIGN) {
-            break;
-        }
+        assert(move != FastBoard::RESIGN) {
         std::string movestr = state->board.move_to_text_sgf(move);
         if (state->get_to_move() == FastBoard::BLACK) {
             moves.append(";W[" + movestr + "]");
@@ -463,7 +461,7 @@ std::string SGFTree::state_to_string(GameState& pstate, int compcolor) {
         }
     }
 
-    if (state->get_last_move() != FastBoard::RESIGN) {
+    if (state->has_resigned() == FastBoard::EMPTY) {
         float score = state->final_score();
 
         if (score > 0.0f) {
@@ -472,8 +470,7 @@ std::string SGFTree::state_to_string(GameState& pstate, int compcolor) {
             header.append("RE[W+" + str(boost::format("%.1f") % -score) + "]");
         }
     } else {
-        // Last move was resign, so side to move won
-        if (state->get_to_move() == FastBoard::BLACK) {
+        if (state->has_resigned() == FastBoard::WHITE) {
             header.append("RE[B+Resign]");
         } else {
             header.append("RE[W+Resign]");

--- a/src/SGFTree.cpp
+++ b/src/SGFTree.cpp
@@ -362,7 +362,7 @@ int SGFTree::get_move(int tomove) {
     return SGFTree::EOT;
 }
 
-FastBoard::square_t SGFTree::get_winner() {
+FastBoard::square_t SGFTree::get_winner() const {
     return m_winner;
 }
 
@@ -449,7 +449,7 @@ std::string SGFTree::state_to_string(GameState& pstate, int compcolor) {
 
     while (state->forward_move()) {
         int move = state->get_last_move();
-        assert(move != FastBoard::RESIGN) {
+        assert(move != FastBoard::RESIGN);
         std::string movestr = state->board.move_to_text_sgf(move);
         if (state->get_to_move() == FastBoard::BLACK) {
             moves.append(";W[" + movestr + "]");

--- a/src/SGFTree.h
+++ b/src/SGFTree.h
@@ -51,7 +51,7 @@ public:
     bool is_initialized() const {
         return m_initialized;
     }
-    FastBoard::square_t get_winner();
+    FastBoard::square_t get_winner() const;
 
     static std::string state_to_string(GameState& state, int compcolor);
 


### PR DESCRIPTION
Instead of handling a resignation as a bit of a pass with some special handling, just set a specific flag in the GameState object.

This should allow removing some hacks in AutoGTP where it has to fix up our SGF files.

@marcocalignano @sethtroisi can you review?