### PR TITLE
Qmake version checking fix

### DIFF
--- a/autogtp/autogtp.pro
+++ b/autogtp/autogtp.pro
@@ -1,7 +1,12 @@
-QT_REQ_VERSION = 5.3
+QT_REQ_MAJOR_VERSION = 5
+QT_REQ_MINOR_VERSION = 3
+QT_REQ_VERSION = "$$QT_REQ_MAJOR_VERSION"."$$QT_REQ_MINOR_VERSION"
 
-lessThan(QT_VERSION, $$QT_REQ_VERSION) {
-    error(Minimum supported Qt5 version is $$QT_REQ_VERSION!)
+lessThan(QT_MAJOR_VERSION, $$QT_REQ_MAJOR_VERSION) {
+    error(Minimum supported Qt version is $$QT_REQ_VERSION!)
+}
+equals(QT_MAJOR_VERSION, $$QT_REQ_MAJOR_VERSION):lessThan(QT_MINOR_VERSION, $$QT_REQ_MINOR_VERSION) {
+    error(Minimum supported Qt version is $$QT_REQ_VERSION!)
 }
 
 QT  -= gui


### PR DESCRIPTION
lessThan function does numerical compare between variables, but failed on qt version "5.10".
btw, Qt 5.10 adds a new function 'versionAtLeast', but it's unavailable in older versions.