### PR TITLE
Fix broken USE_HALF compilation

### DIFF
--- a/src/Im2Col.h
+++ b/src/Im2Col.h
@@ -25,7 +25,7 @@
 
 template <unsigned long filter_size>
 void im2col(const int channels,
-            const std::vector<net_t>& input,
+            const std::vector<float>& input,
             std::vector<float>& output) {
     constexpr unsigned int height = 19;
     constexpr unsigned int width = 19;
@@ -35,7 +35,7 @@ void im2col(const int channels,
     constexpr unsigned int output_h = height + 2 * pad - filter_size  + 1;
     constexpr unsigned int output_w = width + 2 * pad - filter_size + 1;
 
-    const net_t* data_im = input.data();
+    const float* data_im = input.data();
     float* data_col = output.data();
 
     for (int channel = channels; channel--; data_im += channel_size) {
@@ -68,7 +68,7 @@ void im2col(const int channels,
 
 template <>
 void im2col<1>(const int channels,
-               const std::vector<net_t>& input,
+               const std::vector<float>& input,
                std::vector<float>& output) {
     constexpr unsigned int boardsize = 19;
     auto outSize = size_t{channels * boardsize * boardsize};

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -269,7 +269,7 @@ void Network::initialize(void) {
 #ifdef USE_BLAS
 template<unsigned int filter_size>
 void convolve(size_t outputs,
-              const std::vector<net_t>& input,
+              const std::vector<float>& input,
               const std::vector<float>& weights,
               const std::vector<float>& biases,
               std::vector<float>& output) {
@@ -505,7 +505,7 @@ Network::Netresult Network::get_scored_moves_internal(
     constexpr int height = 19;
     const auto convolve_channels = conv_pol_w.size() / conv_pol_b.size();
     std::vector<net_t> input_data;
-    std::vector<net_t> output_data(convolve_channels * width * height);
+    std::vector<float> output_data(convolve_channels * width * height);
     std::vector<float> policy_data(2 * width * height);
     std::vector<float> value_data(1 * width * height);
     std::vector<float> policy_out((width * height) + 1);

--- a/src/OpenCL.h
+++ b/src/OpenCL.h
@@ -115,7 +115,7 @@ public:
         return m_layers.size();
     }
 
-    void forward(const std::vector<net_t>& input, std::vector<net_t>& output);
+    void forward(const std::vector<net_t>& input, std::vector<float>& output);
 
 private:
     using weight_slice_t = std::vector<cl::Buffer>::const_iterator;


### PR DESCRIPTION
The code is not being compatiable with the CPU implementation of OpenCL.  To make it somewhat compatiable I made changes to
minimize net_t usage on Network.cpp so that it does not further break things.  There is a slight performance overhead due to
additional copying operations but I think it is negligible.