### PR TITLE
Remove unused monte carlo score estimate

### DIFF
--- a/src/FastBoard.cpp
+++ b/src/FastBoard.cpp
@@ -109,8 +109,6 @@ void FastBoard::reset_board(int size) {
     m_tomove = BLACK;
     m_prisoners[BLACK] = 0;
     m_prisoners[WHITE] = 0;
-    m_totalstones[BLACK] = 0;
-    m_totalstones[WHITE] = 0;
     m_empty_cnt = 0;
 
     m_dirs[0] = -size-2;
@@ -303,40 +301,6 @@ float FastBoard::area_score(float komi) const {
     }
 
     return score;
-}
-
-int FastBoard::estimate_mc_score(float komi) const {
-    int wsc, bsc;
-
-    bsc = m_totalstones[BLACK];
-    wsc = m_totalstones[WHITE];
-
-    return bsc-wsc-((int)komi)+1;
-}
-
-float FastBoard::final_mc_score(float komi) const {
-    int wsc, bsc;
-    int maxempty = m_empty_cnt;
-
-    bsc = m_totalstones[BLACK];
-    wsc = m_totalstones[WHITE];
-
-    for (int v = 0; v < maxempty; v++) {
-        int i = m_empty[v];
-
-        assert(m_square[i] == EMPTY);
-
-        int allblack = ((m_neighbours[i] >> (NBR_SHIFT * BLACK)) & 7) == 4;
-        int allwhite = ((m_neighbours[i] >> (NBR_SHIFT * WHITE)) & 7) == 4;
-
-        if (allwhite) {
-            wsc++;
-        } else if (allblack) {
-            bsc++;
-        }
-    }
-
-    return (float)(bsc)-((float)(wsc)+komi);
 }
 
 void FastBoard::display_board(int lastmove) {

--- a/src/FastBoard.h
+++ b/src/FastBoard.h
@@ -87,8 +87,6 @@ public:
     int get_dir(int i) const;
     int get_extra_dir(int i) const;
 
-    int estimate_mc_score(float komi) const;
-    float final_mc_score(float komi) const;
     float area_score(float komi) const;
     std::vector<bool> calc_reach_color(int col) const;
 
@@ -124,7 +122,6 @@ protected:
     std::array<int, 4>                     m_dirs;        /* movement directions 4 way */
     std::array<int, 8>                     m_extradirs;   /* movement directions 8 way */
     std::array<int, 2>                     m_prisoners;   /* prisoners per color */
-    std::array<int, 2>                     m_totalstones; /* stones per color */
     std::vector<int>                       m_critical;    /* queue of critical points */
     std::array<unsigned short, MAXSQ>      m_empty;       /* empty squares */
     std::array<unsigned short, MAXSQ>      m_empty_idx;   /* indexes of square */

--- a/src/FastState.cpp
+++ b/src/FastState.cpp
@@ -117,10 +117,6 @@ size_t FastState::get_movenum() const {
     return m_movenum;
 }
 
-int FastState::estimate_mc_score(void) {
-    return board.estimate_mc_score(m_komi + m_handicap);
-}
-
 int FastState::get_last_move(void) const {
     return m_lastmove.front();
 }

--- a/src/FastState.h
+++ b/src/FastState.h
@@ -47,7 +47,6 @@ public:
     void set_passes(int val);
     void increment_passes();
 
-    int estimate_mc_score();
     float final_score();
 
     size_t get_movenum() const;

--- a/src/FullBoard.cpp
+++ b/src/FullBoard.cpp
@@ -38,7 +38,6 @@ int FullBoard::remove_string(int i) {
 
         m_square[pos] = EMPTY;
         m_parent[pos] = MAXSQ;
-        m_totalstones[color]--;
 
         remove_neighbour(pos, color);
 
@@ -112,7 +111,6 @@ int FullBoard::update_board(const int color, const int i) {
     m_parent[i] = i;
     m_libs[i] = count_pliberties(i);
     m_stones[i] = 1;
-    m_totalstones[color]++;
 
     m_hash ^= Zobrist::zobrist[m_square[i]][i];
     m_ko_hash ^= Zobrist::zobrist[m_square[i]][i];

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -406,17 +406,6 @@ bool GTP::execute(GameState & game, std::string xinput) {
         gtp_printf(id, "");
         game.display_state();
         return true;
-    } else if (command.find("mc_score") == 0) {
-        float ftmp = game.board.final_mc_score(game.get_komi());
-        /* white wins */
-        if (ftmp < -0.1) {
-            gtp_printf(id, "W+%3.1f", (float)fabs(ftmp));
-        } else if (ftmp > 0.1) {
-            gtp_printf(id, "B+%3.1f", ftmp);
-        } else {
-            gtp_printf(id, "0");
-        }
-        return true;
     } else if (command.find("final_score") == 0) {
         float ftmp = game.final_score();
         /* white wins */


### PR DESCRIPTION
Unused except by hidden GTP command "mc_score"
GTP command "final_score" is much more appropriate (and accurate).


`grep -ri "mc_score" .` matches nothing in src

Some testing was done with 
`(yes "go" | head -n150 && echo "mc_score" && echo "final_score") | ./leelaz -t 1 -s 123 -w ../weights.txt -p 50 --noponder`
to verify before / after