### PR TITLE
convert centis in Timing to ms

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -48,7 +48,7 @@ using namespace Utils;
 bool cfg_allow_pondering;
 int cfg_num_threads;
 int cfg_max_playouts;
-int cfg_lagbuffer_cs;
+int cfg_lagbuffer_ms;
 int cfg_resignpct;
 int cfg_noise;
 int cfg_random_cnt;
@@ -69,7 +69,7 @@ void GTP::setup_default_parameters() {
     cfg_allow_pondering = true;
     cfg_num_threads = std::max(1, std::min(SMP::get_num_cpus(), MAX_CPUS));
     cfg_max_playouts = std::numeric_limits<decltype(cfg_max_playouts)>::max();
-    cfg_lagbuffer_cs = 100;
+    cfg_lagbuffer_ms = 1000;
 #ifdef USE_OPENCL
     cfg_gpus = { };
     cfg_rowtiles = 5;
@@ -447,8 +447,8 @@ bool GTP::execute(GameState & game, std::string xinput) {
         cmdstream >> tmp >> maintime >> byotime >> byostones;
 
         if (!cmdstream.fail()) {
-            // convert to centiseconds and set
-            game.set_timecontrol(maintime * 100, byotime * 100, byostones, 0);
+            // convert to milliseconds and set
+            game.set_timecontrol(maintime * 1000, byotime * 1000, byostones, 0);
 
             gtp_printf(id, "");
         } else {
@@ -474,7 +474,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
                 return 1;
             }
 
-            game.adjust_time(icolor, time * 100, stones);
+            game.adjust_time(icolor, time * 1000, stones);
 
             gtp_printf(id, "");
 
@@ -640,18 +640,18 @@ bool GTP::execute(GameState & game, std::string xinput) {
 
         if (tc_type.find("none") != std::string::npos) {
             // 30 mins
-            game.set_timecontrol(30 * 60 * 100, 0, 0, 0);
+            game.set_timecontrol(30 * 60 * 1000, 0, 0, 0);
         } else if (tc_type.find("absolute") != std::string::npos) {
             cmdstream >> maintime;
-            game.set_timecontrol(maintime * 100, 0, 0, 0);
+            game.set_timecontrol(maintime * 1000, 0, 0, 0);
         } else if (tc_type.find("canadian") != std::string::npos) {
             cmdstream >> maintime >> byotime >> byostones;
-            // convert to centiseconds and set
-            game.set_timecontrol(maintime * 100, byotime * 100, byostones, 0);
+            // convert to milliseconds and set
+            game.set_timecontrol(maintime * 1000, byotime * 1000, byostones, 0);
         } else if (tc_type.find("byoyomi") != std::string::npos) {
             // KGS style Fischer clock
             cmdstream >> maintime >> byotime >> byoperiods;
-            game.set_timecontrol(maintime * 100, byotime * 100, 0, byoperiods);
+            game.set_timecontrol(maintime * 1000, byotime * 1000, 0, byoperiods);
         } else {
             gtp_fail_printf(id, "syntax not understood");
             return true;

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -30,7 +30,7 @@
 extern bool cfg_allow_pondering;
 extern int cfg_num_threads;
 extern int cfg_max_playouts;
-extern int cfg_lagbuffer_cs;
+extern int cfg_lagbuffer_ms;
 extern int cfg_resignpct;
 extern int cfg_noise;
 extern int cfg_random_cnt;

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -61,8 +61,8 @@ static void parse_commandline(int argc, char *argv[], bool & gtp_mode) {
         ("playouts,p", po::value<int>(),
                        "Weaken engine by limiting the number of playouts. "
                        "Requires --noponder.")
-        ("lagbuffer,b", po::value<int>()->default_value(cfg_lagbuffer_cs),
-                        "Safety margin for time usage in centiseconds.")
+        ("lagbuffer,b", po::value<int>()->default_value(cfg_lagbuffer_ms),
+                        "Safety margin for time usage in milliseconds.")
         ("resignpct,r", po::value<int>()->default_value(cfg_resignpct),
                         "Resign when winrate is less than x%.")
         ("randomcnt,m", po::value<int>()->default_value(cfg_random_cnt),
@@ -205,9 +205,9 @@ static void parse_commandline(int argc, char *argv[], bool & gtp_mode) {
 
     if (vm.count("lagbuffer")) {
         int lagbuffer = vm["lagbuffer"].as<int>();
-        if (lagbuffer != cfg_lagbuffer_cs) {
-            myprintf("Using per-move time margin of %.2fs.\n", lagbuffer/100.0f);
-            cfg_lagbuffer_cs = lagbuffer;
+        if (lagbuffer != cfg_lagbuffer_ms) {
+            myprintf("Using per-move time margin of %.3fs.\n", lagbuffer/1000.0f);
+            cfg_lagbuffer_ms = lagbuffer;
         }
     }
 

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -61,7 +61,7 @@ static void parse_commandline(int argc, char *argv[], bool & gtp_mode) {
         ("playouts,p", po::value<int>(),
                        "Weaken engine by limiting the number of playouts. "
                        "Requires --noponder.")
-        ("lagbuffer,b", po::value<int>()->default_value(cfg_lagbuffer_ms),
+        ("lagbuffer_ms,b", po::value<int>()->default_value(cfg_lagbuffer_ms),
                         "Safety margin for time usage in milliseconds.")
         ("resignpct,r", po::value<int>()->default_value(cfg_resignpct),
                         "Resign when winrate is less than x%.")
@@ -203,11 +203,11 @@ static void parse_commandline(int argc, char *argv[], bool & gtp_mode) {
         cfg_random_cnt = vm["randomcnt"].as<int>();
     }
 
-    if (vm.count("lagbuffer")) {
-        int lagbuffer = vm["lagbuffer"].as<int>();
-        if (lagbuffer != cfg_lagbuffer_ms) {
-            myprintf("Using per-move time margin of %.3fs.\n", lagbuffer/1000.0f);
-            cfg_lagbuffer_ms = lagbuffer;
+    if (vm.count("lagbuffer_ms")) {
+        int lagbuffer_ms = vm["lagbuffer_ms"].as<int>();
+        if (lagbuffer_ms != cfg_lagbuffer_ms) {
+            myprintf("Using per-move time margin of %.3fs.\n", lagbuffer_ms/1000.0f);
+            cfg_lagbuffer_ms = lagbuffer_ms;
         }
     }
 

--- a/src/TimeControl.cpp
+++ b/src/TimeControl.cpp
@@ -63,17 +63,17 @@ void TimeControl::start(int color) {
 
 void TimeControl::stop(int color) {
     Time stop;
-    int elapsed_centis = Time::timediff_centis(m_times[color], stop);
+    int elapsed_ms = Time::timediff_ms(m_times[color], stop);
 
-    assert(elapsed_centis >= 0);
+    assert(elapsed_ms >= 0);
 
-    m_remaining_time[color] -= elapsed_centis;
+    m_remaining_time[color] -= elapsed_ms;
 
     if (m_inbyo[color]) {
         if (m_byostones) {
             m_stones_left[color]--;
         } else if (m_byoperiods) {
-            if (elapsed_centis > m_byotime) {
+            if (elapsed_ms > m_byotime) {
                 m_periods_left[color]--;
             }
         }
@@ -97,7 +97,7 @@ void TimeControl::stop(int color) {
 }
 
 void TimeControl::display_color_time(int color) {
-    auto rem = m_remaining_time[color] / 100;  /* centiseconds to seconds */
+    auto rem = m_remaining_time[color] / 1000;  /* milliseconds to seconds */
     auto minuteDiv = std::div(rem, 60);
     auto hourDiv = std::div(minuteDiv.quot, 60);
     auto seconds = minuteDiv.rem;
@@ -110,7 +110,7 @@ void TimeControl::display_color_time(int color) {
             myprintf(", %d stones left", m_stones_left[color]);
         } else if (m_byoperiods) {
             myprintf(", %d period(s) of %d seconds left",
-                     m_periods_left[color], m_byotime / 100);
+                     m_periods_left[color], m_byotime / 1000);
         }
     }
     myprintf("\n");
@@ -131,10 +131,10 @@ int TimeControl::max_time_for_move(int color) {
     if (m_byotime != 0) {
         /*
           no periods or stones set means
-          infinite time = 1 month
+          infinite time = 1 week
         */
         if (m_byostones == 0 && m_byoperiods == 0) {
-            return 31 * 24 * 60 * 60 * 100;
+            return 7 * 24 * 60 * 60 * 1000;
         }
 
         // byo yomi and in byo yomi
@@ -166,11 +166,11 @@ int TimeControl::max_time_for_move(int color) {
         }
     }
 
-    // always keep a cfg_lagbugger_cs centisecond margin
+    // always keep a cfg_lagbugger_ms millisecond margin
     // for network hiccups or GUI lag
-    auto base_time = std::max(time_remaining - cfg_lagbuffer_cs, 0) /
+    auto base_time = std::max(time_remaining - cfg_lagbuffer_ms, 0) /
                      std::max(moves_remaining, 1);
-    auto inc_time = std::max(extra_time_per_move - cfg_lagbuffer_cs, 0);
+    auto inc_time = std::max(extra_time_per_move - cfg_lagbuffer_ms, 0);
 
     return base_time + inc_time;
 }

--- a/src/TimeControl.h
+++ b/src/TimeControl.h
@@ -26,10 +26,10 @@
 class TimeControl {
 public:
     /*
-        Initialize time control. Timing info is per GTP and in centiseconds
+        Initialize time control. Timing info is per GTP and in milliseconds
     */
     TimeControl(int boardsize = 19,
-                int maintime = 60 * 60 * 100,
+                int maintime = 60 * 60 * 1000,
                 int byotime = 0, int byostones = 25,
                 int byoperiods = 0);
 

--- a/src/Timing.cpp
+++ b/src/Timing.cpp
@@ -21,9 +21,9 @@
 #include <chrono>
 
 
-int Time::timediff_centis(Time start, Time end) {
+int Time::timediff_ms(Time start, Time end) {
     return std::chrono::duration_cast<std::chrono::milliseconds>
-        (end.m_time - start.m_time).count() / 10;
+        (end.m_time - start.m_time).count();
 }
 
 double Time::timediff_seconds(Time start, Time end) {

--- a/src/Timing.h
+++ b/src/Timing.h
@@ -26,8 +26,8 @@ public:
     /* sets to current time */
     Time(void);
 
-    /* time difference in centiseconds */
-    static int timediff_centis(Time start, Time end);
+    /* time difference in milliseconds */
+    static int timediff_ms(Time start, Time end);
 
     /* time difference in seconds */
     static double timediff_seconds(Time start, Time end);

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -330,7 +330,7 @@ int UCTSearch::think(int color, passflag_t passflag) {
     m_rootstate.get_timecontrol().set_boardsize(m_rootstate.board.get_boardsize());
     auto time_for_move = m_rootstate.get_timecontrol().max_time_for_move(color);
 
-    myprintf("Thinking at most %.1f seconds...\n", time_for_move/100.0f);
+    myprintf("Thinking at most %.1f seconds...\n", time_for_move/1000.0f);
 
     // create a sorted list off legal moves (make sure we
     // play something legal and decent even in time trouble)
@@ -351,8 +351,8 @@ int UCTSearch::think(int color, passflag_t passflag) {
         tg.add_task(UCTWorker(m_rootstate, this, &m_root));
     }
 
-    bool keeprunning = true;
-    int last_update = 0;
+    auto keeprunning = true;
+    auto last_update = 0;
     do {
         auto currstate = std::make_unique<GameState>(m_rootstate);
 
@@ -362,16 +362,16 @@ int UCTSearch::think(int color, passflag_t passflag) {
         }
 
         Time elapsed;
-        int elapsed_centis = Time::timediff_centis(start, elapsed);
+        int elapsed_ms = Time::timediff_ms(start, elapsed);
 
         // output some stats every few seconds
         // check if we should still search
-        if (elapsed_centis - last_update > 250) {
-            last_update = elapsed_centis;
+        if (elapsed_ms - last_update > 2500) {
+            last_update = elapsed_ms;
             dump_analysis(static_cast<int>(m_playouts));
         }
         keeprunning  = is_running();
-        keeprunning &= (elapsed_centis < time_for_move);
+        keeprunning &= (elapsed_ms < time_for_move);
         keeprunning &= !playout_limit_reached();
     } while(keeprunning);
 
@@ -390,13 +390,13 @@ int UCTSearch::think(int color, passflag_t passflag) {
     Training::record(m_rootstate, m_root);
 
     Time elapsed;
-    int elapsed_centis = Time::timediff_centis(start, elapsed);
-    if (elapsed_centis > 0) {
+    int elapsed_ms = Time::timediff_ms(start, elapsed);
+    if (elapsed_ms > 0) {
         myprintf("%d visits, %d nodes, %d playouts, %d n/s\n\n",
                  m_root.get_visits(),
                  static_cast<int>(m_nodes),
                  static_cast<int>(m_playouts),
-                 (m_playouts * 100) / (elapsed_centis+1));
+                 (m_playouts * 1000) / (elapsed_ms + 1));
     }
     int bestmove = get_best_move(passflag);
     return bestmove;

--- a/training/tf/tfprocess.py
+++ b/training/tf/tfprocess.py
@@ -92,9 +92,9 @@ class TFProcess:
         correct_prediction = tf.cast(correct_prediction, tf.float32)
         self.accuracy = tf.reduce_mean(correct_prediction)
 
-        self.avg_policy_loss = None
-        self.avg_mse_loss = None
-        self.avg_reg_term = None
+        self.avg_policy_loss = []
+        self.avg_mse_loss = []
+        self.avg_reg_term = []
         self.time_start = None
 
         # Summary part
@@ -159,34 +159,28 @@ class TFProcess:
         # Google's paper scales MSE by 1/4 to a [0, 1] range, so do the same to
         # get comparable values.
         mse_loss = mse_loss / 4.0
-        decay = 0.999
-        if self.avg_policy_loss:
-            self.avg_policy_loss = decay * self.avg_policy_loss + (1 - decay) * policy_loss
-        else:
-            self.avg_policy_loss = policy_loss
-        if self.avg_mse_loss:
-            self.avg_mse_loss = decay * self.avg_mse_loss + (1 - decay) * mse_loss
-        else:
-            self.avg_mse_loss = mse_loss
-        if self.avg_reg_term:
-            self.avg_reg_term = decay * self.avg_reg_term + (1 - decay) * reg_term
-        else:
-            self.avg_reg_term = reg_term
+        self.avg_policy_loss.append(policy_loss)
+        self.avg_mse_loss.append(mse_loss)
+        self.avg_reg_term.append(reg_term)
         if steps % 100 == 0:
             time_end = time.time()
             speed = 0
             if self.time_start:
                 elapsed = time_end - self.time_start
                 speed = batch_size * (100.0 / elapsed)
+            avg_policy_loss = np.mean(self.avg_policy_loss or [0])
+            avg_mse_loss = np.mean(self.avg_mse_loss or [0])
+            avg_reg_term = np.mean(self.avg_reg_term or [0])
             print("step {}, policy={:g} mse={:g} reg={:g} total={:g} ({:g} pos/s)".format(
-                steps, self.avg_policy_loss, self.avg_mse_loss, self.avg_reg_term,
-                self.avg_policy_loss + self.avg_mse_loss + self.avg_reg_term,
+                steps, avg_policy_loss, avg_mse_loss, avg_reg_term,
+                avg_policy_loss + avg_mse_loss + avg_reg_term,
                 speed))
             train_summaries = tf.Summary(value=[
-                tf.Summary.Value(tag="Policy Loss", simple_value=self.avg_policy_loss),
-                tf.Summary.Value(tag="MSE Loss", simple_value=self.avg_mse_loss)])
+                tf.Summary.Value(tag="Policy Loss", simple_value=avg_policy_loss),
+                tf.Summary.Value(tag="MSE Loss", simple_value=avg_mse_loss)])
             self.train_writer.add_summary(train_summaries, steps)
             self.time_start = time_end
+            self.avg_policy_loss, self.avg_mse_loss, self.avg_reg_term = [], [], []
         # Ideally this would use a seperate dataset and so on...
         if steps % 2000 == 0:
             sum_accuracy = 0


### PR DESCRIPTION
Smoked tested with
Unlimited
`echo -e "time_settings 0 1 0\nauto" | ./leelaz -w ../weights.txt`
Byo stones
`echo -e "time_settings 120 60 5\nauto" | ./leelaz -w ../weights.txt`
KGS style Fischer GO
`echo -e "kgs-time_settings byoyomi 20 6 4\nauto" | ./leelaz -w ../weights.txt`
lagbuffer
`echo -e "kgs-time_settings byoyomi 20 6 4\nauto" | ./leelaz --lagbuffer 700 -w ../weights.txt`

The `--lagbuffer` parameter used to accept centiseconds which we/you might want to change,
These are some of the options,
* keeping parameter as centiseconds
* changing parameter to ms, (what I coded)\*
* changing parameter name to lagbuffer_cs (or lagbuffer_ms)

\*One downside is anyone passing lagbuffer will now be passing a value ten times smaller :/

Infinite time setting, 1 month, overflowed the ms counter (max value 560 hours ~=25 days) and was reduced to 1 week.