### PR TITLE
MSVC update for removing SMP.cpp

### DIFF
--- a/msvc/VS2015/leela-zero.vcxproj
+++ b/msvc/VS2015/leela-zero.vcxproj
@@ -84,7 +84,6 @@
     <ClCompile Include="..\..\src\Random.cpp" />
     <ClCompile Include="..\..\src\SGFParser.cpp" />
     <ClCompile Include="..\..\src\SGFTree.cpp" />
-    <ClCompile Include="..\..\src\SMP.cpp" />
     <ClCompile Include="..\..\src\TimeControl.cpp" />
     <ClCompile Include="..\..\src\Timing.cpp" />
     <ClCompile Include="..\..\src\Training.cpp" />

--- a/msvc/VS2015/leela-zero.vcxproj.filters
+++ b/msvc/VS2015/leela-zero.vcxproj.filters
@@ -54,9 +54,6 @@
     <ClInclude Include="..\..\src\SGFTree.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\SMP.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\src\ThreadPool.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/msvc/VS2017/leela-zero.vcxproj
+++ b/msvc/VS2017/leela-zero.vcxproj
@@ -58,7 +58,6 @@
     <ClCompile Include="..\..\src\Random.cpp" />
     <ClCompile Include="..\..\src\SGFParser.cpp" />
     <ClCompile Include="..\..\src\SGFTree.cpp" />
-    <ClCompile Include="..\..\src\SMP.cpp" />
     <ClCompile Include="..\..\src\TimeControl.cpp" />
     <ClCompile Include="..\..\src\Timing.cpp" />
     <ClCompile Include="..\..\src\Training.cpp" />

--- a/msvc/VS2017/leela-zero.vcxproj.filters
+++ b/msvc/VS2017/leela-zero.vcxproj.filters
@@ -125,9 +125,6 @@
     <ClCompile Include="..\..\src\SGFTree.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\SMP.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\TimeControl.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
SMP.cpp was removed from src. This is to match up with the MSVC projects so it keep compiling.