### PR TITLE
Fix FastBoard::play_pass consistency with similar logics

### DIFF
--- a/src/FastState.cpp
+++ b/src/FastState.cpp
@@ -70,14 +70,14 @@ bool FastState::is_move_legal(int color, int vertex) {
                 !board.is_suicide(vertex, color));
 }
 
-void FastState::play_pass(void) {
+void FastState::play_pass(int color) {
     m_movenum++;
 
     std::rotate(rbegin(m_lastmove), rbegin(m_lastmove) + 1, rend(m_lastmove));
     m_lastmove[0] = FastBoard::PASS;
 
     board.m_hash  ^= 0xABCDABCDABCDABCDULL;
-    board.m_tomove = !board.m_tomove;
+    board.m_tomove = !color;
 
     board.m_hash ^= Zobrist::zobrist_pass[get_passes()];
     increment_passes();
@@ -109,7 +109,7 @@ void FastState::play_move(int color, int vertex) {
             board.m_hash ^= Zobrist::zobrist_pass[0];
         }
     } else if (vertex == FastBoard::PASS) {
-        play_pass();
+        play_pass(color);
     }
 }
 

--- a/src/FastState.h
+++ b/src/FastState.h
@@ -32,7 +32,7 @@ public:
     void reset_game();
     void reset_board();
 
-    void play_pass(void);
+    void play_pass(int color);
     void play_move(int vertex);
 
     bool is_move_legal(int color, int vertex);

--- a/src/KoState.cpp
+++ b/src/KoState.cpp
@@ -64,7 +64,7 @@ void KoState::play_move(int color, int vertex) {
     if (vertex != FastBoard::PASS && vertex != FastBoard::RESIGN) {
         FastState::play_move(color, vertex);
     } else if (vertex == FastBoard::PASS) {
-        FastState::play_pass();
+        FastState::play_pass(color);
     }
     m_ko_hash_history.push_back(board.get_ko_hash());
 }


### PR DESCRIPTION
Part of #528 maybe unnecessary (the `play_textmove` part) with this fix.

The current `FastState::play_move` function uses different logic to flip the m_tomove state for normal play and a pass. It sets the next player to move to be the opposite of the given player argument, this is correct but this code only apply to normal play.

For a pass play it delegate to `play_pass` without specifying the player. So it can only look at the current playing user, which is not necessary the same as the playing color. This may cause inconsistency but I don't know how can I trigger it.

Also, all other "State" classes (`KoState`, `GameState`) have a function `play_pass` with a player color argument, but `FastState` does not. So I decided to make it consistent rather than just add a single line before calling `play_pass`.