### PR TITLE
Change definition of playout_limit_reached

### DIFF
--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -297,7 +297,7 @@ bool UCTSearch::is_running() const {
 }
 
 bool UCTSearch::playout_limit_reached() const {
-    return m_playouts >= m_maxplayouts;
+    return m_root.get_visits() >= m_maxplayouts;
 }
 
 void UCTWorker::operator()() {


### PR DESCRIPTION
See issue #538. Instead of using m_playouts, use m_root.get_visits to decide when we have reached the playout limit.

BEFORE: 1147 ms/move
AFTER: 602 ms/move
1.9X faster
