### PR TITLE
UCTNode size reduction optimization

### DIFF
--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -67,8 +67,8 @@ public:
     static constexpr passflag_t NORESIGN = 1 << 1;
 
     /*
-        Maximum size of the tree in memory. Nodes are about
-        40 bytes, so limit to ~1.6G.
+        Maximum size of the tree in memory. Nodes are 56 bytes
+        so limit to roughly 2GB-ish.
     */
     static constexpr auto MAX_TREE_SIZE = 40'000'000;
 


### PR DESCRIPTION
- Changed order of declaration of instance variables for better packing
- Removed mutex and used a shared mutex (40 byte per mutex!)
- 112B -> 56B on a 64-bit Linux gcc compilation

Next obvious target is the std::vector (28 bytes) but probably not worth the additional hassle.