### PR TITLE
Resize cache if max_playout is set

### DIFF
--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -32,6 +32,7 @@
 #include "GTP.h"
 #include "GameState.h"
 #include "Network.h"
+#include "NNCache.h"
 #include "Random.h"
 #include "ThreadPool.h"
 #include "Utils.h"
@@ -264,6 +265,15 @@ int main (int argc, char *argv[]) {
 
     // Initialize network
     Network::initialize();
+
+    // Initialize cache if playouts is set
+    if (cfg_max_playouts) {
+        // cache hits are generally from last several moves so setting cache
+        // size based on playouts increases the hit rate while balancing memory
+        // usage for low playout instances. 100'000 cache entries is ~500 MB
+        auto max_size = std::min(100'000, std::max(6'000, 3*cfg_max_playouts));
+        NNCache::get_NNCache()->resize(max_size);
+    }
 
     auto maingame = std::make_unique<GameState>();
 

--- a/src/NNCache.cpp
+++ b/src/NNCache.cpp
@@ -81,6 +81,14 @@ void NNCache::insert(const Network::NNPlanes& features, const Network::Netresult
     }
 }
 
+void NNCache::resize(int size) {
+    m_size = size;
+    while (m_order.size() > m_size) {
+        m_cache.erase(m_order.front());
+        m_order.pop_front();
+    }
+}
+
 void NNCache::dump_stats() {
     Utils::myprintf("NNCache: %d/%d hits/lookups = %.1f%% hitrate, %d inserts, %d size, %d collisions\n",
         m_hits, m_lookups, 100. * m_hits / (m_lookups + 1), m_inserts, m_cache.size(), m_collisions);

--- a/src/NNCache.cpp
+++ b/src/NNCache.cpp
@@ -73,7 +73,6 @@ void NNCache::insert(const Network::NNPlanes& features, const Network::Netresult
     m_order.push_back(hash);
     ++m_inserts;
 
-
     // If the cache is too large, remove the oldest entry.
     if (m_order.size() > m_size) {
         m_cache.erase(m_order.front());
@@ -88,6 +87,15 @@ void NNCache::resize(int size) {
         m_order.pop_front();
     }
 }
+
+void NNCache::set_size_from_playouts(int max_playouts) {
+    // cache hits are generally from last several moves so setting cache
+    // size based on playouts increases the hit rate while balancing memory
+    // usage for low playout instances. 100'000 cache entries is ~500 MB
+    auto max_size = std::min(100'000, std::max(6'000, 3 * max_playouts));
+    NNCache::get_NNCache()->resize(max_size);
+}
+
 
 void NNCache::dump_stats() {
     Utils::myprintf("NNCache: %d/%d hits/lookups = %.1f%% hitrate, %d inserts, %d size, %d collisions\n",

--- a/src/NNCache.h
+++ b/src/NNCache.h
@@ -32,6 +32,9 @@ public:
     // return the global NNCache
     static NNCache* get_NNCache(void);
 
+    // Set a reasonable size gives max number of playouts
+    void set_size_from_playouts(int max_playouts);
+
     // Resize NNCache
     void resize(int size);
 

--- a/src/NNCache.h
+++ b/src/NNCache.h
@@ -32,6 +32,9 @@ public:
     // return the global NNCache
     static NNCache* get_NNCache(void);
 
+    // Resize NNCache
+    void resize(int size);
+
     // Try and find an existing entry.
     const Network::Netresult* lookup(const Network::NNPlanes& features);
 


### PR DESCRIPTION
Testing is documented [here (Google Sheets)](https://docs.google.com/spreadsheets/d/1KI6rRX_FAIHkq74p51weL2pRj2cMqlrZFCu6Ohh3kH8/edit#gid=785169179)

For people who use high playouts memory is already REALLY high (several gigs, thought I hope pull/567 helps with that) so the extra cache is unnoticed by them.

For people running autogtp performance will be the same (with size = 15,000 it's identical because no cache hit happens with age > 15,000) but 70 megs lighter. This allows for 40% more instances of leelaz to be run which is useful for people using cuDNN and large batch_sizes.

---
Spot testing

First 38 moves are the same when testing with
`(yes "go" | head -n60) | /usr/bin/time -v ./leelaz -t1 -s120 -w ../weights.txt -p 1000 --noponder |& tee smaller_cache`

Memory is reduced by ~70 megs

```
< 	System time (seconds): 10.08
< 	Maximum resident set size (kbytes): 198600
---
> 	System time (seconds): 10.61
> 	Maximum resident set size (kbytes): 271700
```




