### PR TITLE
Anchor the history after non-alternating moves

### DIFF
--- a/src/FastState.cpp
+++ b/src/FastState.cpp
@@ -76,7 +76,9 @@ void FastState::play_pass(int color) {
     std::rotate(rbegin(m_lastmove), rbegin(m_lastmove) + 1, rend(m_lastmove));
     m_lastmove[0] = FastBoard::PASS;
 
-    board.m_hash  ^= 0xABCDABCDABCDABCDULL;
+    if (board.m_tomove == color) {
+        board.m_hash ^= 0xABCDABCDABCDABCDULL;
+    }
     board.m_tomove = !color;
 
     board.m_hash ^= Zobrist::zobrist_pass[get_passes()];

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -172,9 +172,9 @@ bool GTP::execute(GameState & game, std::string xinput) {
         if (xinput[tmp] == 9) {
             input += " ";
         } else if ((xinput[tmp] > 0 && xinput[tmp] <= 9)
-	        || (xinput[tmp] >= 11 && xinput[tmp] <= 31)
-	        || xinput[tmp] == 127) {
-	       continue;
+            || (xinput[tmp] >= 11 && xinput[tmp] <= 31)
+            || xinput[tmp] == 127) {
+           continue;
         } else {
             if (transform_lowercase) {
                 input += std::tolower(xinput[tmp]);
@@ -341,11 +341,11 @@ bool GTP::execute(GameState & game, std::string xinput) {
             {
                 auto search = std::make_unique<UCTSearch>(game);
 
-				//If played a black after a black, 
-				//this is not a normal game move and the history
-				//no longer makes sense. Clear the history for analysis purpose.
-				if (game.get_to_move() != who) 
-					game.anchor_game_history();
+                //If played a black after a black, 
+                //this is not a normal game move and the history
+                //no longer makes sense. Clear the history for analysis purpose.
+                if (game.get_to_move() != who) 
+                    game.anchor_game_history();
                 int move = search->think(who);
                 game.play_move(who, move);
 
@@ -384,11 +384,11 @@ bool GTP::execute(GameState & game, std::string xinput) {
             {
                 auto search = std::make_unique<UCTSearch>(game);
 
-				//If played a black after a black, 
-				//this is not a normal game move and the history
-				//no longer makes sense. Clear the history for analysis purpose.
-				if (game.get_to_move() != who)
-					game.anchor_game_history();
+                //If played a black after a black, 
+                //this is not a normal game move and the history
+                //no longer makes sense. Clear the history for analysis purpose.
+                if (game.get_to_move() != who) 
+                    game.anchor_game_history();
                 int move = search->think(who, UCTSearch::NOPASS);
                 game.play_move(who, move);
 

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -341,9 +341,13 @@ bool GTP::execute(GameState & game, std::string xinput) {
             {
                 auto search = std::make_unique<UCTSearch>(game);
 
-                game.set_to_move(who);
+				//If played a black after a black, 
+				//this is not a normal game move and the history
+				//no longer makes sense. Clear the history for analysis purpose.
+				if (game.get_to_move() != who) 
+					game.anchor_game_history();
                 int move = search->think(who);
-                game.play_move(move);
+                game.play_move(who, move);
 
                 std::string vertex = game.move_to_text(move);
                 gtp_printf(id, "%s", vertex.c_str());
@@ -380,9 +384,13 @@ bool GTP::execute(GameState & game, std::string xinput) {
             {
                 auto search = std::make_unique<UCTSearch>(game);
 
-                game.set_to_move(who);
+				//If played a black after a black, 
+				//this is not a normal game move and the history
+				//no longer makes sense. Clear the history for analysis purpose.
+				if (game.get_to_move() != who)
+					game.anchor_game_history();
                 int move = search->think(who, UCTSearch::NOPASS);
-                game.play_move(move);
+                game.play_move(who, move);
 
                 std::string vertex = game.move_to_text(move);
                 gtp_printf(id, "%s", vertex.c_str());

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -148,8 +148,12 @@ bool GameState::play_textmove(std::string color, std::string vertex) {
 
     int move = board.get_vertex(column, row);
 
-    set_to_move(who);
-    play_move(move);
+	//If played a black after a black, 
+	//this is not a normal game move and the history
+	//no longer makes sense. Clear the history for analysis purpose.
+	if (get_to_move() != who)
+		anchor_game_history();
+    play_move(who, move);
 
     return true;
 }

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -148,11 +148,11 @@ bool GameState::play_textmove(std::string color, std::string vertex) {
 
     int move = board.get_vertex(column, row);
 
-	//If played a black after a black, 
-	//this is not a normal game move and the history
-	//no longer makes sense. Clear the history for analysis purpose.
-	if (get_to_move() != who)
-		anchor_game_history();
+    //If played a black after a black, 
+    //this is not a normal game move and the history
+    //no longer makes sense. Clear the history for analysis purpose.
+    if (get_to_move() != who)
+        anchor_game_history();
     play_move(who, move);
 
     return true;


### PR DESCRIPTION
As @roy7 pointed out in #528 the solution in that pull request is not the final solution.

The reason that Leela zero cannot handle non-alternating moves is because it calls `undo_move` in the code so it will mass up the moving color if the history is not alternating. Later when it restores the state, it will be in a wrong state.

To resolve this issue, there are a couple of ways:

  1. we can make `undo_move` clever enough to do the right thing. But this will require any moves in the history come with its colour, which requires more space.
  2. we can make sure whenever an non-alternating moves played all histories being truncated. So `undo_move` never go beyond the point a non-alternating move being played.

I believe option 2 is better as in practice, we never consider that a (super) ko which jumping into a state beyond the setup point being a forbidden move. So whenever a non-alternating move being played, it is a new starting point of ko state history.

## Other changes


@oni-link pointed out for #535 that the recent change on `FastState::play_pass` function there is a need to adjust the way the hash of the game to be calculated.

As the project uses space rather than tabs for indent, as a result of formatting my own code some other piece of code was also formatted.

## Testing

Start a new game and enter the following commands

```
    genmove b
    genmove b
```

should generate a board with two black moves.
  