### PR TITLE
Fix assert in GameState

### DIFF
--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -336,6 +336,6 @@ void GameState::place_free_handicap(int stones) {
 
 const FullBoard& GameState::get_past_board(int moves_ago) const {
     assert(moves_ago >= 0 && (unsigned)moves_ago <= m_movenum);
-    assert(m_movenum + 1 == game_history.size());
+    assert(m_movenum + 1 <= game_history.size());
     return game_history[m_movenum - moves_ago]->board;
 }


### PR DESCRIPTION
This assert fires when you run these commands:
```
play b q4
undo
genmove b
```

@sethtroisi do you see any other problems? From a quick test seems the rest of the code works.
