### PR TITLE
UCTNode field reorganization to optimize memory layout (attempt 2)

### DIFF
--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -79,16 +79,11 @@ private:
     void link_nodelist(std::atomic<int>& nodecount,
                        std::vector<Network::scored_node>& nodelist,
                        float init_eval);
-
-    // Tree data
-    std::atomic<bool> m_has_children{false};
-    std::vector<node_ptr_t> m_children;
-
     // Move
-    int m_move;
+    int16_t m_move;
     // UCT
+    std::atomic<int16_t> m_virtual_loss{0};
     std::atomic<int> m_visits{0};
-    std::atomic<int> m_virtual_loss{0};
     // UCT eval
     float m_score;
     float m_init_eval;
@@ -99,6 +94,12 @@ private:
     // We don't need to unset this.
     bool m_is_expanding{false};
     SMP::Mutex m_nodemutex;
+
+    // Tree data
+    std::atomic<bool> m_has_children{false};
+    std::vector<node_ptr_t> m_children;
+
+
 };
 
 #endif

--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -79,10 +79,14 @@ private:
     void link_nodelist(std::atomic<int>& nodecount,
                        std::vector<Network::scored_node>& nodelist,
                        float init_eval);
+    // Note : This class is very size-sensitive as we are going to create
+    // tens of millions of instances of these.  Please put extra caution
+    // if you want to add/remove/reorder any variables here.
+
     // Move
-    int16_t m_move;
+    std::int16_t m_move;
     // UCT
-    std::atomic<int16_t> m_virtual_loss{0};
+    std::atomic<std::uint16_t> m_virtual_loss{0};
     std::atomic<int> m_visits{0};
     // UCT eval
     float m_score;
@@ -98,8 +102,6 @@ private:
     // Tree data
     std::atomic<bool> m_has_children{false};
     std::vector<node_ptr_t> m_children;
-
-
 };
 
 #endif


### PR DESCRIPTION
We had the discussion on how to reduce memory footprint and have many good ideas, but this is a simple stopgap change which is better than nothing until we have something better.

(prior discussion : https://github.com/gcp/leela-zero/pull/567)

72 bytes -> 56 bytes, this is 2 cache lines vs. 1 cache line in many CPUs.