### PR TITLE
After search, sync all TTable entries in root node

### DIFF
--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -336,6 +336,6 @@ void GameState::place_free_handicap(int stones) {
 
 const FullBoard& GameState::get_past_board(int moves_ago) const {
     assert(moves_ago >= 0 && (unsigned)moves_ago <= m_movenum);
-    assert(m_movenum + 1 == game_history.size());
+    assert(m_movenum + 1 <= game_history.size());
     return game_history[m_movenum - moves_ago]->board;
 }

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -88,6 +88,7 @@ private:
     std::string get_pv(KoState& state, UCTNode& parent);
     void dump_analysis(int playouts);
     int get_best_move(passflag_t passflag);
+    void ttable_sync_all_children(GameState & currstate, UCTNode* const node);
 
     GameState & m_rootstate;
     UCTNode m_root{FastBoard::PASS, 0.0f, 0.5f};


### PR DESCRIPTION
Because of the interaction of a new search and the TTable, the policy prior can be distorted. If the new search doesn't do any additional searches to a node that is in the TTable, we don't pick up those playouts. I found cases were nodes with as many as 487 playouts in a TTable entry were left out. In another case 87 different moves were left out, although most of them were very low playouts. 

See below a couple examples of the dump_stats output before and after this change. And here is the full [diff.txt](https://github.com/gcp/leela-zero/files/1609157/diff.txt)

This is the most conservative fix for the problem, the search and gameplay is completely unaffected, only the dump_stats output and dump_training output is changed. I spot checked the dump_training output, it looks ok.

I think this sort of interaction between TTable and the search will distort the shape of the search throughout the tree. After the first search in a node, it will suddenly have many playouts for that one node. Q, puct, and U are supposed to control the narrowness of the search in a smooth way but that will be distorted by this. I think most of the problems would go away if we implement a real tree reuse.

There are many moving parts here so it's complicated. @gcp I'm looking for some input on what to do about these issues.


```
rm before1.log; printf "auto\nprintsgf before.sgf\ndump_training b train_before.txt" | ./leelaz -t 1 -p 1600 --noponder -r 1 -n -d -w ~/networks/58da61769a5fb12ff555ee927f16b50d4c24de73a1170a85df1b0d2d706bdef3 -s 3 -l before1.log

rm after1.log; printf "auto\nprintsgf after.sgf\ndump_training b train_after.txt" | ./leelaz -t 1 -p 1600 --noponder -r 1 -n -d -w ~/networks/58da61769a5fb12ff555ee927f16b50d4c24de73a1170a85df1b0d2d706bdef3 -s 3 -l after1.log

diff --side-by-side -W 88 before1.log after1.log

 G10 ->    4847 (V: 45.13%) (N: 21.92%)          G10 ->    4847 (V: 45.13%) (N: 21.92%)
 M12 ->     640 (V: 43.88%) (N:  9.10%)          M12 ->     640 (V: 43.88%) (N:  9.10%)
  R2 ->     632 (V: 44.59%) (N:  2.44%)           R2 ->     632 (V: 44.59%) (N:  2.44%)
                                           >     G11 ->     487 (V: 44.83%) (N:  0.33%)
 H12 ->     196 (V: 43.04%) (N:  4.66%)          H12 ->     196 (V: 43.04%) (N:  4.66%)
 B17 ->     113 (V: 41.31%) (N:  4.66%)          B17 ->     113 (V: 41.31%) (N:  4.66%)
 L12 ->      82 (V: 44.22%) (N:  0.77%)          L12 ->      82 (V: 44.22%) (N:  0.77%)
 H11 ->      80 (V: 43.34%) (N:  1.44%)          H11 ->      80 (V: 43.34%) (N:  1.44%)
 J13 ->      64 (V: 35.93%) (N:  8.23%)          J13 ->      64 (V: 35.93%) (N:  8.23%)
  P8 ->      58 (V: 43.85%) (N:  0.77%)           P8 ->      58 (V: 43.85%) (N:  0.77%)
  S4 ->      56 (V: 44.06%) (N:  0.48%)           S4 ->      56 (V: 44.06%) (N:  0.48%)
  Q2 ->      37 (V: 41.67%) (N:  1.56%)           Q2 ->      37 (V: 41.67%) (N:  1.56%)
 N12 ->      36 (V: 34.05%) (N:  4.63%)          N12 ->      36 (V: 34.05%) (N:  4.63%)
  C5 ->      32 (V: 43.28%) (N:  0.50%)           C5 ->      32 (V: 43.28%) (N:  0.50%)
  B6 ->      31 (V: 41.22%) (N:  1.79%)           B6 ->      31 (V: 41.22%) (N:  1.79%)
 O14 ->      22 (V: 31.27%) (N:  3.47%)          O14 ->      22 (V: 31.27%) (N:  3.47%)
  F2 ->      21 (V: 42.99%) (N:  0.51%)           F2 ->      21 (V: 42.99%) (N:  0.51%)
  B4 ->      20 (V: 41.13%) (N:  1.10%)           B4 ->      20 (V: 41.13%) (N:  1.10%)
  C8 ->      18 (V: 40.48%) (N:  0.92%)           C8 ->      18 (V: 40.48%) (N:  0.92%)
 A13 ->      18 (V: 34.26%) (N:  2.86%)          A13 ->      18 (V: 34.26%) (N:  2.86%)
 M17 ->      17 (V: 36.94%) (N:  1.77%)          M17 ->      17 (V: 36.94%) (N:  1.77%)
  E7 ->      16 (V: 33.01%) (N:  2.80%)           E7 ->      16 (V: 33.01%) (N:  2.80%)
 E14 ->      15 (V: 39.52%) (N:  1.28%)          E14 ->      15 (V: 39.52%) (N:  1.28%)
 N14 ->      14 (V: 38.87%) (N:  1.12%)          N14 ->      14 (V: 38.87%) (N:  1.12%)
  G2 ->      14 (V: 37.33%) (N:  1.63%)           G2 ->      14 (V: 37.33%) (N:  1.63%)
 J12 ->      13 (V: 41.21%) (N:  0.69%)          J12 ->      13 (V: 41.21%) (N:  0.69%)
 K12 ->      13 (V: 40.83%) (N:  0.59%)          K12 ->      13 (V: 40.83%) (N:  0.59%)
 F13 ->      11 (V: 41.41%) (N:  0.47%)          F13 ->      11 (V: 41.41%) (N:  0.47%)
 A18 ->      11 (V: 37.43%) (N:  1.24%)          A18 ->      11 (V: 37.43%) (N:  1.24%)
  E8 ->      10 (V: 38.35%) (N:  0.77%)           E8 ->      10 (V: 38.35%) (N:  0.77%)
 L14 ->      10 (V: 37.06%) (N:  0.77%)          L14 ->      10 (V: 37.06%) (N:  0.77%)
                                           >     H10 ->       9 (V: 41.90%) (N:  0.29%)
  S5 ->       9 (V: 40.11%) (N:  0.44%)           S5 ->       9 (V: 40.11%) (N:  0.44%)
 C13 ->       9 (V: 38.04%) (N:  0.63%)          C13 ->       9 (V: 38.04%) (N:  0.63%)
 M18 ->       4 (V: 38.12%) (N:  0.49%)          M18 ->       4 (V: 38.12%) (N:  0.49%)
 S10 ->       4 (V: 30.80%) (N:  0.97%)          S10 ->       4 (V: 30.80%) (N:  0.97%)
  L4 ->       4 (V: 25.57%) (N:  1.10%)           L4 ->       4 (V: 25.57%) (N:  1.10%)
                                           >     S19 ->       2 (V: 31.00%) (N:  0.29%)
 L19 ->       2 (V: 27.86%) (N:  0.55%)          L19 ->       2 (V: 27.86%) (N:  0.55%)
7685 visits, 364118 nodes, 1600 playouts   |    7685 visits, 364118 nodes, 1600 playouts

  J3 ->    3832 (V: 62.50%) (N: 30.17%)           J3 ->    3832 (V: 62.50%) (N: 30.17%)
  H5 ->      61 (V: 40.80%) (N: 22.36%)           H5 ->      61 (V: 40.80%) (N: 22.36%)
  H6 ->      58 (V: 54.67%) (N:  5.48%)           H6 ->      58 (V: 54.67%) (N:  5.48%)
 R19 ->      19 (V: 48.24%) (N:  5.25%)          R19 ->      19 (V: 48.24%) (N:  5.25%)
 R10 ->      13 (V: 29.14%) (N:  8.44%)          R10 ->      13 (V: 29.14%) (N:  8.44%)
 O18 ->      11 (V: 56.52%) (N:  0.36%)          O18 ->      11 (V: 56.52%) (N:  0.36%)
 O14 ->      11 (V: 51.52%) (N:  1.37%)          O14 ->      11 (V: 51.52%) (N:  1.37%)
  A2 ->      10 (V: 58.88%) (N:  0.28%)           A2 ->      10 (V: 58.88%) (N:  0.28%)
 N15 ->      10 (V: 55.97%) (N:  0.29%)          N15 ->      10 (V: 55.97%) (N:  0.29%)
  P2 ->      10 (V: 55.77%) (N:  0.35%)           P2 ->      10 (V: 55.77%) (N:  0.35%)
 Q11 ->      10 (V: 52.98%) (N:  1.15%)          Q11 ->      10 (V: 52.98%) (N:  1.15%)
 E15 ->       8 (V: 55.92%) (N:  0.46%)          E15 ->       8 (V: 55.92%) (N:  0.46%)
 S17 ->       7 (V: 44.19%) (N:  1.40%)          S17 ->       7 (V: 44.19%) (N:  1.40%)
  Q4 ->       7 (V: 21.37%) (N:  5.59%)           Q4 ->       7 (V: 21.37%) (N:  5.59%)
 J12 ->       6 (V: 57.06%) (N:  0.14%)          J12 ->       6 (V: 57.06%) (N:  0.14%)
  O8 ->       6 (V: 54.86%) (N:  0.18%)           O8 ->       6 (V: 54.86%) (N:  0.18%)
 S19 ->       6 (V: 53.28%) (N:  0.29%)          S19 ->       6 (V: 53.28%) (N:  0.29%)
  F5 ->       6 (V: 46.72%) (N:  0.38%)           F5 ->       6 (V: 46.72%) (N:  0.38%)
  J9 ->       6 (V: 40.00%) (N:  0.46%)           J9 ->       6 (V: 40.00%) (N:  0.46%)
 G11 ->       6 (V: 37.80%) (N:  1.31%)          G11 ->       6 (V: 37.80%) (N:  1.31%)
 G12 ->       6 (V: 34.39%) (N:  0.29%)          G12 ->       6 (V: 34.39%) (N:  0.29%)
  O3 ->       6 (V: 32.99%) (N:  0.30%)           O3 ->       6 (V: 32.99%) (N:  0.30%)
 O19 ->       6 (V: 32.39%) (N:  0.41%)          O19 ->       6 (V: 32.39%) (N:  0.41%)
  G9 ->       6 (V: 29.59%) (N:  0.38%)           G9 ->       6 (V: 29.59%) (N:  0.38%)
  A7 ->       6 (V: 21.19%) (N:  0.79%)           A7 ->       6 (V: 21.19%) (N:  0.79%)
  Q1 ->       5 (V: 56.43%) (N:  0.08%)           Q1 ->       5 (V: 56.43%) (N:  0.08%)
  E8 ->       5 (V: 55.99%) (N:  0.21%)           E8 ->       5 (V: 55.99%) (N:  0.21%)
  D4 ->       5 (V: 33.93%) (N:  0.26%)           D4 ->       5 (V: 33.93%) (N:  0.26%)
  G4 ->       5 (V: 32.36%) (N:  0.25%)           G4 ->       5 (V: 32.36%) (N:  0.25%)
 H19 ->       5 (V: 31.75%) (N:  0.28%)          H19 ->       5 (V: 31.75%) (N:  0.28%)
 F19 ->       5 (V: 30.82%) (N:  0.17%)          F19 ->       5 (V: 30.82%) (N:  0.17%)
 A17 ->       5 (V: 24.96%) (N:  0.24%)          A17 ->       5 (V: 24.96%) (N:  0.24%)
  S2 ->       4 (V: 52.17%) (N:  0.10%)           S2 ->       4 (V: 52.17%) (N:  0.10%)
  B6 ->       4 (V: 47.54%) (N:  0.13%)           B6 ->       4 (V: 47.54%) (N:  0.13%)
  K5 ->       4 (V: 41.32%) (N:  0.13%)           K5 ->       4 (V: 41.32%) (N:  0.13%)
  E5 ->       4 (V: 41.01%) (N:  0.11%)           E5 ->       4 (V: 41.01%) (N:  0.11%)
  F8 ->       4 (V: 39.41%) (N:  0.10%)           F8 ->       4 (V: 39.41%) (N:  0.10%)
 P12 ->       4 (V: 36.16%) (N:  0.16%)          P12 ->       4 (V: 36.16%) (N:  0.16%)
  K2 ->       4 (V: 31.78%) (N:  1.40%)           K2 ->       4 (V: 31.78%) (N:  1.40%)
 B15 ->       4 (V: 31.16%) (N:  0.11%)          B15 ->       4 (V: 31.16%) (N:  0.11%)
 Q12 ->       4 (V: 28.40%) (N:  0.15%)          Q12 ->       4 (V: 28.40%) (N:  0.15%)
 P19 ->       4 (V: 27.65%) (N:  0.14%)          P19 ->       4 (V: 27.65%) (N:  0.14%)
                                           >     O13 ->       3 (V: 51.52%) (N:  0.07%)
                                           >      E2 ->       3 (V: 47.04%) (N:  0.04%)
 T11 ->       3 (V: 45.69%) (N:  0.14%)          T11 ->       3 (V: 45.69%) (N:  0.14%)
  K6 ->       3 (V: 31.19%) (N:  0.57%)           K6 ->       3 (V: 31.19%) (N:  0.57%)
  A5 ->       3 (V: 29.13%) (N:  1.57%)           A5 ->       3 (V: 29.13%) (N:  1.57%)
                                           >      F1 ->       2 (V: 42.83%) (N:  0.03%)
 G13 ->       2 (V: 41.77%) (N:  0.12%)          G13 ->       2 (V: 41.77%) (N:  0.12%)
  Q3 ->       2 (V: 40.68%) (N:  0.58%)           Q3 ->       2 (V: 40.68%) (N:  0.58%)
                                           >     T12 ->       2 (V: 37.46%) (N:  0.02%)
                                           >      S1 ->       2 (V: 37.26%) (N:  0.02%)
  Q7 ->       2 (V: 34.02%) (N:  0.59%)           Q7 ->       2 (V: 34.02%) (N:  0.59%)
  S6 ->       2 (V: 30.63%) (N:  0.13%)           S6 ->       2 (V: 30.63%) (N:  0.13%)
  T9 ->       2 (V: 27.26%) (N:  1.18%)           T9 ->       2 (V: 27.26%) (N:  1.18%)
                                           >     C19 ->       2 (V: 27.12%) (N:  0.07%)
                                           >     D19 ->       2 (V: 25.26%) (N:  0.07%)
  A6 ->       2 (V: 18.16%) (N:  0.26%)           A6 ->       2 (V: 18.16%) (N:  0.26%)
 H11 ->       2 (V: 10.36%) (N:  0.13%)          H11 ->       2 (V: 10.36%) (N:  0.13%)
                                           >     T15 ->       1 (V: 58.10%) (N:  0.03%)
                                           >      L1 ->       1 (V: 56.13%) (N:  0.02%)
                                           >      T4 ->       1 (V: 51.38%) (N:  0.03%)
                                           >      H1 ->       1 (V: 48.50%) (N:  0.05%)
                                           >      A3 ->       1 (V: 48.49%) (N:  0.02%)
<74 move moves in after1.log but not in before 1.log>
4332 visits, 220085 nodes, 1600 playouts        4332 visits, 220085 nodes, 1600 playouts
```