### PR TITLE
simplify FastBoard final_score and general cleanups

### DIFF
--- a/src/FastBoard.cpp
+++ b/src/FastBoard.cpp
@@ -111,15 +111,6 @@ void FastBoard::reset_board(int size) {
     m_dirs[2] = +m_squaresize;
     m_dirs[3] = -1;
 
-    m_extradirs[0] = -m_squaresize-1;
-    m_extradirs[1] = -m_squaresize;
-    m_extradirs[2] = -m_squaresize+1;
-    m_extradirs[3] = -1;
-    m_extradirs[4] = +1;
-    m_extradirs[5] = +m_squaresize-1;
-    m_extradirs[6] = +m_squaresize;
-    m_extradirs[7] = +m_squaresize+1;
-
     for (int i = 0; i < m_maxsq; i++) {
         m_square[i]     = INVAL;
         m_neighbours[i] = 0;
@@ -194,7 +185,7 @@ int FastBoard::count_pliberties(const int i) const {
 // the border of the board has fake neighours of both colors
 int FastBoard::count_neighbours(const int c, const int v) const {
     assert(c == WHITE || c == BLACK || c == EMPTY);
-    return (m_neighbours[v] >> (NBR_SHIFT * c)) & 7;
+    return (m_neighbours[v] >> (NBR_SHIFT * c)) & NBR_MASK;
 }
 
 void FastBoard::add_neighbour(const int vtx, const int color) {
@@ -248,13 +239,15 @@ void FastBoard::remove_neighbour(const int vtx, const int color) {
     }
 }
 
-std::vector<bool> FastBoard::calc_reach_color(int col) const {
+int FastBoard::calc_reach_color(int color) const {
+    auto reachable = 0;
     auto bd = std::vector<bool>(m_maxsq, false);
     auto open = std::queue<int>();
     for (auto i = 0; i < m_boardsize; i++) {
         for (auto j = 0; j < m_boardsize; j++) {
             auto vertex = get_vertex(i, j);
-            if (m_square[vertex] == col) {
+            if (m_square[vertex] == color) {
+                reachable++;
                 bd[vertex] = true;
                 open.push(vertex);
             }
@@ -268,34 +261,20 @@ std::vector<bool> FastBoard::calc_reach_color(int col) const {
         for (auto k = 0; k < 4; k++) {
             auto neighbor = vertex + m_dirs[k];
             if (!bd[neighbor] && m_square[neighbor] == EMPTY) {
+                reachable++;
                 bd[neighbor] = true;
                 open.push(neighbor);
             }
         }
     }
-    return bd;
+    return reachable;
 }
 
 // Needed for scoring passed out games not in MC playouts
 float FastBoard::area_score(float komi) const {
     auto white = calc_reach_color(WHITE);
     auto black = calc_reach_color(BLACK);
-
-    auto score = -komi;
-
-    for (int i = 0; i < m_boardsize; i++) {
-        for (int j = 0; j < m_boardsize; j++) {
-            auto vertex = get_vertex(i, j);
-
-            if (white[vertex] && !black[vertex]) {
-                score -= 1.0f;
-            } else if (black[vertex] && !white[vertex]) {
-                score += 1.0f;
-            }
-        }
-    }
-
-    return score;
+    return black - white - komi;
 }
 
 void FastBoard::display_board(int lastmove) {
@@ -381,9 +360,7 @@ void FastBoard::merge_strings(const int ip, const int aip) {
     } while (newpos != aip);
 
     /* merge stings */
-    int tmp = m_next[aip];
-    m_next[aip] = m_next[ip];
-    m_next[ip] = tmp;
+    std::swap(m_next[aip], m_next[ip]);
 }
 
 bool FastBoard::is_eye(const int color, const int i) const {
@@ -478,9 +455,9 @@ std::string FastBoard::move_to_text_sgf(int move) const {
     } else if (move == FastBoard::PASS) {
         result << "tt";
     } else if (move == FastBoard::RESIGN) {
-	result << "tt";
+        result << "tt";
     } else {
-	result << "error";
+        result << "error";
     }
 
     return result.str();
@@ -539,7 +516,7 @@ void FastBoard::set_to_move(int tomove) {
     m_tomove = tomove;
 }
 
-std::string FastBoard::get_string(int vertex) {
+std::string FastBoard::get_string(int vertex) const {
     std::string result;
 
     int start = m_parent[vertex];
@@ -551,12 +528,12 @@ std::string FastBoard::get_string(int vertex) {
     } while (newpos != start);
 
     // eat last space
-    result.resize(result.size() - 1);
+    if (result.size() > 0) result.resize(result.size() - 1);
 
     return result;
 }
 
-std::string FastBoard::get_stone_list() {
+std::string FastBoard::get_stone_list() const {
     std::string res;
 
     for (int i = 0; i < m_boardsize; i++) {
@@ -570,7 +547,7 @@ std::string FastBoard::get_stone_list() {
     }
 
     // eat final space
-    res.resize(res.size() - 1);
+    if (res.size() > 0) res.resize(res.size() - 1);
 
     return res;
 }

--- a/src/FastBoard.h
+++ b/src/FastBoard.h
@@ -35,6 +35,7 @@ public:
         but a power of 2 makes things a bit faster
     */
     static constexpr int NBR_SHIFT = 4;
+    static constexpr int NBR_MASK = (1 << NBR_SHIFT) - 1;
 
     /*
         largest board supported
@@ -86,7 +87,6 @@ public:
     bool is_eye(const int color, const int vtx) const;
 
     float area_score(float komi) const;
-    std::vector<bool> calc_reach_color(int col) const;
 
     int get_prisoners(int side) const;
     bool black_to_move() const;
@@ -96,8 +96,8 @@ public:
 
     std::string move_to_text(int move) const;
     std::string move_to_text_sgf(int move) const;
-    std::string get_stone_list();
-    std::string get_string(int vertex);
+    std::string get_stone_list() const;
+    std::string get_string(int vertex) const;
 
     void reset_board(int size);
     void display_board(int lastmove = -1);
@@ -119,9 +119,7 @@ protected:
     std::array<unsigned short, MAXSQ+1>    m_stones;      /* stones per string parent */
     std::array<unsigned short, MAXSQ>      m_neighbours;  /* counts of neighboring stones */
     std::array<int, 4>                     m_dirs;        /* movement directions 4 way */
-    std::array<int, 8>                     m_extradirs;   /* movement directions 8 way */
     std::array<int, 2>                     m_prisoners;   /* prisoners per color */
-    std::vector<int>                       m_critical;    /* queue of critical points */
     std::array<unsigned short, MAXSQ>      m_empty;       /* empty squares */
     std::array<unsigned short, MAXSQ>      m_empty_idx;   /* indexes of square */
     int m_empty_cnt;                                      /* count of empties */
@@ -131,6 +129,8 @@ protected:
 
     int m_boardsize;
     int m_squaresize;
+
+    int calc_reach_color(int color) const;
 
     int count_neighbours(const int color, const int i) const;
     void merge_strings(const int ip, const int aip);

--- a/src/FastState.cpp
+++ b/src/FastState.cpp
@@ -162,9 +162,8 @@ std::string FastState::move_to_text(int move) {
     return board.move_to_text(move);
 }
 
-float FastState::final_score() {
-    FastState workstate(*this);
-    return workstate.board.area_score(get_komi() + get_handicap());
+float FastState::final_score() const {
+    return board.area_score(get_komi() + get_handicap());
 }
 
 float FastState::get_komi() const {

--- a/src/FastState.h
+++ b/src/FastState.h
@@ -47,7 +47,7 @@ public:
     void set_passes(int val);
     void increment_passes();
 
-    float final_score();
+    float final_score() const;
 
     size_t get_movenum() const;
     int get_last_move() const;

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -126,10 +126,10 @@ const std::string GTP::s_commands[] = {
     ""
 };
 
-std::string GTP::get_life_list(GameState & game, bool live) {
+std::string GTP::get_life_list(const GameState & game, bool live) {
     std::vector<std::string> stringlist;
     std::string result;
-    FastBoard & board = game.board;
+    const auto& board = game.board;
 
     if (live) {
         for (int i = 0; i < board.get_boardsize(); i++) {

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -54,7 +54,7 @@ public:
 private:
     static constexpr int GTP_VERSION = 2;
 
-    static std::string get_life_list(GameState & game, bool live);
+    static std::string get_life_list(const GameState & game, bool live);
     static const std::string s_commands[];
 };
 


### PR DESCRIPTION
Tested with
`(yes "go" | head -n100 && echo "final_status_list alive" ) | /usr/bin/time -v ./leelaz -t1 -s120 -w ../weights.txt -p 100 --noponder -g`
