### PR TITLE
Removes a rare possible race condition on NNCache

### DIFF
--- a/src/NNCache.h
+++ b/src/NNCache.h
@@ -39,7 +39,7 @@ public:
     void resize(int size);
 
     // Try and find an existing entry.
-    const Network::Netresult* lookup(const Network::NNPlanes& features);
+    bool lookup(const Network::NNPlanes& features, Network::Netresult & result);
 
     // Insert a new entry.
     void insert(const Network::NNPlanes& features,

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -488,8 +488,8 @@ Network::Netresult Network::get_scored_moves(
 
     // See if we already have this in the cache.
     if (!skip_cache) {
-      if (auto r = NNCache::get_NNCache().lookup(planes)) {
-        return *r;
+      if (NNCache::get_NNCache().lookup(planes, result)) {
+        return result;
       }
     }
 


### PR DESCRIPTION
I am not sure if this is a real bug or not, so I am posting a pull request anyway.  Please have a look and close if this seems to be a non-issue.

The concern here is that the prior lookup() does things this way:
1) acquire lock
2) search cache and find entry
3) return method, and release lock
4) create a copy, and return (this happens on Network::get_scored_moves)

If the entry gets deleted on insert() between 3) and 4) we can potentially segfault or have a corrupted table because the pointer is going to be deleted.

This patch tries to plug the hole by copying Netresult inside the lookup() method while holding the lock.