### PR TITLE
Minor fixes for dump_stats and get_pv.

### DIFF
--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -373,7 +373,7 @@ private:
     int m_color;
 };
 
-void UCTNode::sort_root_children(int color) {
+void UCTNode::sort_children(int color) {
     LOCK(get_mutex(), lock);
     std::stable_sort(begin(m_children), end(m_children), NodeComp(color));
     std::reverse(begin(m_children), end(m_children));

--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -70,7 +70,7 @@ public:
     UCTNode* get_nopass_child(FastState& state) const;
     const std::vector<node_ptr_t>& get_children() const;
 
-    void sort_root_children(int color);
+    void sort_children(int color);
     UCTNode& get_best_root_child(int color);
     SMP::Mutex& get_mutex();
 

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -108,7 +108,7 @@ void UCTSearch::dump_stats(KoState & state, UCTNode & parent) {
     const int color = state.get_to_move();
 
     // sort children, put best move on top
-    parent.sort_root_children(color);
+    parent.sort_children(color);
 
 
     if (parent.get_first_child()->first_visit()) {
@@ -117,7 +117,9 @@ void UCTSearch::dump_stats(KoState & state, UCTNode & parent) {
 
     int movecount = 0;
     for (const auto& node : parent.get_children()) {
-        if (!node->get_visits()) break;
+        // Always display at least two moves. In the case there is
+        // only one move searched the user could get an idea why.
+        if (++movecount > 2 && !node->get_visits()) break;
 
         std::string tmp = state.move_to_text(node->get_move());
         std::string pvstring(tmp);
@@ -125,7 +127,7 @@ void UCTSearch::dump_stats(KoState & state, UCTNode & parent) {
         myprintf("%4s -> %7d (V: %5.2f%%) (N: %5.2f%%) PV: ",
             tmp.c_str(),
             node->get_visits(),
-            node->get_visits() > 0 ? node->get_eval(color)*100.0f : 0.0f,
+            node->get_eval(color)*100.0f,
             node->get_score() * 100.0f);
 
         KoState tmpstate = state;
@@ -141,7 +143,7 @@ int UCTSearch::get_best_move(passflag_t passflag) {
     int color = m_rootstate.board.get_to_move();
 
     // Make sure best is first
-    m_root.sort_root_children(color);
+    m_root.sort_children(color);
 
     // Check whether to randomize the best move proportional
     // to the playout counts, early game only.

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -108,7 +108,7 @@ void UCTSearch::dump_stats(KoState & state, UCTNode & parent) {
     const int color = state.get_to_move();
 
     // sort children, put best move on top
-    m_root.sort_root_children(color);
+    parent.sort_root_children(color);
 
 
     if (parent.get_first_child()->first_visit()) {
@@ -117,7 +117,7 @@ void UCTSearch::dump_stats(KoState & state, UCTNode & parent) {
 
     int movecount = 0;
     for (const auto& node : parent.get_children()) {
-        if (++movecount > 2 && !node->get_visits()) break;
+        if (!node->get_visits()) break;
 
         std::string tmp = state.move_to_text(node->get_move());
         std::string pvstring(tmp);
@@ -266,6 +266,9 @@ std::string UCTSearch::get_pv(KoState & state, UCTNode& parent) {
     }
 
     auto& best_child = parent.get_best_root_child(state.get_to_move());
+    if (best_child.first_visit()) {
+        return std::string();
+    }
     auto best_move = best_child.get_move();
     auto res = state.move_to_text(best_move);
 
@@ -391,7 +394,7 @@ int UCTSearch::think(int color, passflag_t passflag) {
 
     Time elapsed;
     int elapsed_centis = Time::timediff_centis(start, elapsed);
-    if (elapsed_centis > 0) {
+    if (elapsed_centis+1 > 0) {
         myprintf("%d visits, %d nodes, %d playouts, %d n/s\n\n",
                  m_root.get_visits(),
                  static_cast<int>(m_nodes),


### PR DESCRIPTION
Three minor fixes, found while testing very low playouts (`-t 1 -p 2 --noponder`).

- The PV was sometimes outputting an extra random move. 
- movecount>2 check causes it to output an extra random move when there is only 1 move searched. I think the !node->get_visits check is sufficient? Or is there some other corner case I didn't consider?
- the elapsed_centis check may not be needed at all, because the code below adds 1 to avoid the possibility of divide by zero. I left it in but changed it to check for it being less than negative one, although that should be impossible. The code as is suppresses the output for the testing I was doing since it ran fast enough to make elapsed_centis=0.

@roy7 this fixes a few issues you mentioned. 
