### PR TITLE
Add new option --visits

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -48,6 +48,7 @@ using namespace Utils;
 bool cfg_allow_pondering;
 int cfg_num_threads;
 int cfg_max_playouts;
+int cfg_max_visits;
 int cfg_lagbuffer_cs;
 int cfg_resignpct;
 int cfg_noise;
@@ -69,6 +70,7 @@ void GTP::setup_default_parameters() {
     cfg_allow_pondering = true;
     cfg_num_threads = std::max(1, std::min(SMP::get_num_cpus(), MAX_CPUS));
     cfg_max_playouts = std::numeric_limits<decltype(cfg_max_playouts)>::max();
+    cfg_max_visits = std::numeric_limits<decltype(cfg_max_visits)>::max();
     cfg_lagbuffer_cs = 100;
 #ifdef USE_OPENCL
     cfg_gpus = { };

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -30,6 +30,7 @@
 extern bool cfg_allow_pondering;
 extern int cfg_num_threads;
 extern int cfg_max_playouts;
+extern int cfg_max_visits;
 extern int cfg_lagbuffer_cs;
 extern int cfg_resignpct;
 extern int cfg_noise;

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -63,8 +63,7 @@ static void parse_commandline(int argc, char *argv[], bool & gtp_mode) {
                        "Weaken engine by limiting the number of playouts. "
                        "Requires --noponder.")
         ("visits,v", po::value<int>(),
-                       "Weaken engine by limiting the number of visits. "
-                       "Requires --noponder.")
+                       "Weaken engine by limiting the number of visits. ")
         ("lagbuffer,b", po::value<int>()->default_value(cfg_lagbuffer_cs),
                         "Safety margin for time usage in centiseconds.")
         ("resignpct,r", po::value<int>()->default_value(cfg_resignpct),
@@ -201,12 +200,6 @@ static void parse_commandline(int argc, char *argv[], bool & gtp_mode) {
 
     if (vm.count("visits")) {
         cfg_max_visits = vm["visits"].as<int>();
-        if (!vm.count("noponder")) {
-            myprintf("Nonsensical options: Visits are restricted but "
-                     "thinking on the opponent's time is still allowed. "
-                     "Add --noponder if you want a weakened engine.\n");
-            exit(EXIT_FAILURE);
-        }
     }
 
     if (vm.count("resignpct")) {

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -62,6 +62,9 @@ static void parse_commandline(int argc, char *argv[], bool & gtp_mode) {
         ("playouts,p", po::value<int>(),
                        "Weaken engine by limiting the number of playouts. "
                        "Requires --noponder.")
+        ("visits,v", po::value<int>(),
+                       "Weaken engine by limiting the number of visits. "
+                       "Requires --noponder.")
         ("lagbuffer,b", po::value<int>()->default_value(cfg_lagbuffer_cs),
                         "Safety margin for time usage in centiseconds.")
         ("resignpct,r", po::value<int>()->default_value(cfg_resignpct),
@@ -190,6 +193,16 @@ static void parse_commandline(int argc, char *argv[], bool & gtp_mode) {
         cfg_max_playouts = vm["playouts"].as<int>();
         if (!vm.count("noponder")) {
             myprintf("Nonsensical options: Playouts are restricted but "
+                     "thinking on the opponent's time is still allowed. "
+                     "Add --noponder if you want a weakened engine.\n");
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    if (vm.count("visits")) {
+        cfg_max_visits = vm["visits"].as<int>();
+        if (!vm.count("noponder")) {
+            myprintf("Nonsensical options: Visits are restricted but "
                      "thinking on the opponent's time is still allowed. "
                      "Add --noponder if you want a weakened engine.\n");
             exit(EXIT_FAILURE);

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -117,7 +117,7 @@ void UCTSearch::dump_stats(KoState & state, UCTNode & parent) {
 
     int movecount = 0;
     for (const auto& node : parent.get_children()) {
-        if (++movecount > 2 && !node->get_visits()) break;
+        if (!node->get_visits()) break;
 
         std::string tmp = state.move_to_text(node->get_move());
         std::string pvstring(tmp);
@@ -266,6 +266,9 @@ std::string UCTSearch::get_pv(KoState & state, UCTNode& parent) {
     }
 
     auto& best_child = parent.get_best_root_child(state.get_to_move());
+    if (best_child.first_visit()) {
+        return std::string();
+    }
     auto best_move = best_child.get_move();
     auto res = state.move_to_text(best_move);
 
@@ -391,7 +394,7 @@ int UCTSearch::think(int color, passflag_t passflag) {
 
     Time elapsed;
     int elapsed_centis = Time::timediff_centis(start, elapsed);
-    if (elapsed_centis > 0) {
+    if (elapsed_centis+1 > 0) {
         myprintf("%d visits, %d nodes, %d playouts, %d n/s\n\n",
                  m_root.get_visits(),
                  static_cast<int>(m_nodes),

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -118,7 +118,7 @@ void UCTSearch::dump_stats(KoState & state, UCTNode & parent) {
 
     int movecount = 0;
     for (const auto& node : parent.get_children()) {
-        if (!node->get_visits()) break;
+        if (++movecount > 2 && !node->get_visits()) break;
 
         std::string tmp = state.move_to_text(node->get_move());
         std::string pvstring(tmp);
@@ -267,9 +267,6 @@ std::string UCTSearch::get_pv(KoState & state, UCTNode& parent) {
     }
 
     auto& best_child = parent.get_best_root_child(state.get_to_move());
-    if (best_child.first_visit()) {
-        return std::string();
-    }
     auto best_move = best_child.get_move();
     auto res = state.move_to_text(best_move);
 
@@ -395,7 +392,7 @@ int UCTSearch::think(int color, passflag_t passflag) {
 
     Time elapsed;
     int elapsed_centis = Time::timediff_centis(start, elapsed);
-    if (elapsed_centis+1 > 0) {
+    if (elapsed_centis > 0) {
         myprintf("%d visits, %d nodes, %d playouts, %d n/s\n\n",
                  m_root.get_visits(),
                  static_cast<int>(m_nodes),

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -98,7 +98,6 @@ private:
     std::atomic<bool> m_run{false};
     int m_maxplayouts;
     int m_maxvisits;
-    int m_initial_sum_child_visits;
 };
 
 class UCTWorker {

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -77,9 +77,10 @@ public:
     UCTSearch(GameState& g);
     int think(int color, passflag_t passflag = NORMAL);
     void set_playout_limit(int playouts);
+    void set_visit_limit(int visits);
     void ponder();
     bool is_running() const;
-    bool playout_limit_reached() const;
+    bool playout_or_visit_limit_reached() const;
     void increment_playouts();
     SearchResult play_simulation(GameState& currstate, UCTNode* const node);
 
@@ -88,6 +89,7 @@ private:
     std::string get_pv(KoState& state, UCTNode& parent);
     void dump_analysis(int playouts);
     int get_best_move(passflag_t passflag);
+    void ttable_sync_all_children(GameState & currstate, UCTNode* const node);
 
     GameState & m_rootstate;
     UCTNode m_root{FastBoard::PASS, 0.0f, 0.5f};
@@ -95,6 +97,8 @@ private:
     std::atomic<int> m_playouts{0};
     std::atomic<bool> m_run{false};
     int m_maxplayouts;
+    int m_maxvisits;
+    int m_initial_sum_child_visits;
 };
 
 class UCTWorker {


### PR DESCRIPTION
When this option is used, include past search results and stop the search when the sum of the children's visits reaches --visits.

I'm re-running the tournament to ensure we still get an Elo improvement on same CPU usage. 

I made it so ttable_sync_all_children is only called when the --visits argument is used. This way the behavior when using --playouts doesn't change. I also verified the code in Training::record that does sum_visits always gets exactly --visits.

