### PR TITLE
Fix Random::seedrandom to initilize xoroshiro128+ prng properly

### DIFF
--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -26,6 +26,13 @@
 #include "GTP.h"
 #include "Utils.h"
 
+static std::uint64_t splitmix64(std::uint64_t z) {
+    z += 0x9e3779b97f4a7c15;
+    z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9;
+    z = (z ^ (z >> 27)) * 0x94d049bb133111eb;
+    return z ^ (z >> 31);
+}
+
 Random& Random::get_Rng(void) {
     static thread_local Random s_rng{0};
     return s_rng;
@@ -69,11 +76,12 @@ std::uint32_t Random::randuint32() {
 }
 
 void Random::seedrandom(std::uint64_t seed) {
-    // Magic values from Pierre L'Ecuyer,
-    // "Tables of Linear Congruental Generators of different sizes and
-    // good lattice structure"
-    m_s[0] = (1181783497276652981ULL * seed);
-    m_s[1] = (1181783497276652981ULL * m_s[0]);
+
+    // Initialize state of xoroshiro128+ by transform the seed
+    // with splitmix64 algorithm.
+    // As suggested by http://xoroshiro.di.unimi.it/xoroshiro128plus.c
+    m_s[0] = splitmix64(seed);
+    m_s[1] = splitmix64(m_s[0]);
 }
 
 float Random::randflt(void) {


### PR DESCRIPTION
Fix for #592. Throgh it's very unlikely to happen, in a probability of around 1/2^64.