### PR TITLE
new resign logic for handicap threshold

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -77,6 +77,7 @@ void GTP::setup_default_parameters() {
 #endif
     cfg_puct = 0.85f;
     cfg_softmax_temp = 1.0f;
+    // Keep in sync with UCTSearch::should_resign
     cfg_resignpct = 10;
     cfg_noise = false;
     cfg_random_cnt = 0;

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -77,8 +77,8 @@ void GTP::setup_default_parameters() {
 #endif
     cfg_puct = 0.85f;
     cfg_softmax_temp = 1.0f;
-    // Keep in sync with UCTSearch::should_resign
-    cfg_resignpct = 10;
+    // see UCTSearch::should_resign
+    cfg_resignpct = -1;
     cfg_noise = false;
     cfg_random_cnt = 0;
     cfg_dumbpass = false;

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -250,12 +250,13 @@ int UCTSearch::get_best_move(passflag_t passflag) {
                                  * m_rootstate.board.get_boardsize();
             auto move_threshold = board_squares / 4;
             auto resign_threshold = 0.01 * cfg_resignpct;
+            // TODO add something to disable if -r is user set.
             if (m_rootstate.get_handicap() > 0) {
                 auto handicap_resign_threshold =
-                    resign_threshold / std::sqrt(1 + m_rootstate.get_handicap());
-                // blend the thresholds for the first ~180 moves.
+                    resign_threshold / (1 + m_rootstate.get_handicap());
+                // blend the thresholds for the first ~215 moves.
                 auto blend_ratio = std::max(1.0, m_rootstate.get_movenum() /
-                                                 (0.5 * board_squares));
+                                                 (0.6 * board_squares));
                 resign_threshold = handicap_resign_threshold +
                     blend_ratio * (resign_threshold - handicap_resign_threshold);
             }

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -87,7 +87,7 @@ private:
     void dump_stats(KoState& state, UCTNode& parent);
     std::string get_pv(KoState& state, UCTNode& parent);
     void dump_analysis(int playouts);
-    bool should_resign(passflag_t passflag);
+    bool should_resign(passflag_t passflag, float bestscore);
     int get_best_move(passflag_t passflag);
 
     GameState & m_rootstate;

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -87,6 +87,7 @@ private:
     void dump_stats(KoState& state, UCTNode& parent);
     std::string get_pv(KoState& state, UCTNode& parent);
     void dump_analysis(int playouts);
+    bool should_resign(passflag_t passflag);
     int get_best_move(passflag_t passflag);
 
     GameState & m_rootstate;


### PR DESCRIPTION
New resign logic discussed in https://github.com/gcp/leela-zero/issues/622

Leelaz doesn't resign before move 90 (92?).
For games with handicap reduce handicap rate even more for moves 90 to ~215.

[Old graph of resign pct vs move number](
https://docs.google.com/spreadsheets/d/1AIGYObGCGWadcdWwN1ceMuPd_qu1hyQd2tD8QzSsGV8/edit#gid=1843999952)