### PR TITLE
Fixes to m_hash and m_ko_hash.

### DIFF
--- a/src/FastState.cpp
+++ b/src/FastState.cpp
@@ -34,7 +34,7 @@ void FastState::init_game(int size, float komi) {
 
     m_movenum = 0;
 
-    m_komove = 0;
+    m_komove = FastBoard::PASS;
     m_lastmove = 0;
     m_komi = komi;
     m_handicap = 0;
@@ -53,7 +53,7 @@ void FastState::reset_game(void) {
     m_movenum = 0;
     m_passes = 0;
     m_handicap = 0;
-    m_komove = 0;
+    m_komove = FastBoard::PASS;
     m_lastmove = 0;
 }
 
@@ -74,6 +74,10 @@ void FastState::play_pass(int color) {
 
     m_lastmove = FastBoard::PASS;
 
+    board.m_hash ^= Zobrist::zobrist_ko[m_komove];
+    m_komove = FastBoard::PASS;
+    board.m_hash ^= Zobrist::zobrist_ko[m_komove];
+
     if (board.m_tomove == color) {
         board.m_hash ^= 0xABCDABCDABCDABCDULL;
     }
@@ -90,9 +94,16 @@ void FastState::play_move(int vertex) {
 
 void FastState::play_move(int color, int vertex) {
     if (vertex != FastBoard::PASS) {
+        board.m_hash ^= Zobrist::zobrist_ko[m_komove];
         int kosq = board.update_board(color, vertex);
+        if ( board.get_square(kosq) == FastBoard::EMPTY &&
+            !board.is_suicide(kosq, !color)) {
+            m_komove = kosq;
+        } else {
+            m_komove = FastBoard::PASS;
+        }
+        board.m_hash ^= Zobrist::zobrist_ko[m_komove];
 
-        m_komove = kosq;
         m_lastmove = vertex;
         m_movenum++;
 

--- a/src/FastState.cpp
+++ b/src/FastState.cpp
@@ -95,13 +95,7 @@ void FastState::play_move(int vertex) {
 void FastState::play_move(int color, int vertex) {
     if (vertex != FastBoard::PASS) {
         board.m_hash ^= Zobrist::zobrist_ko[m_komove];
-        int kosq = board.update_board(color, vertex);
-        if ( board.get_square(kosq) == FastBoard::EMPTY &&
-            !board.is_suicide(kosq, !color)) {
-            m_komove = kosq;
-        } else {
-            m_komove = FastBoard::PASS;
-        }
+        m_komove = board.update_board(color, vertex);
         board.m_hash ^= Zobrist::zobrist_ko[m_komove];
 
         m_lastmove = vertex;

--- a/src/FastState.cpp
+++ b/src/FastState.cpp
@@ -148,7 +148,7 @@ int FastState::get_to_move() const {
 }
 
 void FastState::set_to_move(int tom) {
-    board.m_tomove = tom;
+    board.set_to_move(tom);
 }
 
 void FastState::display_state() {

--- a/src/FullBoard.cpp
+++ b/src/FullBoard.cpp
@@ -84,7 +84,7 @@ std::uint64_t FullBoard::calc_hash(int komove) {
     res ^= Zobrist::zobrist_pris[1][m_prisoners[1]];
 
     if (m_tomove == BLACK) {
-        res ^= 0xABCDABCDABCDABCDULL;
+        res ^= Zobrist::zobrist_blacktomove;
     }
 
     m_hash ^= Zobrist::zobrist_ko[komove];
@@ -100,6 +100,13 @@ std::uint64_t FullBoard::get_hash(void) const {
 
 std::uint64_t FullBoard::get_ko_hash(void) const {
     return m_ko_hash;
+}
+
+void FullBoard::set_to_move(int tomove) {
+    if (m_tomove != tomove) {
+        m_hash ^= Zobrist::zobrist_blacktomove;
+    }
+    FastBoard::set_to_move(tomove);
 }
 
 int FullBoard::update_board(const int color, const int i) {

--- a/src/FullBoard.cpp
+++ b/src/FullBoard.cpp
@@ -70,7 +70,7 @@ std::uint64_t FullBoard::calc_ko_hash(void) {
     return res;
 }
 
-std::uint64_t FullBoard::calc_hash(void) {
+std::uint64_t FullBoard::calc_hash(int komove) {
     auto res = std::uint64_t{0x1234567887654321ULL};
 
     for (int i = 0; i < m_maxsq; i++) {
@@ -86,6 +86,8 @@ std::uint64_t FullBoard::calc_hash(void) {
     if (m_tomove == BLACK) {
         res ^= 0xABCDABCDABCDABCDULL;
     }
+
+    m_hash ^= Zobrist::zobrist_ko[komove];
 
     m_hash = res;
 
@@ -179,6 +181,6 @@ void FullBoard::display_board(int lastmove) {
 void FullBoard::reset_board(int size) {
     FastBoard::reset_board(size);
 
-    calc_hash();
+    calc_hash(FastBoard::PASS);
     calc_ko_hash();
 }

--- a/src/FullBoard.cpp
+++ b/src/FullBoard.cpp
@@ -173,10 +173,12 @@ int FullBoard::update_board(const int color, const int i) {
 
     /* check for possible simple ko */
     if (captured_stones == 1 && eyeplay) {
+        assert (get_square(captured_sq) == FastBoard::EMPTY &&
+            !is_suicide(captured_sq, !color));
         return captured_sq;
     }
 
-    return -1;
+    return FastBoard::PASS;
 }
 
 void FullBoard::display_board(int lastmove) {
@@ -188,6 +190,6 @@ void FullBoard::display_board(int lastmove) {
 void FullBoard::reset_board(int size) {
     FastBoard::reset_board(size);
 
-    calc_hash(FastBoard::PASS);
+    calc_hash();
     calc_ko_hash();
 }

--- a/src/FullBoard.h
+++ b/src/FullBoard.h
@@ -28,7 +28,7 @@ public:
     int remove_string(int i);
     int update_board(const int color, const int i);
 
-    std::uint64_t calc_hash(void);
+    std::uint64_t calc_hash(int komove);
     std::uint64_t calc_ko_hash(void);
     std::uint64_t get_hash(void) const;
     std::uint64_t get_ko_hash(void) const;

--- a/src/FullBoard.h
+++ b/src/FullBoard.h
@@ -28,7 +28,7 @@ public:
     int remove_string(int i);
     int update_board(const int color, const int i);
 
-    std::uint64_t calc_hash(int komove);
+    std::uint64_t calc_hash(int komove = FastBoard::PASS);
     std::uint64_t calc_ko_hash(void);
     std::uint64_t get_hash(void) const;
     std::uint64_t get_ko_hash(void) const;

--- a/src/FullBoard.h
+++ b/src/FullBoard.h
@@ -32,6 +32,7 @@ public:
     std::uint64_t calc_ko_hash(void);
     std::uint64_t get_hash(void) const;
     std::uint64_t get_ko_hash(void) const;
+    void set_to_move(int tomove);
 
     void reset_board(int size);
     void display_board(int lastmove = -1);

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -201,7 +201,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
         return true;
     } else if (input == "exit") {
         exit(EXIT_SUCCESS);
-    } else if (input == "#") {
+    } else if (input.find("#") == 0) {
         return true;
     } else if (std::isdigit(input[0])) {
         std::istringstream strm(input);

--- a/src/Zobrist.cpp
+++ b/src/Zobrist.cpp
@@ -21,6 +21,7 @@
 #include "Random.h"
 
 std::array<std::array<std::uint64_t, FastBoard::MAXSQ>,     4> Zobrist::zobrist;
+std::array<std::uint64_t, FastBoard::MAXSQ>                    Zobrist::zobrist_ko;
 std::array<std::array<std::uint64_t, FastBoard::MAXSQ * 2>, 2> Zobrist::zobrist_pris;
 std::array<std::uint64_t, 5>                                   Zobrist::zobrist_pass;
 
@@ -30,6 +31,11 @@ void Zobrist::init_zobrist(Random& rng) {
             Zobrist::zobrist[i][j]  = ((std::uint64_t)rng.randuint32()) << 32;
             Zobrist::zobrist[i][j] ^= (std::uint64_t)rng.randuint32();
         }
+    }
+
+    for (int j = 0; j < FastBoard::MAXSQ; j++) {
+        Zobrist::zobrist_ko[j]  = ((std::uint64_t)rng.randuint32()) << 32;
+        Zobrist::zobrist_ko[j] ^= (std::uint64_t)rng.randuint32();
     }
 
     for (int i = 0; i < 2; i++) {

--- a/src/Zobrist.h
+++ b/src/Zobrist.h
@@ -29,6 +29,7 @@
 class Zobrist {
 public:
     static std::array<std::array<std::uint64_t, FastBoard::MAXSQ>,     4> zobrist;
+    static std::array<std::uint64_t, FastBoard::MAXSQ>                    zobrist_ko;
     static std::array<std::array<std::uint64_t, FastBoard::MAXSQ * 2>, 2> zobrist_pris;
     static std::array<std::uint64_t, 5>                                   zobrist_pass;
 

--- a/src/Zobrist.h
+++ b/src/Zobrist.h
@@ -32,6 +32,7 @@ public:
     static std::array<std::uint64_t, FastBoard::MAXSQ>                    zobrist_ko;
     static std::array<std::array<std::uint64_t, FastBoard::MAXSQ * 2>, 2> zobrist_pris;
     static std::array<std::uint64_t, 5>                                   zobrist_pass;
+    static const auto zobrist_blacktomove = 0xABCDABCDABCDABCDULL;
 
     static void init_zobrist(Random& rng);
 };


### PR DESCRIPTION
Fixes issue #576.

Definition of m_komove changed slightly to be only set to the vertex if that vertex is actually a ko. That part used to be lazy calculated in is_move_legal. I think that extra code could be removed now from is_move_legal but I need to check weird cases like same color gets to genmove commands. Maybe we don't care about that.

Reproduce bug:
`rm master.log; cat testgtp.txt | $lzmaster -w latest.txt -p 10 --noponder -l master.log
`
Verify fix:
`rm test.log; cat testgtp.txt | ./leelaz -w latest.txt -p 10 --noponder -l test.log
`

[testgtp.txt](https://github.com/gcp/leela-zero/files/1629027/testgtp.txt)
[master.log](https://github.com/gcp/leela-zero/files/1629028/master.log)
[test.log](https://github.com/gcp/leela-zero/files/1629029/test.log)

I will to add a few more tests with undos and passes later.

Note different hashes based on ko status. Also note Ko-Hash is purely positional, so these positions have the same Ko-Hash. Superkos will be detected by going through the stack of them. 
```
   a b c d e f g h j k l m n o p q r s t
19 . . . . . . . . . . . . . . . . . . . 19
18 . . . . . . . . . . . . . . . . . . . 18
17 . . . . . . . . . . . . . . . . . . . 17
16 . . . + . . . . . + . . . . . + . . . 16
15 . . . . . . . . . . . . . . . . . . . 15
14 . . . . . . . . . . . . . . . . . . . 14
13 . . . . . . . . . . . . . . . . . . . 13
12 . . . . . . . . . . . . . . . . . . . 12
11 . . . . . . . . . . . . . . . . . . . 11
10 . . . + . . . . . + . . . . . + . . . 10
 9 . . . . . . . . . . . . . . . . . . .  9
 8 . . . . . . . . . . . . . . . . . . .  8
 7 . . . . . . . . . . . . . . . . . . .  7
 6 . . . . X O . . . . . . . . . . . . .  6
 5 . . . . X O . . . . . . . . . . . . .  5
 4 . . . X(O). O . . + . . . . . + . . .  4
 3 . . . . X O . . . . . . . . . . . . .  3
 2 . . . . . . . . . . . . . . . . . . .  2
 1 . . . . . . . . . . . . . . . . . . .  1
   a b c d e f g h j k l m n o p q r s t

Hash: 58C219E7A22CBE0D Ko-Hash: CF5EC0B8BB82BF52

   a b c d e f g h j k l m n o p q r s t
19 . . . . . . . . . . . . . . . . . . . 19
18 . . . . . . . . . . . . . . . . . . . 18
17 . . . . . . . . . . . . . . . . . . . 17
16 . . . + . . . . . + . . . . . + . . . 16
15 . . . . . . . . . . . . . . . . . . . 15
14 . . . . . . . . . . . . . . . . . . . 14
13 . . . . . . . . . . . . . . . . . . . 13
12 . . . . . . . . . . . . . . . . . . . 12
11 . . . . . . . . . . . . . . . . . . . 11
10 . . . + . . . . . + . . . . . + . . . 10
 9 . . . . . . . . . . . . . . . . . . .  9
 8 . . . . . . . . . . . . . . . . . . .  8
 7 . . . . . . . . . . . . . . . . . . .  7
 6 . . . . X(O). . . . . . . . . . . . .  6
 5 . . . . X O . . . . . . . . . . . . .  5
 4 . . . X O . O . . + . . . . . + . . .  4
 3 . . . . X O . . . . . . . . . . . . .  3
 2 . . . . . . . . . . . . . . . . . . .  2
 1 . . . . . . . . . . . . . . . . . . .  1
   a b c d e f g h j k l m n o p q r s t

Hash: 38EAE2514E7FA02E Ko-Hash: CF5EC0B8BB82BF52
```

This example shows why the zobrish hash isn't a simple "ko last turn" but specifies which intersection the ko is on. It matters which ko is active.
```
   a b c d e f g h j k l m n o p q r s t
19 O X . . . . . . . . . . . . . . . . . 19
18 . . . . . . . . . . . . . . . . . . . 18
17 . . . . . . . . . . . . . . . . . . . 17
16 . . . + . . . . . + . . . . . + . . . 16
15 . . . . . . . . . . . . . . . . . . . 15
14 . . . . . . . . . . . . . . . . . . . 14
13 . . . . . . . . . . . . . . . . . . . 13
12 . . . . . . . . . . . . . . . . . . . 12
11 . . . . . . . . . . . . . . . . . . . 11
10 . . . + . . . . . + . . . . . + . . . 10
 9 . . . . . . . . . . . . . . . . . . .  9
 8 . . . . . . . . . . . . . . . . . . .  8
 7 . . . . . . . . . . . . . . . . . . .  7
 6 . . . . . . . . . . . . . . . . . . .  6
 5 . . X . . . . . . . . . . . . . X . .  5
 4 . X(O)X . . . . . + . . . . . X O X .  4
 3 . O . O . . . . . . . . . . . O . O .  3
 2 . . O . . . . . . . . . . . . . O . .  2
 1 . . . . . . . . . . . . . . . . . . .  1
   a b c d e f g h j k l m n o p q r s t

Hash: 5BF1BD611EA9A560 Ko-Hash: 5DEAB48D9EB780B7

   a b c d e f g h j k l m n o p q r s t
19 O X . . . . . . . . . . . . . . . . . 19
18 . . . . . . . . . . . . . . . . . . . 18
17 . . . . . . . . . . . . . . . . . . . 17
16 . . . + . . . . . + . . . . . + . . . 16
15 . . . . . . . . . . . . . . . . . . . 15
14 . . . . . . . . . . . . . . . . . . . 14
13 . . . . . . . . . . . . . . . . . . . 13
12 . . . . . . . . . . . . . . . . . . . 12
11 . . . . . . . . . . . . . . . . . . . 11
10 . . . + . . . . . + . . . . . + . . . 10
 9 . . . . . . . . . . . . . . . . . . .  9
 8 . . . . . . . . . . . . . . . . . . .  8
 7 . . . . . . . . . . . . . . . . . . .  7
 6 . . . . . . . . . . . . . . . . . . .  6
 5 . . X . . . . . . . . . . . . . X . .  5
 4 . X O X . . . . . + . . . . . X(O)X .  4
 3 . O . O . . . . . . . . . . . O . O .  3
 2 . . O . . . . . . . . . . . . . O . .  2
 1 . . . . . . . . . . . . . . . . . . .  1
   a b c d e f g h j k l m n o p q r s t

Hash: F43208F94077881F Ko-Hash: 5DEAB48D9EB780B7

```