### PR TITLE
replaced #include <lib.h> with equivilant <clib>

### DIFF
--- a/src/FastBoard.cpp
+++ b/src/FastBoard.cpp
@@ -18,7 +18,7 @@
 
 #include "FastBoard.h"
 
-#include <assert.h>
+#include <cassert>
 #include <array>
 #include <iostream>
 #include <queue>

--- a/src/FastState.h
+++ b/src/FastState.h
@@ -19,7 +19,7 @@
 #ifndef FASTSTATE_H_INCLUDED
 #define FASTSTATE_H_INCLUDED
 
-#include <stddef.h>
+#include <cstddef>
 #include <array>
 #include <string>
 #include <vector>

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -21,7 +21,7 @@
 
 #include "config.h"
 
-#include <stdio.h>
+#include <cstdio>
 #include <string>
 #include <vector>
 

--- a/src/KoState.cpp
+++ b/src/KoState.cpp
@@ -19,7 +19,7 @@
 #include "config.h"
 #include "KoState.h"
 
-#include <assert.h>
+#include <cassert>
 #include <algorithm>
 #include <iterator>
 

--- a/src/OpenCL.cpp
+++ b/src/OpenCL.cpp
@@ -21,7 +21,7 @@
 #ifdef USE_OPENCL
 #include "OpenCL.h"
 
-#include <assert.h>
+#include <cassert>
 #include <algorithm>
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>

--- a/src/OpenCL.h
+++ b/src/OpenCL.h
@@ -25,7 +25,7 @@
 #define CL_HPP_TARGET_OPENCL_VERSION    120
 #define CL_HPP_ENABLE_EXCEPTIONS
 #include <CL/cl2.hpp>
-#include <stddef.h>
+#include <cstddef>
 #include <memory>
 #include <string>
 #include <vector>

--- a/src/SGFParser.h
+++ b/src/SGFParser.h
@@ -19,8 +19,8 @@
 #ifndef SGFPARSER_H_INCLUDED
 #define SGFPARSER_H_INCLUDED
 
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 #include <climits>
 #include <sstream>
 #include <string>

--- a/src/SGFTree.cpp
+++ b/src/SGFTree.cpp
@@ -19,7 +19,7 @@
 #include "config.h"
 #include "SGFTree.h"
 
-#include <assert.h>
+#include <cassert>
 #include <boost/format.hpp>
 #include <boost/algorithm/string.hpp>
 #include <ctime>

--- a/src/SGFTree.h
+++ b/src/SGFTree.h
@@ -19,7 +19,7 @@
 #ifndef SGFTREE_H_INCLUDED
 #define SGFTREE_H_INCLUDED
 
-#include <stddef.h>
+#include <cstddef>
 #include <map>
 #include <sstream>
 #include <string>

--- a/src/Training.h
+++ b/src/Training.h
@@ -21,7 +21,7 @@
 
 #include "config.h"
 
-#include <stddef.h>
+#include <cstddef>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -18,8 +18,8 @@
 
 #include "config.h"
 
-#include <assert.h>
-#include <stdio.h>
+#include <cassert>
+#include <cstdio>
 #include <cstdint>
 #include <algorithm>
 #include <cmath>

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -19,8 +19,8 @@
 #include "config.h"
 #include "UCTSearch.h"
 
-#include <assert.h>
-#include <stddef.h>
+#include <cassert>
+#include <cstddef>
 #include <limits>
 #include <memory>
 #include <type_traits>

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -20,8 +20,8 @@
 #include "Utils.h"
 
 #include <mutex>
-#include <stdarg.h>
-#include <stdio.h>
+#include <cstdarg>
+#include <cstdio>
 
 #ifdef _WIN32
 #include <windows.h>


### PR DESCRIPTION
`grep -rh '^#include <c[a-z]*>' *.cpp *.h | sed -e 's/.*<c//' -e s'/.$//' | sort -u | xargs -I{} sh -c 'echo "$(grep -riho "include <c{}>" *.cpp *.h | wc -w) c{} vs $(grep -riho "include <{}.h>" *.cpp *.h | wc -w) {}.h"' | sort -rn`

14 cassert vs 12 assert.h
12 cstdint vs 2 stdint.h
6 cstdlib vs 0 stdlib.h
6 cmath vs 0 math.h
6 chrono vs 0 hrono.h
6 cctype vs 0 ctype.h
4 cstdio vs 6 stdio.h
4 climits vs 0 limits.h
2 ctime vs 0 time.h
2 cstddef vs 12 stddef.h

afterwards I found one extra instance (of stdarg.h) with
`grep -rh '^#include .*\.h>' *.cpp *.h`

If you prefer the .h version I can convert all existing <cLIB> version to <LIB.h> I just prefer consistence 