### PR TITLE
net2net

### DIFF
--- a/src/FastBoard.cpp
+++ b/src/FastBoard.cpp
@@ -281,14 +281,7 @@ void FastBoard::display_board(int lastmove) {
     int boardsize = get_boardsize();
 
     myprintf("\n   ");
-    for (int i = 0; i < boardsize; i++) {
-        if (i < 25) {
-            myprintf("%c ", (('a' + i < 'i') ? 'a' + i : 'a' + i + 1));
-        } else {
-            myprintf("%c ", (('A' + (i-25) < 'I') ? 'A' + (i-25) : 'A' + (i-25) + 1));
-        }
-    }
-    myprintf("\n");
+    print_columns();
     for (int j = boardsize-1; j >= 0; j--) {
         myprintf("%2d", j+1);
         if (lastmove == get_vertex(0, j))
@@ -312,14 +305,20 @@ void FastBoard::display_board(int lastmove) {
         myprintf("%2d\n", j+1);
     }
     myprintf("   ");
-    for (int i = 0; i < boardsize; i++) {
-         if (i < 25) {
+    print_columns();
+    myprintf("\n");
+}
+
+void FastBoard::print_columns() {
+    for (int i = 0; i < get_boardsize(); i++) {
+        if (i < 25) {
             myprintf("%c ", (('a' + i < 'i') ? 'a' + i : 'a' + i + 1));
-        } else {
-            myprintf("%c ", (('A' + (i-25) < 'I') ? 'A' + (i-25) : 'A' + (i-25) + 1));
+        }
+        else {
+            myprintf("%c ", (('A' + (i - 25) < 'I') ? 'A' + (i - 25) : 'A' + (i - 25) + 1));
         }
     }
-    myprintf("\n\n");
+    myprintf("\n");
 }
 
 void FastBoard::merge_strings(const int ip, const int aip) {

--- a/src/FastBoard.h
+++ b/src/FastBoard.h
@@ -136,6 +136,7 @@ protected:
     void merge_strings(const int ip, const int aip);
     void add_neighbour(const int i, const int color);
     void remove_neighbour(const int i, const int color);
+    void print_columns();
 };
 
 #endif

--- a/training/tf/net2net.py
+++ b/training/tf/net2net.py
@@ -1,4 +1,21 @@
 #!/usr/bin/env python3
+#
+#    This file is part of Leela Zero.
+#    Copyright (C) 2017 Henrik Forsten
+#
+#    Leela Zero is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Leela Zero is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with Leela Zero.  If not, see <http://www.gnu.org/licenses/>.
+
 import argparse
 import os
 import numpy as np

--- a/training/tf/net2net.py
+++ b/training/tf/net2net.py
@@ -124,7 +124,7 @@ if __name__ == "__main__":
     parser.add_argument("blocks", help="Residual blocks to add", type=int)
     parser.add_argument("filters", help="Filters to add", type=int)
     parser.add_argument("network", help="Input network", type=str)
-    parser.add_argument("--noise", nargs='?', help="Standard deviation of noise to add to new filters/blocks. Default: 1e-5", default=1e-5, type=float)
+    parser.add_argument("--noise", nargs='?', help="Standard deviation of noise to add to new filters/blocks. Default: 5e-3", default=5e-3, type=float)
     parser.add_argument("--verify", help="Verify that output matches", default=False, action='store_true')
 
     args = parser.parse_args()

--- a/training/tf/net2net.py
+++ b/training/tf/net2net.py
@@ -66,7 +66,7 @@ def conv_bn_wider(weights, next_weights, inputs, channels,
 
         for i in range(len(rand)):
             noise = 0
-            if i > channels:
+            if i >= channels:
                 noise = np.random.normal(0, noise_std)
             next_weights_new[j][:, i, :, :] *= (1.0 + noise)/rep_factor[rand[i]]
 

--- a/training/tf/net2net.py
+++ b/training/tf/net2net.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import numpy as np
+import scipy.signal as signal
+from copy import deepcopy
+
+def convolve(w, x):
+    x_ch, x_w, x_h = x.shape
+    outputs, inputs, _, __ = w.shape
+    assert x_ch == inputs
+    res = np.zeros((outputs, x_w, x_h))
+    for o in range(outputs):
+        for c in range(inputs):
+            res[o,:,:] += signal.correlate2d(x[c,:,:], w[o,c,:,:], mode='same')
+    return res
+
+def read_net(filename):
+    with open(filename, 'r') as f:
+        weights = []
+        for e, line in enumerate(f):
+            if e == 0:
+                print("Version", line.strip())
+                if line != '1\n':
+                    raise ValueError("Unknown version {}".format(line.strip()))
+            else:
+                weights.append(list(map(float, line.split(' '))))
+            if e == 2:
+                channels = len(line.split(' '))
+                print("Channels", channels)
+        blocks = e - (4 + 14)
+        if blocks % 8 != 0:
+            raise ValueError("Inconsistent number of weights in the file")
+        blocks //= 8
+        print("Blocks", blocks)
+
+        return blocks, channels, weights
+
+def conv_bn_wider(weights, next_weights, inputs, channels,
+                  new_channels, noise_std=0, next_conv=True,
+                  verify=False):
+    """new_channels = number of channels to add"""
+
+    if new_channels == 0:
+        return weights, next_weights
+
+    rand = range(channels)
+    rand.extend(np.random.randint(0, channels, new_channels))
+    rep_factor = np.bincount(rand)
+
+    #Widen the current layer
+    w_conv_new = np.array(weights[0]).reshape(channels, inputs, 3, 3)[rand, :, :, :]
+    w_bn_means = np.array(weights[2])[rand]
+    w_bn_vars = np.array(weights[3])[rand]
+
+    #Widen the next layer inputs
+    if next_conv:
+        w_filter = 3
+    else:
+        w_filter = 1
+
+    next_weights_new = []
+    for j in range(len(next_weights)):
+        n = np.array(next_weights[j]).reshape(-1, channels, w_filter, w_filter)
+        next_weights_new.append(n[:, rand, :, :])
+
+        for i in range(len(rand)):
+            noise = 0
+            if i > channels:
+                noise = np.random.normal(0, noise_std)
+            next_weights_new[j][:, i, :, :] *= (1.0 + noise)/rep_factor[rand[i]]
+
+    if noise_std == 0 and verify:
+        x = np.random.random((inputs, 19, 19))
+        old1 = convolve(np.array(weights[0]).reshape(channels, inputs, 3, 3), x)
+        old2 = convolve(np.array(next_weights[0]).reshape(-1, channels, w_filter, w_filter), old1)
+        new1 = convolve(np.array(w_conv_new).reshape(channels + new_channels, inputs, 3, 3), x)
+        new2 = convolve(np.array(next_weights_new[0]).reshape(-1, channels + new_channels, w_filter, w_filter), new1)
+        assert (np.abs(old2 - new2) < 1e-6).all()
+
+    w_conv_new = w_conv_new.flatten()
+    for j in range(len(next_weights)):
+        next_weights_new[j] = next_weights_new[j].flatten()
+
+    #Biases are always zero
+    bias = np.zeros(channels + new_channels)
+
+    w_new = [w_conv_new, bias, w_bn_means, w_bn_vars]
+
+    return w_new, next_weights_new
+
+def write_layer(weights, out_file):
+    for w in weights:
+        out_file.write(' '.join(map(str,w)) + '\n')
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description='Add filters/blocks to existing network such that the output is preserved.')
+    parser.add_argument("blocks", help="Residual blocks to add", type=int)
+    parser.add_argument("filters", help="Filters to add", type=int)
+    parser.add_argument("network", help="Input network", type=str)
+    parser.add_argument("--noise", nargs='?', help="Standard deviation of noise to add to new filters/blocks. Default: 1e-5", default=1e-5, type=float)
+    parser.add_argument("--verify", help="Verify that output matches", default=False, action='store_true')
+
+    args = parser.parse_args()
+    new_blocks = args.blocks
+    new_filters = args.filters
+    net_filename = args.network
+    noise_std = args.noise
+    verify = args.verify
+
+    if verify and noise_std != 0:
+        raise ValueError("Noise must be zero if verify is enabled.")
+
+    base, ext = os.path.splitext(net_filename)
+    output_filename = base + "_net2net" + ext
+    blocks, channels, weights = read_net(net_filename)
+
+    if new_blocks < 0:
+        raise ValueError("Blocks must be non-negative")
+
+    if new_filters < 0:
+        raise ValueError("Filters must be non-negative")
+
+    input_planes = 18
+
+    #Input convolution, bias, batch norm means, batch norm variances
+    w_input = weights[:4]
+
+    #Residual block convolution + batch norm
+    w_convs = []
+    for b in range(2*blocks):
+        w_convs.append(weights[4 + b*4: 4 + (b+1)*4])
+
+    i = ((b+1)*4) + 4
+    w_pol = weights[i:i+6]
+    w_val = weights[i+6:]
+
+    if new_blocks > 0:
+        #New blocks must have zero output due to the residual connection
+        new_block_conv = np.random.normal(0, noise_std, 9*(channels)**2)
+        new_block_bias = np.zeros(channels)
+        new_block_bn_mean = new_block_bias.copy()
+        new_block_bn_variances = np.ones(channels)
+        new_block = [new_block_conv, new_block_bias, new_block_bn_mean, new_block_bn_variances]
+
+        for i in range(2*new_blocks):
+            w_convs.append(deepcopy(new_block))
+
+        blocks += new_blocks
+
+    out_file = open(output_filename, 'w')
+
+    #Version
+    out_file.write('1\n')
+
+    #Input
+    w_wider, conv_next = conv_bn_wider(w_input, [w_convs[0][0]], input_planes, channels, new_filters, noise_std, verify=verify)
+    w_convs[0][0] = conv_next[0]
+
+    write_layer(w_wider, out_file)
+
+    for e, w in enumerate(w_convs[:-1]):
+        if e % 2 == 0:
+            print("Processing block", 1 + e//2)
+        w_wider, conv_next = conv_bn_wider(w, [w_convs[e+1][0]], channels + new_filters, channels, new_filters, noise_std, verify=verify)
+        w_convs[e+1][0] = conv_next[0]
+        write_layer(w_wider, out_file)
+
+    #The last block is special case because of policy and value heads
+    w_wider, w_next = conv_bn_wider(w_convs[-1], [w_pol[0], w_val[0]], channels + new_filters, channels, new_filters, noise_std, next_conv=False, verify=verify)
+    w_pol[0] = w_next[0]
+    w_val[0] = w_next[1]
+
+    write_layer(w_wider, out_file)
+
+    write_layer(w_pol, out_file)
+    write_layer(w_val, out_file)
+
+    out_file.close()

--- a/training/tf/net2net.py
+++ b/training/tf/net2net.py
@@ -63,7 +63,7 @@ def read_net(filename):
 
 def conv_bn_wider(weights, next_weights, inputs, channels,
                   new_channels, noise_std=0, last_block=False,
-                  rand=None, verify=False):
+                  rand=None, dir_alpha=None, verify=False):
 
     if new_channels == 0:
         return weights, next_weights
@@ -72,6 +72,24 @@ def conv_bn_wider(weights, next_weights, inputs, channels,
         rand = list(range(channels))
         rand.extend(np.random.randint(0, channels, new_channels))
     rep_factor = np.bincount(rand)
+
+    factor = np.zeros(len(rand))
+
+    #In the net2net paper every input weight was weighted equally,
+    #but in general we can have unequal division of the weights
+    if dir_alpha == None:
+        #Equal division
+        for i in range(len(rand)):
+            factor[i] = 1.0/rep_factor[rand[i]]
+    else:
+        #Unequal input weighting determined by dirichlet distribution
+        for i in range(channels):
+            x = np.random.dirichlet([dir_alpha]*rep_factor[i])
+            e = 0
+            for j in range(channels + new_channels):
+                if rand[j] == i:
+                    factor[j] = x[e]
+                    e += 1
 
     #Widen the current layer
     w_conv_new = np.array(weights[0]).reshape(channels, inputs, 3, 3)[rand, :, :, :]
@@ -93,7 +111,7 @@ def conv_bn_wider(weights, next_weights, inputs, channels,
             noise = 0
             if i >= channels:
                 noise = np.random.normal(0, noise_std)
-            next_weights_new[j][:, i, :, :] *= (1.0 + noise)/rep_factor[rand[i]]
+            next_weights_new[j][:, i, :, :] *= (1.0 + noise)*factor[i]
 
     if noise_std == 0 and verify:
         x = np.random.random((inputs, 19, 19))
@@ -124,15 +142,28 @@ if __name__ == "__main__":
     parser.add_argument("blocks", help="Residual blocks to add", type=int)
     parser.add_argument("filters", help="Filters to add", type=int)
     parser.add_argument("network", help="Input network", type=str)
-    parser.add_argument("--noise", nargs='?', help="Standard deviation of noise to add to new filters/blocks. Default: 5e-3", default=5e-3, type=float)
-    parser.add_argument("--verify", help="Verify that output matches", default=False, action='store_true')
+    parser.add_argument("--noise", nargs='?', help="Standard deviation of noise to add to new filters/blocks. Default: 5e-3",
+            default=5e-3, type=float)
+    parser.add_argument("--dir_alpha", nargs='?', help=\
+        """Dirichlet distribution parameter for input weight distribution for replicated channels. """\
+        """Larger values divide input values more equally. """\
+        """Smaller ones give one large input weight while others are very small. """\
+        """You probably want this to be at least 1 to avoid near zero weights. """\
+        """Set to 0 to divide input weights equally. Default: 10""",
+        default=10, type=float)
+    parser.add_argument("--verify", help="Verify that output matches. Noise must be disabled.",
+            default=False, action='store_true')
 
     args = parser.parse_args()
     new_blocks = args.blocks
     new_channels = args.filters
     net_filename = args.network
     noise_std = args.noise
+    dir_alpha = args.dir_alpha
     verify = args.verify
+
+    if dir_alpha <= 0:
+        dir_alpha = None
 
     if verify and noise_std != 0:
         raise ValueError("Noise must be zero if verify is enabled.")
@@ -146,6 +177,9 @@ if __name__ == "__main__":
 
     if new_channels < 0:
         raise ValueError("Filters must be non-negative")
+
+    print("Output will have {} blocks and {} channels.".format(
+        blocks+new_blocks, channels+new_channels))
 
     input_planes = 18
 
@@ -186,20 +220,27 @@ if __name__ == "__main__":
     rand.extend(np.random.randint(0, channels, new_channels))
 
     #Input
-    w_wider, conv_next = conv_bn_wider(w_input, [w_convs[0][0]], input_planes, channels, new_channels, noise_std, rand=rand, verify=verify)
+    w_wider, conv_next = conv_bn_wider(w_input, [w_convs[0][0]], input_planes,
+            channels, new_channels, noise_std, rand=rand, dir_alpha=dir_alpha, verify=verify)
     w_convs[0][0] = conv_next[0]
 
     write_layer(w_wider, out_file)
 
     for e, w in enumerate(w_convs[:-1]):
+        r = rand
         if e % 2 == 0:
             print("Processing block", 1 + e//2)
-        w_wider, conv_next = conv_bn_wider(w, [w_convs[e+1][0]], channels + new_channels, channels, new_channels, noise_std, rand=rand, verify=verify)
+            #First convolution in residual block can be widened randomly
+            r = None
+
+        w_wider, conv_next = conv_bn_wider(w, [w_convs[e+1][0]], channels + new_channels,
+                channels, new_channels, noise_std, rand=r, dir_alpha=dir_alpha, verify=verify)
         w_convs[e+1][0] = conv_next[0]
         write_layer(w_wider, out_file)
 
     #The last block is special case because of policy and value heads
-    w_wider, w_next = conv_bn_wider(w_convs[-1], [w_pol[0], w_val[0]], channels + new_channels, channels, new_channels, noise_std, last_block=True, rand=rand, verify=verify)
+    w_wider, w_next = conv_bn_wider(w_convs[-1], [w_pol[0], w_val[0]], channels + new_channels,
+            channels, new_channels, noise_std, last_block=True, rand=rand, dir_alpha=dir_alpha, verify=verify)
     w_pol[0] = w_next[0]
     w_val[0] = w_next[1]
 

--- a/training/tf/net2net.py
+++ b/training/tf/net2net.py
@@ -44,7 +44,7 @@ def conv_bn_wider(weights, next_weights, inputs, channels,
     if new_channels == 0:
         return weights, next_weights
 
-    rand = range(channels)
+    rand = list(range(channels))
     rand.extend(np.random.randint(0, channels, new_channels))
     rep_factor = np.bincount(rand)
 


### PR DESCRIPTION
Implementation of net2net (https://arxiv.org/abs/1511.05641) for leelaz network.

Adding blocks works, but widening has still some bugs and the output of the widened network isn't exactly equal to the old one. It's still pretty close and it should be a better initialization than random even now.

Just putting this here in case anyone else was working on this. I'll investigate the widening later.

Example usage:

`python net2net.py 1 64 <network>` adds 1 block and 64 filters to the network. Output is written to `<network>_net2net`.