### PR TITLE
Remove filter size restriction in batch norm

### DIFF
--- a/src/OpenCL.cpp
+++ b/src/OpenCL.cpp
@@ -568,11 +568,6 @@ void OpenCL_Network::batchnorm(int outputs,
 
     cl::Kernel & batchnorm_kernel = opencl_thread_data.m_batchnorm_kernel;
 
-    size_t channelGroup = 1;
-    if (channel_size == 361) {
-        channelGroup = 19;
-    }
-
     try {
         batchnorm_kernel.setArg(0, bufferInput);
         batchnorm_kernel.setArg(1, bufferOutput);
@@ -585,8 +580,7 @@ void OpenCL_Network::batchnorm(int outputs,
         batchnorm_kernel.setArg(4, weights[1]);
 
         queue.enqueueNDRangeKernel(batchnorm_kernel, cl::NullRange,
-                                   cl::NDRange(outputs, channel_size),
-                                   cl::NDRange(std::min(8, outputs), channelGroup));
+                                   cl::NDRange(outputs, channel_size));
     } catch (const cl::Error &e) {
         std::cerr << "Error in batchnorm: " << e.what() << ": "
             << e.err() << std::endl;


### PR DESCRIPTION
Batch norm is the only remaining kernel that requires number of channels to be divisible by 8. Removing the fixed local size allows using network with any amount of filters. I used the odd sizes for testing net2net, but maybe they are useful in other tests too.

This kernel is actually only run once for the input convolution. Other batch norms are calculated inside the Winograd output transformation and this whole kernel could be removed with some refactoring.

Effect to performance is less than what I'm able to benchmark accurately.