### PR TITLE
Check that filters/blocks match in net_to_model

### DIFF
--- a/training/tf/net_to_model.py
+++ b/training/tf/net_to_model.py
@@ -20,7 +20,7 @@ with open(sys.argv[1], 'r') as f:
     blocks = e - (4 + 14)
     if blocks % 8 != 0:
         raise ValueError("Inconsistent number of weights in the file")
-    blocks /= 8
+    blocks //= 8
     print("Blocks", blocks)
 
 x = [
@@ -30,6 +30,12 @@ x = [
     ]
 
 tfprocess = TFProcess(x)
+if tfprocess.RESIDUAL_BLOCKS != blocks:
+    raise ValueError("Number of blocks in tensorflow model doesn't match "\
+            "number of blocks in input network")
+if tfprocess.RESIDUAL_FILTERS != channels:
+    raise ValueError("Number of filters in tensorflow model doesn't match "\
+            "number of filters in input network")
 tfprocess.replace_weights(weights)
 path = os.path.join(os.getcwd(), "leelaz-model")
 save_path = tfprocess.saver.save(tfprocess.session, path, global_step=0)

--- a/training/tf/tfprocess.py
+++ b/training/tf/tfprocess.py
@@ -44,6 +44,11 @@ def conv2d(x, W):
 
 class TFProcess:
     def __init__(self, next_batch):
+
+        # Network structure
+        self.RESIDUAL_FILTERS = 128
+        self.RESIDUAL_BLOCKS = 6
+
         gpu_options = tf.GPUOptions(per_process_gpu_memory_fraction=0.75)
         config = tf.ConfigProto(gpu_options=gpu_options)
         self.session = tf.Session(config=config)
@@ -308,9 +313,6 @@ class TFProcess:
         return h_out_2
 
     def construct_net(self, planes):
-        # Network structure
-        RESIDUAL_FILTERS = 128
-        RESIDUAL_BLOCKS = 6
 
         # NCHW format
         # batch, 18 channels, 19 x 19
@@ -319,14 +321,14 @@ class TFProcess:
         # Input convolution
         flow = self.conv_block(x_planes, filter_size=3,
                                input_channels=18,
-                               output_channels=RESIDUAL_FILTERS)
+                               output_channels=self.RESIDUAL_FILTERS)
         # Residual tower
-        for _ in range(0, RESIDUAL_BLOCKS):
-            flow = self.residual_block(flow, RESIDUAL_FILTERS)
+        for _ in range(0, self.RESIDUAL_BLOCKS):
+            flow = self.residual_block(flow, self.RESIDUAL_FILTERS)
 
         # Policy head
         conv_pol = self.conv_block(flow, filter_size=1,
-                                   input_channels=RESIDUAL_FILTERS,
+                                   input_channels=self.RESIDUAL_FILTERS,
                                    output_channels=2)
         h_conv_pol_flat = tf.reshape(conv_pol, [-1, 2*19*19])
         W_fc1 = weight_variable([2 * 19 * 19, (19 * 19) + 1])
@@ -337,7 +339,7 @@ class TFProcess:
 
         # Value head
         conv_val = self.conv_block(flow, filter_size=1,
-                                   input_channels=RESIDUAL_FILTERS,
+                                   input_channels=self.RESIDUAL_FILTERS,
                                    output_channels=1)
         h_conv_val_flat = tf.reshape(conv_val, [-1, 19*19])
         W_fc2 = weight_variable([19 * 19, 256])


### PR DESCRIPTION
If the filters/blocks are different and the replacement is tried it will fail with hard to understand error message. This commit adds a clearer error message.