### PR TITLE
cleanup get_best_move

### DIFF
--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -221,16 +221,11 @@ int UCTSearch::get_best_move(passflag_t passflag) {
         m_root->randomize_first_proportionally();
     }
 
-    int bestmove = m_root->get_first_child()->get_move();
+    auto first_child = m_root->get_first_child();
+    assert(first_child != nullptr);
 
-    // do we have statistics on the moves?
-    if (m_root->get_first_child() != nullptr) {
-        if (m_root->get_first_child()->first_visit()) {
-            return bestmove;
-        }
-    }
-
-    float bestscore = m_root->get_first_child()->get_eval(color);
+    int bestmove = first_child->get_move();
+    float bestscore = first_child->get_eval(color);
 
     // do we want to fiddle with the best move because of the rule set?
     if (passflag & UCTSearch::NOPASS) {


### PR DESCRIPTION
if get_first_child is nullptr then line 224 would have segfaulted

I don't believe line 228 ever gets invoked (we should always have at least one visit per the structure of UCTSearch::think)

Even if we did were trying to decide on the best move with zero playouts I don't see why that special case would get to overrides the pass/nopass/dumppass behavior
