### PR TITLE
Make UCTSearch take a reference to the game state.

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -166,7 +166,7 @@ std::string GTP::get_life_list(const GameState & game, bool live) {
 
 bool GTP::execute(GameState & game, std::string xinput) {
     std::string input;
-    static auto search = std::make_unique<UCTSearch>();
+    static auto search = std::make_unique<UCTSearch>(game);
 
     bool transform_lowercase = true;
 
@@ -280,7 +280,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
     } else if (command.find("clear_board") == 0) {
         Training::clear_training();
         game.reset_game();
-        std::make_unique<UCTSearch>().swap(search);
+        std::make_unique<UCTSearch>(game).swap(search);
         gtp_printf(id, "");
         return true;
     } else if (command.find("komi") == 0) {
@@ -349,7 +349,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
             // start thinking
             {
                 game.set_to_move(who);
-                int move = search->think(who, game);
+                int move = search->think(who);
                 game.play_move(move);
 
                 std::string vertex = game.move_to_text(move);
@@ -358,7 +358,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
             if (cfg_allow_pondering) {
                 // now start pondering
                 if (!game.has_resigned()) {
-                    search->ponder(game);
+                    search->ponder();
                 }
             }
         } else {
@@ -385,7 +385,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
             game.set_passes(0);
             {
                 game.set_to_move(who);
-                int move = search->think(who, game, UCTSearch::NOPASS);
+                int move = search->think(who, UCTSearch::NOPASS);
                 game.play_move(move);
 
                 std::string vertex = game.move_to_text(move);
@@ -394,7 +394,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
             if (cfg_allow_pondering) {
                 // now start pondering
                 if (!game.has_resigned()) {
-                    search->ponder(game);
+                    search->ponder();
                 }
             }
         } else {
@@ -477,7 +477,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
                 // KGS sends this after our move
                 // now start pondering
                 if (!game.has_resigned()) {
-                    search->ponder(game);
+                    search->ponder();
                 }
             }
         } else {
@@ -486,7 +486,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
         return true;
     } else if (command.find("auto") == 0) {
         do {
-            int move = search->think(game.get_to_move(), game, UCTSearch::NORMAL);
+            int move = search->think(game.get_to_move(), UCTSearch::NORMAL);
             game.play_move(move);
             game.display_state();
 
@@ -494,7 +494,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
 
         return true;
     } else if (command.find("go") == 0) {
-        int move = search->think(game.get_to_move(), game);
+        int move = search->think(game.get_to_move());
         game.play_move(move);
 
         std::string vertex = game.move_to_text(move);

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -322,9 +322,9 @@ void GameState::place_free_handicap(int stones) {
 
     stones -= set_fixed_handicap_2(stones);
 
-    UCTSearch search;
     for (int i = 0; i < stones; i++) {
-        int move = search.think(FastBoard::BLACK, *this, UCTSearch::NOPASS);
+        auto search = std::make_unique<UCTSearch>(*this);
+        auto move = search->think(FastBoard::BLACK, UCTSearch::NOPASS);
         play_move(FastBoard::BLACK, move);
     }
 

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -425,26 +425,29 @@ UCTNode::node_ptr_t UCTNode::find_new_root(const int move) {
 
 // Use this version if the child could be anywhere.
 void UCTNode::find_new_root(node_ptr_t& root,
-                            const GameState& g_new,
-                            GameState& g_curr) {
+                            const GameState& g_curr,
+                            std::unique_ptr<GameState>&& g_old) {
     auto found = false;
 
-    if (g_new.get_komi() == g_curr.get_komi()) {
-        if (g_new.board.get_hash() == g_curr.board.get_hash()) {
-            // root is already set correctly
-            found = true;
-        } else {
-            // search the direct children
-            for (auto& child : root->m_children) {
-                auto move = child->get_move();
-                if (g_new.get_last_move() == move) {
-                    g_curr.play_move(move);
-                    if (g_curr.board.get_hash() == g_new.board.get_hash()) {
-                        root = std::move(child);
-                        found = true;
-                        break;
+    if (g_old) {
+        if (g_curr.get_komi() == g_old->get_komi()) {
+            if (g_curr.board.get_hash() == g_old->board.get_hash()) {
+                // root is already set correctly
+                found = true;
+            } else {
+                // search the direct children
+                for (auto& child : root->m_children) {
+                    auto move = child->get_move();
+                    if (g_curr.get_last_move() == move) {
+                        g_old->play_move(move);
+                        if (g_curr.board.get_hash()
+                            == g_old->board.get_hash()) {
+                            root = std::move(child);
+                            found = true;
+                            break;
+                        }
+                        g_old->undo_move();
                     }
-                    g_curr.undo_move();
                 }
             }
         }
@@ -453,10 +456,6 @@ void UCTNode::find_new_root(node_ptr_t& root,
     if (!found) {
         root = std::make_unique<UCTNode>(FastBoard::PASS, 0.0f, 0.5f);
     }
-
-    // Always copy GameState because it contains other
-    // things such as TimeControl updates.
-    g_curr = g_new;
 }
 
 UCTNode* UCTNode::get_nopass_child(FastState& state) const {

--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -72,8 +72,8 @@ public:
     size_t count_nodes() const;
     node_ptr_t find_new_root(const int move);
     static void find_new_root(node_ptr_t& root,
-                              const GameState& g_new,
-                              GameState& g_curr);
+                              const GameState& g_curr,
+                              std::unique_ptr<GameState>&& g_old);
     void sort_children(int color);
     UCTNode& get_best_root_child(int color);
     SMP::Mutex& get_mutex();

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -38,25 +38,27 @@
 
 using namespace Utils;
 
-UCTSearch::UCTSearch() {
+UCTSearch::UCTSearch(GameState& g)
+    : m_rootstate(g) {
     set_playout_limit(cfg_max_playouts);
     set_visit_limit(cfg_max_visits);
     m_root = std::make_unique<UCTNode>(FastBoard::PASS, 0.0f, 0.5f);
 }
 
-void UCTSearch::set_gamestate(const GameState & g) {
-    // Definition of m_playouts is playouts from a certain GameState.
+void UCTSearch::update_root() {
+    // Definition of m_playouts is playouts per search call.
     // So reset this count now.
     m_playouts = 0;
     // See if the current state of the game is a direct succesor of
     // our stored tree's root node. If so, make that the new root.
-    UCTNode::find_new_root(m_root, g, m_rootstate);
+    UCTNode::find_new_root(m_root, m_rootstate, std::move(m_last_rootstate));
     // If the above succeeded, we'll have a search tree already. See
     // how big it is.
     m_nodes = m_root->count_nodes();
 }
 
-SearchResult UCTSearch::play_simulation(GameState & currstate, UCTNode* const node) {
+SearchResult UCTSearch::play_simulation(GameState & currstate,
+                                        UCTNode* const node) {
     const auto color = currstate.get_to_move();
     auto result = SearchResult{};
 
@@ -368,12 +370,11 @@ void UCTSearch::increment_playouts() {
     m_playouts++;
 }
 
-int UCTSearch::think(int color, const GameState& g, passflag_t passflag) {
-    set_gamestate(g);
-
+int UCTSearch::think(int color, passflag_t passflag) {
     // Start counting time for us
     m_rootstate.start_clock(color);
 
+    update_root();
     // set side to move
     m_rootstate.board.set_to_move(color);
 
@@ -456,13 +457,17 @@ int UCTSearch::think(int color, const GameState& g, passflag_t passflag) {
                  (m_playouts * 100) / (elapsed_centis+1));
     }
     int bestmove = get_best_move(passflag);
-    m_rootstate.play_move(bestmove);
+    // Update the root to point to the subtree after our selected move.
     m_root = m_root->find_new_root(bestmove);
+    // Copy the root state and play our move. We can search for the
+    // users' played move from this point.
+    m_last_rootstate = std::make_unique<GameState>(m_rootstate);
+    m_last_rootstate->play_move(bestmove);
     return bestmove;
 }
 
-void UCTSearch::ponder(const GameState& g) {
-    set_gamestate(g);
+void UCTSearch::ponder() {
+    update_root();
 
     m_run = true;
     int cpus = cfg_num_threads;

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -74,25 +74,26 @@ public:
     static constexpr auto MAX_TREE_SIZE =
         (sizeof(void*) == 4 ? 25'000'000 : 100'000'000);
 
-    UCTSearch();
-    void set_gamestate(const GameState& g);
-    int think(int color, const GameState& g, passflag_t passflag = NORMAL);
+    UCTSearch(GameState& g);
+    int think(int color, passflag_t passflag = NORMAL);
     void set_playout_limit(int playouts);
     void set_visit_limit(int visits);
-    void ponder(const GameState& g);
+    void ponder();
     bool is_running() const;
     bool playout_or_visit_limit_reached() const;
     void increment_playouts();
     SearchResult play_simulation(GameState& currstate, UCTNode* const node);
 
 private:
+    void update_root();
     void dump_stats(KoState& state, UCTNode& parent);
     std::string get_pv(KoState& state, UCTNode& parent);
     void dump_analysis(int playouts);
     bool should_resign(passflag_t passflag, float bestscore);
     int get_best_move(passflag_t passflag);
 
-    GameState m_rootstate;
+    GameState & m_rootstate;
+    std::unique_ptr<GameState> m_last_rootstate;
     std::unique_ptr<UCTNode> m_root;
     std::atomic<int> m_nodes{0};
     std::atomic<int> m_playouts{0};


### PR DESCRIPTION
UCTSearch originally took a reference to the current game state. Tree
reuse made it keep its own copy, which is now causing problems to keep
in sync. Revert that and make it take a reference again. We copy the
last GameState at the end of the search and use the copy to find back
the right UCTNode root at the beginning of the next search.

Fixes issue #690.