### PR TITLE
Very simple test set for training

### DIFF
--- a/training/tf/parse.py
+++ b/training/tf/parse.py
@@ -286,6 +286,7 @@ def main():
 
         testset = tf.data.Dataset.from_generator(
             parser_test.parse_chunk, output_types=(tf.string))
+        testset = testset.shuffle(4096)
         testset = testset.map(_parse_function)
         testset = testset.batch(BATCH_SIZE)
         testset = testset.prefetch(4)


### PR DESCRIPTION
I saw some discussion about the test set for training. I've been missing it too so here's a simple implementation.

parse.py now takes optional "--test" argument for path to chunk to be used as a test set. Symmetry is still applied to it and it loops around during the testing so the tested positions are not identical. I'm not expert in tensorflow and didn't find a quick method to solve those, but this should still be better than nothing.