### PR TITLE
Change play_move to handle FastBoard::PASS

### DIFF
--- a/src/FastState.h
+++ b/src/FastState.h
@@ -32,7 +32,6 @@ public:
     void reset_game();
     void reset_board();
 
-    void play_pass(int color);
     void play_move(int vertex);
 
     bool is_move_legal(int color, int vertex);

--- a/src/FullBoard.cpp
+++ b/src/FullBoard.cpp
@@ -110,6 +110,7 @@ void FullBoard::set_to_move(int tomove) {
 }
 
 int FullBoard::update_board(const int color, const int i) {
+    assert(i != FastBoard::PASS);
     assert(m_square[i] == EMPTY);
 
     m_hash ^= Zobrist::zobrist[m_square[i]][i];

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -309,7 +309,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
             game.play_move(FastBoard::RESIGN);
             gtp_printf(id, "");
         } else if (command.find("pass") != std::string::npos) {
-            game.play_pass();
+            game.play_move(FastBoard::PASS);
             gtp_printf(id, "");
         } else {
             std::istringstream cmdstream(command);

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -89,17 +89,11 @@ void GameState::play_move(int vertex) {
     play_move(get_to_move(), vertex);
 }
 
-void GameState::play_pass() {
-    play_move(get_to_move(), FastBoard::PASS);
-}
-
 void GameState::play_move(int color, int vertex) {
-    if (vertex != FastBoard::PASS && vertex != FastBoard::RESIGN) {
-        KoState::play_move(color, vertex);
-    } else if (vertex == FastBoard::PASS) {
-        KoState::play_pass();
-    } else if (vertex == FastBoard::RESIGN) {
+    if (vertex == FastBoard::RESIGN) {
         m_resigned = color;
+    } else {
+        KoState::play_move(color, vertex);
     }
 
     // cut off any leftover moves from navigating

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -50,7 +50,6 @@ public:
 
     void play_move(int color, int vertex);
     void play_move(int vertex);
-    void play_pass();
     bool play_textmove(const std::string& color,
                        const std::string& vertex);
 

--- a/src/KoState.cpp
+++ b/src/KoState.cpp
@@ -52,19 +52,13 @@ void KoState::reset_game() {
     m_ko_hash_history.push_back(board.get_ko_hash());
 }
 
-void KoState::play_pass(void) {
-    play_move(board.get_to_move(), FastBoard::PASS);
-}
-
 void KoState::play_move(int vertex) {
     play_move(board.get_to_move(), vertex);
 }
 
 void KoState::play_move(int color, int vertex) {
-    if (vertex != FastBoard::PASS && vertex != FastBoard::RESIGN) {
+    if (vertex != FastBoard::RESIGN) {
         FastState::play_move(color, vertex);
-    } else if (vertex == FastBoard::PASS) {
-        FastState::play_pass(color);
     }
     m_ko_hash_history.push_back(board.get_ko_hash());
 }

--- a/src/KoState.h
+++ b/src/KoState.h
@@ -32,7 +32,6 @@ public:
     bool superko(void) const;
     void reset_game();
 
-    void play_pass(void);
     void play_move(int color, int vertex);
     void play_move(int vertex);
 

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -86,16 +86,10 @@ SearchResult UCTSearch::play_simulation(GameState & currstate,
         if (next != nullptr) {
             auto move = next->get_move();
 
-            if (move != FastBoard::PASS) {
-                currstate.play_move(move);
-
-                if (!currstate.superko()) {
-                    result = play_simulation(currstate, next);
-                } else {
-                    next->invalidate();
-                }
+            currstate.play_move(move);
+            if (move != FastBoard::PASS && currstate.superko()) {
+                next->invalidate();
             } else {
-                currstate.play_pass();
                 result = play_simulation(currstate, next);
             }
         }


### PR DESCRIPTION
IMO this is more generic code and
We're able to removing the nearly identical play_pass from FastState.cpp