### PR TITLE
Add new option --timemanage.

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -50,6 +50,7 @@ bool cfg_allow_pondering;
 int cfg_num_threads;
 int cfg_max_playouts;
 int cfg_max_visits;
+bool cfg_timemanage;
 int cfg_lagbuffer_cs;
 int cfg_resignpct;
 int cfg_noise;
@@ -76,6 +77,7 @@ void GTP::setup_default_parameters() {
     cfg_num_threads = std::max(1, std::min(SMP::get_num_cpus(), MAX_CPUS));
     cfg_max_playouts = std::numeric_limits<decltype(cfg_max_playouts)>::max();
     cfg_max_visits = std::numeric_limits<decltype(cfg_max_visits)>::max();
+    cfg_timemanage = false;
     cfg_lagbuffer_cs = 100;
 #ifdef USE_OPENCL
     cfg_gpus = { };

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -50,7 +50,7 @@ bool cfg_allow_pondering;
 int cfg_num_threads;
 int cfg_max_playouts;
 int cfg_max_visits;
-timemanage_t cfg_timemanage;
+UCTSearch::timemanage_t cfg_timemanage;
 int cfg_lagbuffer_cs;
 int cfg_resignpct;
 int cfg_noise;
@@ -77,7 +77,7 @@ void GTP::setup_default_parameters() {
     cfg_num_threads = std::max(1, std::min(SMP::get_num_cpus(), MAX_CPUS));
     cfg_max_playouts = std::numeric_limits<decltype(cfg_max_playouts)>::max();
     cfg_max_visits = std::numeric_limits<decltype(cfg_max_visits)>::max();
-    cfg_timemanage = AUTO;
+    cfg_timemanage = UCTSearch::AUTO;
     cfg_lagbuffer_cs = 100;
 #ifdef USE_OPENCL
     cfg_gpus = { };

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -50,7 +50,7 @@ bool cfg_allow_pondering;
 int cfg_num_threads;
 int cfg_max_playouts;
 int cfg_max_visits;
-bool cfg_timemanage;
+int cfg_timemanage;
 int cfg_lagbuffer_cs;
 int cfg_resignpct;
 int cfg_noise;
@@ -77,7 +77,7 @@ void GTP::setup_default_parameters() {
     cfg_num_threads = std::max(1, std::min(SMP::get_num_cpus(), MAX_CPUS));
     cfg_max_playouts = std::numeric_limits<decltype(cfg_max_playouts)>::max();
     cfg_max_visits = std::numeric_limits<decltype(cfg_max_visits)>::max();
-    cfg_timemanage = false;
+    cfg_timemanage = -1;
     cfg_lagbuffer_cs = 100;
 #ifdef USE_OPENCL
     cfg_gpus = { };

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -50,7 +50,7 @@ bool cfg_allow_pondering;
 int cfg_num_threads;
 int cfg_max_playouts;
 int cfg_max_visits;
-int cfg_timemanage;
+timemanage_t cfg_timemanage;
 int cfg_lagbuffer_cs;
 int cfg_resignpct;
 int cfg_noise;
@@ -77,7 +77,7 @@ void GTP::setup_default_parameters() {
     cfg_num_threads = std::max(1, std::min(SMP::get_num_cpus(), MAX_CPUS));
     cfg_max_playouts = std::numeric_limits<decltype(cfg_max_playouts)>::max();
     cfg_max_visits = std::numeric_limits<decltype(cfg_max_visits)>::max();
-    cfg_timemanage = -1;
+    cfg_timemanage = AUTO;
     cfg_lagbuffer_cs = 100;
 #ifdef USE_OPENCL
     cfg_gpus = { };

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -32,7 +32,7 @@ extern bool cfg_allow_pondering;
 extern int cfg_num_threads;
 extern int cfg_max_playouts;
 extern int cfg_max_visits;
-extern bool cfg_timemanage;
+extern int cfg_timemanage;
 extern int cfg_lagbuffer_cs;
 extern int cfg_resignpct;
 extern int cfg_noise;

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -26,16 +26,14 @@
 #include <vector>
 
 #include "GameState.h"
+#include "UCTSearch.h"
 
 extern bool cfg_gtp_mode;
 extern bool cfg_allow_pondering;
 extern int cfg_num_threads;
 extern int cfg_max_playouts;
 extern int cfg_max_visits;
-enum timemanage_t : int {
-    AUTO = -1, OFF = 0, ON = 1
-};
-extern timemanage_t cfg_timemanage;
+extern UCTSearch::timemanage_t cfg_timemanage;
 extern int cfg_lagbuffer_cs;
 extern int cfg_resignpct;
 extern int cfg_noise;

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -32,7 +32,10 @@ extern bool cfg_allow_pondering;
 extern int cfg_num_threads;
 extern int cfg_max_playouts;
 extern int cfg_max_visits;
-extern int cfg_timemanage;
+enum timemanage_t : int {
+    AUTO = -1, OFF = 0, ON = 1
+};
+extern timemanage_t cfg_timemanage;
 extern int cfg_lagbuffer_cs;
 extern int cfg_resignpct;
 extern int cfg_noise;

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -32,6 +32,7 @@ extern bool cfg_allow_pondering;
 extern int cfg_num_threads;
 extern int cfg_max_playouts;
 extern int cfg_max_visits;
+extern bool cfg_timemanage;
 extern int cfg_lagbuffer_cs;
 extern int cfg_resignpct;
 extern int cfg_noise;

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -60,10 +60,11 @@ static void parse_commandline(int argc, char *argv[]) {
                       (std::min(2, cfg_num_threads)),
                       "Number of threads to use.")
         ("playouts,p", po::value<int>(),
-                       "Weaken engine by limiting the number of playouts. "
+                       "Weaken engine by limiting the number of playouts."
                        "Requires --noponder.")
         ("visits,v", po::value<int>(),
-                     "Weaken engine by limiting the number of visits. ")
+                     "Weaken engine by limiting the number of visits.")
+        ("timemanage", "Enable extra time management features.")
         ("lagbuffer,b", po::value<int>()->default_value(cfg_lagbuffer_cs),
                         "Safety margin for time usage in centiseconds.")
         ("resignpct,r", po::value<int>()->default_value(cfg_resignpct),
@@ -204,6 +205,10 @@ static void parse_commandline(int argc, char *argv[]) {
 
     if (vm.count("visits")) {
         cfg_max_visits = vm["visits"].as<int>();
+    }
+
+    if (vm.count("timemanage")) {
+        cfg_timemanage = true;
     }
 
     if (vm.count("resignpct")) {

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -64,10 +64,9 @@ static void parse_commandline(int argc, char *argv[]) {
                        "Requires --noponder.")
         ("visits,v", po::value<int>(),
                      "Weaken engine by limiting the number of visits.")
-        ("timemanage", po::value<int>()->default_value(cfg_timemanage),
-                       "Enable extra time management features.\n"
-                       "0 = off, 1 = on, "
-                       "-1 = auto (off when using -m, otherwise on)")
+        ("timemanage", po::value<std::string>()->default_value("auto"),
+                       "[auto|on|off] Enable extra time management features.\n"
+                       "auto = off when using -m, otherwise on")
         ("lagbuffer,b", po::value<int>()->default_value(cfg_lagbuffer_cs),
                         "Safety margin for time usage in centiseconds.")
         ("resignpct,r", po::value<int>()->default_value(cfg_resignpct),
@@ -220,10 +219,20 @@ static void parse_commandline(int argc, char *argv[]) {
     }
 
     if (vm.count("timemanage")) {
-        cfg_timemanage = vm["timemanage"].as<int>();
+        auto tm = vm["timemanage"].as<std::string>();
+        if (tm == "auto") {
+            cfg_timemanage = AUTO;
+        } else if (tm == "on") {
+            cfg_timemanage = ON;
+        } else if (tm == "off") {
+            cfg_timemanage = OFF;
+        } else {
+            myprintf("Invalid timemanage value\n");
+            exit(EXIT_FAILURE);
+        }
     }
-    if (cfg_timemanage == -1) {
-        cfg_timemanage = cfg_random_cnt ? 0 : 1;
+    if (cfg_timemanage == AUTO) {
+        cfg_timemanage = cfg_random_cnt ? OFF : ON;
     }
 
     if (vm.count("lagbuffer")) {

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -64,11 +64,15 @@ static void parse_commandline(int argc, char *argv[]) {
                        "Requires --noponder.")
         ("visits,v", po::value<int>(),
                      "Weaken engine by limiting the number of visits.")
-        ("timemanage", "Enable extra time management features.")
+        ("timemanage", po::value<int>()->default_value(cfg_timemanage),
+                       "Enable extra time management features.\n"
+                       "0 = off, 1 = on, "
+                       "-1 = auto (off when using -m, otherwise on)")
         ("lagbuffer,b", po::value<int>()->default_value(cfg_lagbuffer_cs),
                         "Safety margin for time usage in centiseconds.")
         ("resignpct,r", po::value<int>()->default_value(cfg_resignpct),
-                        "Resign when winrate is less than x%.")
+                        "Resign when winrate is less than x%.\n"
+                        "-1 uses 10% but scales for handicap.")
         ("randomcnt,m", po::value<int>()->default_value(cfg_random_cnt),
                         "Play more randomly the first x moves.")
         ("noise,n", "Enable policy network randomization.")
@@ -207,16 +211,19 @@ static void parse_commandline(int argc, char *argv[]) {
         cfg_max_visits = vm["visits"].as<int>();
     }
 
-    if (vm.count("timemanage")) {
-        cfg_timemanage = true;
-    }
-
     if (vm.count("resignpct")) {
         cfg_resignpct = vm["resignpct"].as<int>();
     }
 
     if (vm.count("randomcnt")) {
         cfg_random_cnt = vm["randomcnt"].as<int>();
+    }
+
+    if (vm.count("timemanage")) {
+        cfg_timemanage = vm["timemanage"].as<int>();
+    }
+    if (cfg_timemanage == -1) {
+        cfg_timemanage = cfg_random_cnt ? 0 : 1;
     }
 
     if (vm.count("lagbuffer")) {

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -221,18 +221,18 @@ static void parse_commandline(int argc, char *argv[]) {
     if (vm.count("timemanage")) {
         auto tm = vm["timemanage"].as<std::string>();
         if (tm == "auto") {
-            cfg_timemanage = AUTO;
+            cfg_timemanage = UCTSearch::AUTO;
         } else if (tm == "on") {
-            cfg_timemanage = ON;
+            cfg_timemanage = UCTSearch::ON;
         } else if (tm == "off") {
-            cfg_timemanage = OFF;
+            cfg_timemanage = UCTSearch::OFF;
         } else {
             myprintf("Invalid timemanage value\n");
             exit(EXIT_FAILURE);
         }
     }
-    if (cfg_timemanage == AUTO) {
-        cfg_timemanage = cfg_random_cnt ? OFF : ON;
+    if (cfg_timemanage == UCTSearch::AUTO) {
+        cfg_timemanage = cfg_random_cnt ? UCTSearch::OFF : UCTSearch::ON;
     }
 
     if (vm.count("lagbuffer")) {

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -385,12 +385,10 @@ bool UCTSearch::stop_thinking(int elapsed_centis, int time_for_move) const {
         auto est_playouts_left = playout_rate * time_left;
         if (est_playouts_left < Nfirst - Nsecond) {
             stop = true;
-            if (!cfg_quiet) {
-                myprintf("%.1fs left\n", time_left/100.0f);
-            }
+            myprintf("%.1fs left\n", time_left/100.0f);
         }
     }
-    if (stop && !cfg_quiet) {
+    if (stop) {
         myprintf("Stopping early.\n");
     }
     return stop;

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -385,10 +385,12 @@ bool UCTSearch::stop_thinking(int elapsed_centis, int time_for_move) const {
         auto est_playouts_left = playout_rate * time_left;
         if (est_playouts_left < Nfirst - Nsecond) {
             stop = true;
-            myprintf("%.1fs left\n", time_left/100.0f);
+            if (!cfg_quiet) {
+                myprintf("%.1fs left\n", time_left/100.0f);
+            }
         }
     }
-    if (stop) {
+    if (stop && !cfg_quiet) {
         myprintf("Stopping early.\n");
     }
     return stop;

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -359,7 +359,7 @@ bool UCTSearch::stop_thinking(int elapsed_centis, int time_for_move) const {
                 || visits >= m_maxvisits
                 || elapsed_centis >= time_for_move;
 
-    if (stop || !cfg_timemanage) {
+    if (stop || cfg_timemanage == OFF) {
         return stop;
     }
 

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -74,6 +74,10 @@ public:
     static constexpr auto MAX_TREE_SIZE =
         (sizeof(void*) == 4 ? 25'000'000 : 100'000'000);
 
+    enum timemanage_t : int {
+        AUTO = -1, OFF = 0, ON = 1
+    };
+
     UCTSearch(GameState& g);
     int think(int color, passflag_t passflag = NORMAL);
     void set_playout_limit(int playouts);

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -80,7 +80,7 @@ public:
     void set_visit_limit(int visits);
     void ponder();
     bool is_running() const;
-    bool playout_or_visit_limit_reached() const;
+    bool stop_thinking(int elapsed_centis = 0, int time_for_move = 0) const;
     void increment_playouts();
     SearchResult play_simulation(GameState& currstate, UCTNode* const node);
 


### PR DESCRIPTION
Stop thinking when it's unlikely for the best move to be overtaken. A simple first step for #788.

I only did a very quick sanity check on this, will test more later. Looking for feedback on switch name etc.

For --visits and --playouts I think it should be impossible for this code to mistakenly stop thinking too early, assuming TM_MARGIN of 0.9f is much larger than virtual loss and other thread weirdness. For time controls there could be issues if the computer load changes while thinking, but that doesn't seem like a big problem to me.
