### PR TITLE
update cl2.hpp which fixes gcc warning

### DIFF
--- a/src/CL/cl2.hpp
+++ b/src/CL/cl2.hpp
@@ -1828,9 +1828,7 @@ public:
 
     cl_type& operator ()() { return object_; }
 
-    const cl_type get() const { return object_; }
-
-    cl_type get() { return object_; }
+    cl_type get() const { return object_; }
 
 protected:
     template<typename Func, typename U>


### PR DESCRIPTION
Got this fixed [upstream](https://github.com/sethtroisi/OpenCL-CLHPP/commit/66358621ece5197f90cc457a08d629ac63559e73)

Generated verified this was the only diff with
curl https://raw.githubusercontent.com/sethtroisi/OpenCL-CLHPP/master/input_cl2.hpp > CL/cl2.hpp

