### PR TITLE
Refactor find_new_root

### DIFF
--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -410,8 +410,8 @@ size_t UCTNode::count_nodes() const {
     return nodecount;
 }
 
-// Use this version if you know the child is directly under the parent.
-UCTNode::node_ptr_t UCTNode::find_new_root(const int move) {
+// Used to find new root in UCTSearch
+UCTNode::node_ptr_t UCTNode::find_child(const int move) {
     if (m_has_children) {
         for (auto& child : m_children) {
             if (child->get_move() == move) {
@@ -419,44 +419,9 @@ UCTNode::node_ptr_t UCTNode::find_new_root(const int move) {
             }
         }
     }
-    // Can happen for example if we resigned. Return a clean
-    // root for the next game or position.
-    return std::make_unique<UCTNode>(FastBoard::PASS, 0.0f, 0.5f);
-}
 
-// Use this version if the child could be anywhere.
-void UCTNode::find_new_root(node_ptr_t& root,
-                            const GameState& g_curr,
-                            std::unique_ptr<GameState>&& g_old) {
-    auto found = false;
-
-    if (g_old) {
-        if (g_curr.get_komi() == g_old->get_komi()) {
-            if (g_curr.board.get_hash() == g_old->board.get_hash()) {
-                // root is already set correctly
-                found = true;
-            } else {
-                // search the direct children
-                for (auto& child : root->m_children) {
-                    auto move = child->get_move();
-                    if (g_curr.get_last_move() == move) {
-                        g_old->play_move(move);
-                        if (g_curr.board.get_hash()
-                            == g_old->board.get_hash()) {
-                            root = std::move(child);
-                            found = true;
-                            break;
-                        }
-                        g_old->undo_move();
-                    }
-                }
-            }
-        }
-    }
-
-    if (!found) {
-        root = std::make_unique<UCTNode>(FastBoard::PASS, 0.0f, 0.5f);
-    }
+    // Can happen for example if we resigned.
+    return nullptr;
 }
 
 UCTNode* UCTNode::get_nopass_child(FastState& state) const {

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -420,7 +420,7 @@ UCTNode::node_ptr_t UCTNode::find_child(const int move) {
         }
     }
 
-    // Can happen for example if we resigned.
+    // Can happen if we resigned or children are not expanded
     return nullptr;
 }
 

--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -70,10 +70,7 @@ public:
     UCTNode* get_nopass_child(FastState& state) const;
     const std::vector<node_ptr_t>& get_children() const;
     size_t count_nodes() const;
-    node_ptr_t find_new_root(const int move);
-    static void find_new_root(node_ptr_t& root,
-                              const GameState& g_curr,
-                              std::unique_ptr<GameState>&& g_old);
+    node_ptr_t find_child(const int move);
     void sort_children(int color);
     UCTNode& get_best_root_child(int color);
     SMP::Mutex& get_mutex();

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -21,7 +21,6 @@
 
 #include <cassert>
 #include <cstddef>
-#include <string>
 #include <limits>
 #include <memory>
 #include <type_traits>
@@ -68,7 +67,7 @@ bool UCTSearch::advance_to_new_rootstate() {
         test->undo_move();
     }
 
-    if (m_last_rootstate->board.get_ko_hash() != test->board.get_ko_hash()) {
+    if (m_last_rootstate->board.get_hash() != test->board.get_hash()) {
         // m_rootstate and m_last_rootstate don't match
         return false;
     }
@@ -87,7 +86,7 @@ bool UCTSearch::advance_to_new_rootstate() {
 
     assert(m_rootstate.get_movenum() == m_last_rootstate->get_movenum());
 
-    if (m_last_rootstate->board.get_ko_hash() != test->board.get_ko_hash()) {
+    if (m_last_rootstate->board.get_hash() != test->board.get_hash()) {
         // Can happen if user plays multiple moves in a row by same player
         return false;
     }

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -85,12 +85,13 @@ public:
     SearchResult play_simulation(GameState& currstate, UCTNode* const node);
 
 private:
-    void update_root();
     void dump_stats(KoState& state, UCTNode& parent);
     std::string get_pv(KoState& state, UCTNode& parent);
     void dump_analysis(int playouts);
     bool should_resign(passflag_t passflag, float bestscore);
     int get_best_move(passflag_t passflag);
+    void update_root();
+    bool advance_to_new_rootstate();
 
     GameState & m_rootstate;
     std::unique_ptr<GameState> m_last_rootstate;


### PR DESCRIPTION
**Improvements**
* Can now find new_root at >1 depth,
* Uses m_rootstate history to find moves
* Prints stats if #ifndef NDEBUG
* Supports 100% tree reuse after a single undo


tested with 

    make -j8 debug
    echo -e "time_settings 0 8 1\ngo\ngo\ngo\ngo\nkomi 8\ngo\nclear_board\ngo\nplay white D4\nplay black R4\nplay white D16\ngo\nundo\ngo" | ./leelaz -w ../weights.txt -s 123 -t 1; echo


|command|explanation|output|
|---|---|---|
|go|no tree reuse on first move||
|go||Leela: update_root Q16, 2857321 -> 423165 nodes (14.8% reused)|
|go||Leela: update_root D4, 2724778 -> 936392 nodes (34.4% reused)|
|go||Leela: update_root R4, 2865117 -> 959579 nodes (33.5% reused)|
|komi 8|||
|go|no reuse because of komi changed||
|clear_board|||
|go|no tree reuse because of clearing board||
|play white D4||
|play black R4||
|play white D16||
|go|tree reuse from depth 3(4?)|Leela: update_root Q16 D4 R4 D16, 5833086 -> 26126 nodes (0.4% reused)|
|go||Leela: update_root F3, 4919913 -> 2289485 nodes (46.5% reused)|
|undo|tree is still usable because of not automatically playing move in in think||
|go||Leela: update_root , 4312540 -> 4312540 nodes (100.0% reused)|

