### PR TITLE
add newline on normal exit

### DIFF
--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -306,6 +306,7 @@ int main (int argc, char *argv[]) {
             GTP::execute(*maingame, input);
         } else {
             // eof or other error
+            std::cout << std::endl;
             break;
         }
 


### PR DESCRIPTION
When file input is used with Leela, and leelaz exits normally the prompt ("Leela: ") without a newline will often be the last output. this shifts the bash prompt and if you press up for the last command and that command is longer than one line it will put [bash in a weird state](https://askubuntu.com/a/24422/767394) because it thinks the command should wrap at a different place.

This prints a newline before exiting in some cases

|command|behavior|
|---|---|
| exit | unchanged (no newline) |
| runtime error | unchanged |
| quit | print an extra, unneeded newline |
| pipe | print a newline for "Leela:" line|
| file redirect | print a newline for "Leela:" line|

This does print the extra newline even in GTP mode but I'm assuming a training newline at EXIT isn't going to break anything (I did test sabaki)