### PR TITLE
Use pinned memory for device -> host transfers

### DIFF
--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -386,6 +386,15 @@ void Network::initialize(void) {
                                       batchnorm_stddivs[weight_index + 1]);
             weight_index += 2;
         }
+
+        //Output head convolutions
+        opencl_net->push_convolve1(channels,
+                       OUTPUTS_POLICY,
+                       conv_pol_w);
+
+        opencl_net->push_convolve1(channels,
+                       OUTPUTS_VALUE,
+                       conv_val_w);
     }
 #endif
 #ifdef USE_BLAS
@@ -699,7 +708,8 @@ void batchnorm(size_t channels,
 }
 
 void Network::forward_cpu(std::vector<float>& input,
-                          std::vector<float>& output) {
+                          std::vector<float>& output_pol,
+                          std::vector<float>& output_val) {
     // Input convolution
     constexpr int width = 19;
     constexpr int height = 19;
@@ -744,7 +754,8 @@ void Network::forward_cpu(std::vector<float>& input,
                        batchnorm_stddivs[i + 1].data(),
                        res.data());
     }
-    std::copy(begin(conv_out), end(conv_out), begin(output));
+    convolve<1>(OUTPUTS_POLICY, conv_out, conv_pol_w, conv_pol_b, output_pol);
+    convolve<1>(OUTPUTS_VALUE, conv_out, conv_val_w, conv_val_b, output_val);
 }
 
 template<typename T>
@@ -849,8 +860,8 @@ Network::Netresult Network::get_scored_moves_internal(
     const auto convolve_channels = conv_pol_w.size() / conv_pol_b.size();
     std::vector<net_t> input_data;
     std::vector<net_t> output_data(convolve_channels * width * height);
-    std::vector<float> policy_data(2 * width * height);
-    std::vector<float> value_data(1 * width * height);
+    std::vector<float> policy_data(OUTPUTS_POLICY * width * height);
+    std::vector<float> value_data(OUTPUTS_VALUE * width * height);
     std::vector<float> policy_out((width * height) + 1);
     std::vector<float> softmax_data((width * height) + 1);
     std::vector<float> winrate_data(256);
@@ -866,34 +877,30 @@ Network::Netresult Network::get_scored_moves_internal(
         }
     }
 #ifdef USE_OPENCL
-    opencl.forward(input_data, output_data);
+    opencl.forward(input_data, policy_data, value_data);
 #elif defined(USE_BLAS) && !defined(USE_OPENCL)
-    forward_cpu(input_data, output_data);
+    forward_cpu(input_data, policy_data, value_data);
 #endif
 #ifdef USE_OPENCL_SELFCHECK
     // Both implementations are available, self-check the OpenCL driver by
     // running both with a probability of 1/2000.
     if (Random::get_Rng().randfix<SELFCHECK_PROBABILITY>() == 0) {
-        auto cpu_output_data = std::vector<float>(output_data.size());
-        forward_cpu(input_data, cpu_output_data);
-        compare_net_outputs(output_data, cpu_output_data);
+        auto cpu_policy_data = std::vector<float>(policy_data.size());
+        auto cpu_value_data = std::vector<float>(value_data.size());
+        forward_cpu(input_data, cpu_policy_data, cpu_value_data);
+        compare_net_outputs(policy_data, cpu_policy_data);
+        compare_net_outputs(value_data, cpu_value_data);
     }
 #endif
-    // We calculate both network heads on the CPU. They are irregular
-    // and have a much lower compute densitity than the residual layers,
-    // which means they don't get much - if any - speedup from being on the
-    // GPU. See issue #185.
 
     // Get the moves
-    convolve<1>(2, output_data, conv_pol_w, conv_pol_b, policy_data);
-    batchnorm<361>(2, policy_data, bn_pol_w1.data(), bn_pol_w2.data());
-    innerproduct<2*361, 362>(policy_data, ip_pol_w, ip_pol_b, policy_out);
+    batchnorm<361>(OUTPUTS_POLICY, policy_data, bn_pol_w1.data(), bn_pol_w2.data());
+    innerproduct<OUTPUTS_POLICY*361, 362>(policy_data, ip_pol_w, ip_pol_b, policy_out);
     softmax(policy_out, softmax_data, cfg_softmax_temp);
     std::vector<float>& outputs = softmax_data;
 
     // Now get the score
-    convolve<1>(1, output_data, conv_val_w, conv_val_b, value_data);
-    batchnorm<361>(1, value_data, bn_val_w1.data(), bn_val_w2.data());
+    batchnorm<361>(OUTPUTS_VALUE, value_data, bn_val_w1.data(), bn_val_w2.data());
     innerproduct<361, 256>(value_data, ip1_val_w, ip1_val_b, winrate_data);
     innerproduct<256, 1>(winrate_data, ip2_val_w, ip2_val_b, winrate_out);
 

--- a/src/Network.h
+++ b/src/Network.h
@@ -50,6 +50,8 @@ public:
     static constexpr auto FORMAT_VERSION = 1;
     static constexpr auto INPUT_MOVES = 8;
     static constexpr auto INPUT_CHANNELS = 2 * INPUT_MOVES + 2;
+    static constexpr auto OUTPUTS_POLICY = 2;
+    static constexpr auto OUTPUTS_VALUE = 1;
 
     // Winograd filter transformation changes 3x3 filters to 4x4
     static constexpr auto WINOGRAD_ALPHA = 4;
@@ -97,7 +99,9 @@ private:
       const GameState* state, NNPlanes & planes, int rotation);
 #if defined(USE_BLAS)
     static void forward_cpu(std::vector<float>& input,
-                            std::vector<float>& output);
+                            std::vector<float>& output_pol,
+                            std::vector<float>& output_val);
+
 #endif
 };
 

--- a/src/OpenCL.h
+++ b/src/OpenCL.h
@@ -63,9 +63,9 @@ private:
     cl::Kernel m_out_transform_bn_kernel;
     cl::Kernel m_out_transform_bn_in_kernel;
     cl::Buffer m_inBuffer;
+    cl::Buffer m_inBuffer2;
     cl::Buffer m_VBuffer;
     cl::Buffer m_MBuffer;
-    cl::Buffer m_residualBuffer;
     cl::Buffer m_pinnedOutBuffer_pol;
     cl::Buffer m_pinnedOutBuffer_val;
     bool m_buffers_allocated{false};
@@ -143,7 +143,9 @@ private:
     void add_weights(size_t layer, size_t size, const float* weights);
 
     void convolve3(int channels, int outputs,
-                    cl::Buffer& bufferInOut, cl::Buffer& bufferV,
+                    cl::Buffer& bufferIn,
+                    cl::Buffer& bufferOut,
+                    cl::Buffer& bufferV,
                     cl::Buffer& bufferM, weight_slice_t weights,
                     cl::Buffer* bufferResidual,
                     weight_slice_t bn_weights,

--- a/src/OpenCL.h
+++ b/src/OpenCL.h
@@ -63,6 +63,7 @@ private:
     cl::Buffer m_VBuffer;
     cl::Buffer m_MBuffer;
     cl::Buffer m_residualBuffer;
+    cl::Buffer m_pinnedOutBuffer;
     bool m_buffers_allocated{false};
 };
 
@@ -131,7 +132,8 @@ private:
                     cl::Buffer* bufferResidual,
                     weight_slice_t bn_weights,
                     bool skip_in_transform,
-                    bool fuse_in_transform, bool store_inout);
+                    bool fuse_in_transform, bool store_inout,
+                    bool last=false);
 
     OpenCL & m_opencl;
 

--- a/src/OpenCLScheduler.cpp
+++ b/src/OpenCLScheduler.cpp
@@ -66,14 +66,15 @@ void OpenCLScheduler::initialize(const int channels) {
 }
 
 void OpenCLScheduler::forward(const std::vector<net_t>& input,
-                              std::vector<net_t>& output) {
+                              std::vector<net_t>& output_pol,
+                              std::vector<net_t>& output_val) {
     if (m_networks.size() == 1) {
-        m_networks[0]->forward(input, output);
+        m_networks[0]->forward(input, output_pol, output_val);
         return;
     }
 
-    auto f = m_threadpool.add_task([this, &input, &output]{
-        m_networks[current_thread_gpu_num]->forward(input, output);
+    auto f = m_threadpool.add_task([this, &input, &output_pol, &output_val]{
+        m_networks[current_thread_gpu_num]->forward(input, output_pol, output_val);
     });
 
     f.get();

--- a/src/OpenCLScheduler.h
+++ b/src/OpenCLScheduler.h
@@ -33,7 +33,8 @@ public:
         return m_networks;
     }
     void forward(const std::vector<net_t>& input,
-                 std::vector<net_t>& output);
+                 std::vector<net_t>& output_pol,
+                 std::vector<net_t>& output_val);
 private:
     class ForwardTask {
     public:


### PR DESCRIPTION
Currently getting data out of the GPU is the biggest bottleneck. This transfer can be made faster with pinned (mapped) memory. Just replacing the transfer gives about 6 % performance increase in netbench.

I also moved the 1x1 convolutions of the output heads to GPU to reduce the amount of memory that needs to be moved. That increased performance gain to 15 % compared to the original.

```
Current:
10000 evaluations in 14.40 seconds -> 694 n/s

Pinned memory:
10000 evaluations in 13.48 seconds -> 741 n/s

Pinned memory + OpenCL head convolutions:
10000 evaluations in 12.41 seconds -> 805 n/s
```

It still seems that the memory transfer is limiting the performance. If I comment it out I get `10000 evaluations in 11.47 seconds -> 871 n/s`. Host -> device memory transfer doesn't seem to be as important.