### PR TITLE
Small cleanup to visit counting

### DIFF
--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -56,14 +56,13 @@ public:
     void set_score(float score);
     float get_eval(int tomove) const;
     double get_blackevals() const;
-    void set_visits(int visits);
     void set_blackevals(double blacevals);
     void accumulate_eval(float eval);
     void virtual_loss(void);
     void virtual_loss_undo(void);
     void dirichlet_noise(float epsilon, float alpha);
     void randomize_first_proportionally();
-    void update(float eval = std::numeric_limits<float>::quiet_NaN());
+    void update(float eval);
 
     UCTNode* uct_select_child(int color);
     UCTNode* get_first_child() const;

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -385,6 +385,7 @@ int UCTSearch::think(int color, passflag_t passflag) {
     float root_eval;
     if (!m_root->has_children()) {
         m_root->create_children(m_nodes, m_rootstate, root_eval);
+        m_root->update(root_eval);
     } else {
         root_eval = m_root->get_eval(color);
     }


### PR DESCRIPTION
if `UCTSearch::play_simulation` expands a leaf node it counts it as a visit. 
if the root node is a leaf node it gets expanded in `UCTSearch::think` but isn't counted as a visit.

I unified this by counting the initial "visit" in `UCTSearch::think` which is a much smaller change because it only happens when playouts is TINY or when opponent play weird moves that weren't expected.

After this behavior is unified I'll write a 2nd change ([preliminary draft](https://github.com/sethtroisi/leela-zero/compare/c__tt_cleanup...sethtroisi:c__tt_cleanup_v2)) to not count initial expansion as visits per "Mastering the game of Go" which says "Edge edge traversed in the simulation is updated to increment its visit count" ie leaf nodes have zero visits but this requires updating `get_pv` and `get_best_move`. In the meantime this is accomplished by subtracting 1 from visit counts in `uct_select_node`