### PR TITLE
simplify get_best_move

### DIFF
--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -227,22 +227,17 @@ int UCTSearch::get_best_move(passflag_t passflag) {
     if (passflag & UCTSearch::NOPASS) {
         // were we going to pass?
         if (bestmove == FastBoard::PASS) {
-            UCTNode * nopass = m_root->get_nopass_child(m_rootstate);
-
+            auto nopass = m_root->get_nopass_child(m_rootstate);
             if (nopass != nullptr) {
                 myprintf("Preferring not to pass.\n");
                 bestmove = nopass->get_move();
-                if (nopass->first_visit()) {
-                    bestscore = 1.0f;
-                } else {
-                    bestscore = nopass->get_eval(color);
-                }
+                bestscore = nopass->get_eval(color);
             } else {
                 myprintf("Pass is the only acceptable move.\n");
             }
         }
-    } else {
-        if (!cfg_dumbpass && bestmove == FastBoard::PASS) {
+    } else if (!cfg_dumbpass) {
+        if (bestmove == FastBoard::PASS) {
             // Either by forcing or coincidence passing is
             // on top...check whether passing loses instantly
             // do full count including dead stones.
@@ -268,23 +263,18 @@ int UCTSearch::get_best_move(passflag_t passflag) {
                 (score < 0.0f && color == FastBoard::BLACK)) {
                 myprintf("Passing loses :-(\n");
                 // Find a valid non-pass move.
-                UCTNode * nopass = m_root->get_nopass_child(m_rootstate);
+                auto nopass = m_root->get_nopass_child(m_rootstate);
                 if (nopass != nullptr) {
                     myprintf("Avoiding pass because it loses.\n");
                     bestmove = nopass->get_move();
-                    if (nopass->first_visit()) {
-                        bestscore = 1.0f;
-                    } else {
-                        bestscore = nopass->get_eval(color);
-                    }
+                    bestscore = nopass->get_eval(color);
                 } else {
                     myprintf("No alternative to passing.\n");
                 }
             } else {
                 myprintf("Passing wins :-)\n");
             }
-        } else if (!cfg_dumbpass
-                   && m_rootstate.get_last_move() == FastBoard::PASS) {
+        } else if (m_rootstate.get_last_move() == FastBoard::PASS) {
             // Opponents last move was passing.
             // We didn't consider passing. Should we have and
             // end the game immediately?


### PR DESCRIPTION
use more generic get_eval and removes the only non-debug uses of first_visit.

This code dates back to GitHub inception prior to FPU changes.

This increases the likelyhood of the initial eval of the no_pass child being less than the resign threshold and Leela resigning*, this can already happen if the no_pass child node has visits.

This only changes behavior in the rare case that search spent **all** of its playouts evaluating PASS and the 2nd move had such a low initial eval that it's resign-able. This frequently happens when playouts = 1, less frequently with p = 2, 3, ...

*You might consider preventing Leela from resigning if NO_PASS is set because it only happens in gen_handicap_moves and kgs_cleanup.

**Pros**
*  Doesn't affect self-play (as dumppass is used)
*  Seth's OCD is improved

**Cons**
*  Changes resign likelihood in `kgs_cleanup` command
*  Changes behavior when `playouts = 1` and top move was pass