### PR TITLE
Saving parent_visit in the parent node to optimize uct_select_child

### DIFF
--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -260,11 +260,10 @@ bool UCTNode::has_children() const {
 }
 
 void UCTNode::set_visits(int visits) {
-    m_visits = visits;
     if(m_parent != nullptr) {
-        m_parent->add_parent_visit(visits);
+        m_parent->add_parent_visit(visits - m_visits);
     }
-    
+    m_visits = visits;
 }
 
 float UCTNode::get_score() const {

--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -39,7 +39,7 @@ public:
 
     using node_ptr_t = std::unique_ptr<UCTNode>;
 
-    explicit UCTNode(int vertex, float score, float init_eval);
+    explicit UCTNode(int vertex, float score, float init_eval, UCTNode* parent = nullptr);
     UCTNode() = delete;
     ~UCTNode() = default;
     bool first_visit() const;
@@ -64,6 +64,7 @@ public:
     void dirichlet_noise(float epsilon, float alpha);
     void randomize_first_proportionally();
     void update(float eval = std::numeric_limits<float>::quiet_NaN());
+    void set_null_parent() { m_parent = nullptr; }
 
     UCTNode* uct_select_child(int color);
     UCTNode* get_first_child() const;
@@ -79,6 +80,8 @@ private:
     void link_nodelist(std::atomic<int>& nodecount,
                        std::vector<Network::scored_node>& nodelist,
                        float init_eval);
+    UCTNode* m_parent;
+    void add_parent_visit(int v) { m_parentVisits += v; }
     // Note : This class is very size-sensitive as we are going to create
     // tens of millions of instances of these.  Please put extra caution
     // if you want to add/remove/reorder any variables here.
@@ -88,6 +91,7 @@ private:
     // UCT
     std::atomic<std::int16_t> m_virtual_loss{0};
     std::atomic<int> m_visits{0};
+    std::atomic<int> m_parentVisits{0};
     // UCT eval
     float m_score;
     float m_init_eval;

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -90,7 +90,7 @@ bool UCTSearch::advance_to_new_rootstate() {
         // Can happen if user plays multiple moves in a row by same player
         return false;
     }
-
+    m_root->set_null_parent();
     return true;
 }
 


### PR DESCRIPTION
This commit saves a lot. On my GTX 1050 Ti I go from `2015 ms/move` to `1630 ms/move`. 
The only thing I am not sure, and I ask for your review is what happens on an GTP Undo command.