### PR TITLE
Make use of <random> in Random.cpp + add tests

### DIFF
--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -22,6 +22,7 @@
 #include <climits>
 #include <cstdint>
 #include <thread>
+#include <random>
 
 #include "GTP.h"
 #include "Utils.h"
@@ -57,15 +58,23 @@ std::uint64_t Random::gen(void) {
 }
 
 std::uint16_t Random::randuint16(const uint16_t max) {
-    return ((gen() >> 48) * max) >> 16;
+    std::uniform_int_distribution<uint32_t> dis(0, max);
+    return dis(*this);
 }
 
 std::uint32_t Random::randuint32(const uint32_t max) {
-    return ((gen() >> 32) * (std::uint64_t)max) >> 32;
+    std::uniform_int_distribution<uint32_t> dis(0, max);
+    return dis(*this);
 }
 
-std::uint32_t Random::randuint32() {
-    return gen() >> 32;
+std::uint64_t Random::randuint64(const uint64_t max) {
+    std::uniform_int_distribution<uint64_t> dis(0, max);
+    return dis(*this);
+}
+
+float Random::randflt(void) {
+    std::uniform_real_distribution<> dis(0.0, 1.0);
+    return dis(*this);
 }
 
 std::uint64_t Random::randuint64() {
@@ -87,10 +96,3 @@ void Random::seedrandom(std::uint64_t seed) {
     m_s[1] = splitmix64(m_s[0]);
 }
 
-float Random::randflt(void) {
-    // We need a 23 bit mantissa + implicit 1 bit = 24 bit number
-    // starting from a 64 bit random.
-    constexpr float umax = 1.0f / (UINT32_C(1) << 24);
-    std::uint32_t num = gen() >> 40;
-    return ((float)num) * umax;
-}

--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -57,24 +57,9 @@ std::uint64_t Random::gen(void) {
     return result;
 }
 
-std::uint16_t Random::randuint16(const uint16_t max) {
-    std::uniform_int_distribution<uint32_t> dis(0, max);
-    return dis(*this);
-}
-
-std::uint32_t Random::randuint32(const uint32_t max) {
-    std::uniform_int_distribution<uint32_t> dis(0, max);
-    return dis(*this);
-}
-
 std::uint64_t Random::randuint64(const uint64_t max) {
-    std::uniform_int_distribution<uint64_t> dis(0, max);
-    return dis(*this);
-}
-
-float Random::randflt(void) {
-    std::uniform_real_distribution<> dis(0.0, 1.0);
-    return dis(*this);
+    const uint64_t inclusive_max = max - 1;
+    return std::uniform_int_distribution<uint64_t>{0, inclusive_max}(*this);
 }
 
 std::uint64_t Random::randuint64() {

--- a/src/Random.h
+++ b/src/Random.h
@@ -32,7 +32,7 @@ public:
     Random(std::uint64_t seed = 0);
     void seedrandom(std::uint64_t s);
 
-    // random numbers from 0 to max
+    // Random numbers from [0, max - 1]
     template<int MAX>
     std::uint32_t randfix() {
         static_assert(0 < MAX &&
@@ -44,12 +44,14 @@ public:
         return gen() % MAX;
     }
 
+    // Random number from [0, max]
     std::uint16_t randuint16(const std::uint16_t max);
     std::uint32_t randuint32(const std::uint32_t max);
-    std::uint32_t randuint32();
+    std::uint64_t randuint64(const std::uint64_t max);
+
     std::uint64_t randuint64();
 
-    // random float from 0 to 1
+    // Random float from [0, 1)
     float randflt(void);
 
     // return the thread local RNG

--- a/src/Random.h
+++ b/src/Random.h
@@ -44,15 +44,10 @@ public:
         return gen() % MAX;
     }
 
-    // Random number from [0, max]
-    std::uint16_t randuint16(const std::uint16_t max);
-    std::uint32_t randuint32(const std::uint32_t max);
-    std::uint64_t randuint64(const std::uint64_t max);
-
     std::uint64_t randuint64();
 
-    // Random float from [0, 1)
-    float randflt(void);
+    // Random number from [0, max - 1]
+    std::uint64_t randuint64(const std::uint64_t max);
 
     // return the thread local RNG
     static Random& get_Rng(void);

--- a/src/Tuner.cpp
+++ b/src/Tuner.cpp
@@ -276,7 +276,7 @@ std::string Tuner::tune_sgemm(const int m, const int n, const int k,
         cfgs *= opts[c].second.size();
     }
 
-    // Don't use thead Rng or determism will depend on if tuner.
+    // Don't use thead Rng or determism will depend on if tuner ran.
     auto rng = Random{0};
 
     for (auto i = 0; i < cfgs; i++) {

--- a/src/Tuner.cpp
+++ b/src/Tuner.cpp
@@ -276,14 +276,14 @@ std::string Tuner::tune_sgemm(const int m, const int n, const int k,
         cfgs *= opts[c].second.size();
     }
 
+    // Don't use thead Rng or determism will depend on if tuner.
     auto rng = Random{0};
 
     for (auto i = 0; i < cfgs; i++) {
         Parameters param = get_parameters_by_int(opts, i);
         if (valid_config_sgemm(param, cfg_sgemm_exhaustive)) {
             if (cfg_sgemm_exhaustive) {
-                auto pick = rng.randflt();
-                if (pick > (1.0f / 16.0f)) {
+                if (rng.randfix<16>() != 0) {
                     continue;
                 }
             }

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -208,14 +208,14 @@ void UCTNode::dirichlet_noise(float epsilon, float alpha) {
 }
 
 void UCTNode::randomize_first_proportionally() {
-    auto accum = std::uint32_t{0};
+    auto accum = std::uint64_t{0};
     auto accum_vector = std::vector<decltype(accum)>{};
     for (const auto& child : m_children) {
         accum += child->get_visits();
         accum_vector.emplace_back(accum);
     }
 
-    auto pick = Random::get_Rng().randuint32(accum);
+    auto pick = Random::get_Rng().randuint64(accum);
     auto index = size_t{0};
     for (size_t i = 0; i < accum_vector.size(); i++) {
         if (pick < accum_vector[i]) {

--- a/src/tests/utils_unittest.cpp
+++ b/src/tests/utils_unittest.cpp
@@ -84,53 +84,7 @@ bool rngBucketsLookRandom(double p, double alpha) {
     return p >= (alpha/2) && p <= (1-alpha/2);
 }
 
-TEST(UtilsTest, Randuint16_max) {
-    // 0 causes Random to use thread id.
-    auto rng = std::make_unique<Random>(0);
-
-    auto expected = size_t{40};
-    auto max = std::numeric_limits<std::uint16_t>::max();
-    auto count = std::vector<short>(max + 1, 0);
-    for (auto i = size_t{0}; i < expected * max; i++) {
-        count[rng->randuint16(max)]++;
-    }
-
-    auto p = randomlyDistributedProbability(count, expected);
-    EXPECT_PRED2(rngBucketsLookRandom, p, ALPHA);
-}
-
-TEST(UtilsTest, Randuint16_small) {
-    // Using seed = 0 results in pseudo-random seed.
-    auto rng = std::make_unique<Random>(0);
-
-    auto expected = size_t{40};
-    auto max = std::uint16_t{100};
-    auto count = std::vector<short>(max + 1, 0);
-    for (auto i = size_t{0}; i < expected * max; i++) {
-        count[rng->randuint16(max)]++;
-    }
-
-    auto p = randomlyDistributedProbability(count, expected);
-    EXPECT_PRED2(rngBucketsLookRandom, p, ALPHA);
-}
-
-TEST(UtilsTest, Randuint64_partial) {
-    // Using seed = 0 results in pseudo-random seed.
-    auto rng = std::make_unique<Random>(0);
-
-    auto expected = size_t{40};
-    // Verify last 8 bits are random.
-    auto max = std::uint16_t{127};
-    auto count = std::vector<short>(max + 1, 0);
-    for (auto i = size_t{0}; i < expected * max; i++) {
-        count[rng->randuint64(max) & 127]++;
-    }
-
-    auto p = randomlyDistributedProbability(count, expected);
-    EXPECT_PRED2(rngBucketsLookRandom, p, ALPHA);
-}
-
-TEST(UtilsTest, Randflt) {
+TEST(UtilsTest, RandFix) {
     // Using seed = 0 results in pseudo-random seed.
     auto rng = std::make_unique<Random>(0);
 
@@ -138,7 +92,38 @@ TEST(UtilsTest, Randflt) {
     auto max = std::uint16_t{200};
     auto count = std::vector<short>(max, 0);
     for (auto i = size_t{0}; i < expected * max; i++) {
-        count[int(max * rng->randflt())]++;
+        count[rng->randfix<200>()]++;
+    }
+
+    auto p = randomlyDistributedProbability(count, expected);
+    EXPECT_PRED2(rngBucketsLookRandom, p, ALPHA);
+}
+
+TEST(UtilsTest, Randuint64_lastEightBits) {
+    // Using seed = 0 results in pseudo-random seed.
+    auto rng = std::make_unique<Random>(0);
+
+    auto expected = size_t{40};
+    // Verify last 8 bits are random.
+    auto max = std::uint16_t{128};
+    auto count = std::vector<short>(max, 0);
+    for (auto i = size_t{0}; i < expected * max; i++) {
+        count[rng->randuint64() & 127]++;
+    }
+
+    auto p = randomlyDistributedProbability(count, expected);
+    EXPECT_PRED2(rngBucketsLookRandom, p, ALPHA);
+}
+
+TEST(UtilsTest, Randuint64_max) {
+    // Using seed = 0 results in pseudo-random seed.
+    auto rng = std::make_unique<Random>(0);
+
+    auto expected = size_t{40};
+    auto max = std::uint64_t{100};
+    auto count = std::vector<short>(max, 0);
+    for (auto i = size_t{0}; i < expected * max; i++) {
+        count[rng->randuint64(max)]++;
     }
 
     auto p = randomlyDistributedProbability(count, expected);

--- a/src/tests/utils_unittest.cpp
+++ b/src/tests/utils_unittest.cpp
@@ -1,6 +1,7 @@
 /*
     This file is part of Leela Zero.
     Copyright (C) 2018 Gian-Carlo Pascutto
+    Copyright (C) 2018 Seth Troisi
 
     Leela Zero is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,8 +16,15 @@
     You should have received a copy of the GNU General Public License
     along with Leela Zero.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <gtest/gtest.h>
 
+#include <boost/math/distributions/chi_squared.hpp>
+#include <cstddef>
+#include <gtest/gtest.h>
+#include <limits>
+#include <vector>
+
+
+#include "Random.h"
 #include "Utils.h"
 
 using namespace Utils;
@@ -42,4 +50,104 @@ TEST(UtilsTest, CeilMultiple) {
     EXPECT_EQ(ceilMultiple(9, 5), (size_t)10);
     EXPECT_EQ(ceilMultiple(23, 5), (size_t)25);
     EXPECT_EQ(ceilMultiple(99, 100), (size_t)100);
+}
+
+bool NotRejectNull(double p, double alpha) {
+    return p >= (alpha/2) && p <= (1-alpha/2);
+}
+
+double randomlyDistributedProbability(std::vector<short> values, double expected) {
+    auto count = values.size();
+
+    // h0: each number had a (1 / count) chance
+    // Chi-square test that each bucket is a randomly distributed count
+
+    // Variance of getting <v> at each iteration is Var[Bernoulli(1/count)]
+    auto varIter = 1.0 / count - 1.0 / (count * count);
+    // All rng are supposedly independant
+    auto variance = count * expected * varIter;
+
+    auto x = 0.0;
+    for (const auto& observed : values) {
+        auto error = observed - expected;
+        auto t = (error * error) / variance;
+        x += t;
+    }
+
+    auto degrees_of_freedom = count - 1;
+    // test statistic of cdf(chi_squared_distribution(count - 1), q);
+    return boost::math::gamma_p(degrees_of_freedom / 2.0, x / 2.0);
+}
+
+TEST(UtilsTest, Randuint16_max) {
+    // 0 causes Random to use thread id.
+    auto rng = std::make_unique<Random>(0);
+
+    auto expected = size_t{40};
+    auto max = std::numeric_limits<std::uint16_t>::max();
+    auto count = std::vector<short>(max + 1, 0);
+    for (auto i = size_t{0}; i < expected * max; i++) {
+        count[rng->randuint16(max)]++;
+    }
+
+    auto p = randomlyDistributedProbability(count, expected);
+
+    // Test should fail this often from distribution not looking uniform.
+    auto alpha = 0.0001;
+    EXPECT_PRED2(NotRejectNull, p, alpha);
+}
+
+TEST(UtilsTest, Randuint16_small) {
+    // Using seed = 0 results in pseudo-random seed.
+    auto rng = std::make_unique<Random>(0);
+
+    auto expected = size_t{40};
+    auto max = std::uint16_t{100};
+    auto count = std::vector<short>(max + 1, 0);
+    for (auto i = size_t{0}; i < expected * max; i++) {
+        count[rng->randuint16(max)]++;
+    }
+
+    auto p = randomlyDistributedProbability(count, expected);
+
+    // Test should fail this often from distribution not looking uniform.
+    auto alpha = 0.0001;
+    EXPECT_PRED2(NotRejectNull, p, alpha);
+}
+
+TEST(UtilsTest, Randuint64_partial) {
+    // Using seed = 0 results in pseudo-random seed.
+    auto rng = std::make_unique<Random>(0);
+
+    auto expected = size_t{40};
+    // Verify last 8 bits are random.
+    auto max = std::uint16_t{127};
+    auto count = std::vector<short>(max + 1, 0);
+    for (auto i = size_t{0}; i < expected * max; i++) {
+        count[rng->randuint64(max) & 127]++;
+    }
+
+    auto p = randomlyDistributedProbability(count, expected);
+
+    // Test should fail this often from distribution not looking uniform.
+    auto alpha = 0.0001;
+    EXPECT_PRED2(NotRejectNull, p, alpha);
+}
+
+TEST(UtilsTest, Randflt) {
+    // Using seed = 0 results in pseudo-random seed.
+    auto rng = std::make_unique<Random>(0);
+
+    auto expected = size_t{40};
+    auto max = std::uint16_t{200};
+    auto count = std::vector<short>(max, 0);
+    for (auto i = size_t{0}; i < expected * max; i++) {
+        count[int(max * rng->randflt())]++;
+    }
+
+    auto p = randomlyDistributedProbability(count, expected);
+
+    // Test should fail this often from distribution not looking uniform.
+    auto alpha = 0.0001;
+    EXPECT_PRED2(NotRejectNull, p, alpha);
 }


### PR DESCRIPTION
None of has real impact (assuming this doesn't break things) because PRNG is good enough for all our uses (Zobrist and sampling)

* Added comments about inclusive vs exclusive
* `uniform_int_distribution` better handles the one arg case.
`randuint16_t(60000)` was twice as likely to choose some numbers (0, 10, 21, 32, ...) as others.
* Replaced the only use of randflt with randfix

News tests can probabilistic fail (they choose a random seed).

**Pros**

* The failure rate is very low (4 in 10,000 theoretically and ~1 in 1,300 in practice).
* Helps detect bad PRNG
* Avoids the problem where everything is a mock and nothing is actually tested

**Cons**

* Possible that if PRNG is bad it will fail rarely but often enough to cause confusion

---

**Testing**

No impact on performance
```
leelaz-next-feb-05 v leelaz-random (34/200 games)
board size: 19   komi: 7.5
                     wins              black         white       avg cpu
leelaz-next-feb-05     16 47.06%       7  41.18%     9  52.94%     10.72
leelaz-random          18 52.94%       8  47.06%     10 58.82%     10.67
                                       15 44.12%     19 55.88%
```

Failure rate is < 1 in 1000
`i=0; while [ $? -eq 0 ]; do ./tests --gtest_filter=UtilsTest.* && echo "$((i++))"; done`