### PR TITLE
modify fpu reduction depending on visited policy

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -86,7 +86,7 @@ void GTP::setup_default_parameters() {
 #endif
     cfg_puct = 0.8f;
     cfg_softmax_temp = 1.0f;
-    cfg_fpu_reduction = 0.22f;
+    cfg_fpu_reduction = 0.25f;
     // see UCTSearch::should_resign
     cfg_resignpct = -1;
     cfg_noise = false;


### PR DESCRIPTION
This is a fpu reduction method that seems like it is as strong as parent's net_eval for weak network while being as strong as flat fpu reduction of 0.22 for strong networks.