### PR TITLE
Replace fpu reduction with best child eval

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,3 +26,5 @@ cheshirecats
 gaieepo
 zediir
 Пахотин Иван
+
+Google LLC  # Please keep.

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -64,7 +64,6 @@ bool cfg_tune_only;
 #endif
 float cfg_puct;
 float cfg_softmax_temp;
-float cfg_fpu_reduction;
 std::string cfg_weightsfile;
 std::string cfg_logfile;
 FILE* cfg_logfile_handle;
@@ -86,7 +85,6 @@ void GTP::setup_default_parameters() {
 #endif
     cfg_puct = 0.8f;
     cfg_softmax_temp = 1.0f;
-    cfg_fpu_reduction = 0.22f;
     // see UCTSearch::should_resign
     cfg_resignpct = -1;
     cfg_noise = false;

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -47,7 +47,6 @@ extern bool cfg_tune_only;
 #endif
 extern float cfg_puct;
 extern float cfg_softmax_temp;
-extern float cfg_fpu_reduction;
 extern std::string cfg_logfile;
 extern std::string cfg_weightsfile;
 extern FILE* cfg_logfile_handle;

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -91,7 +91,6 @@ static void parse_commandline(int argc, char *argv[]) {
 #ifdef USE_TUNER
         ("puct", po::value<float>())
         ("softmax_temp", po::value<float>())
-        ("fpu_reduction", po::value<float>())
 #endif
         ;
     // These won't be shown, we use them to catch incorrect usage of the
@@ -142,9 +141,6 @@ static void parse_commandline(int argc, char *argv[]) {
     }
     if (vm.count("softmax_temp")) {
         cfg_softmax_temp = vm["softmax_temp"].as<float>();
-    }
-    if (vm.count("fpu_reduction")) {
-        cfg_fpu_reduction = vm["fpu_reduction"].as<float>();
     }
 #endif
 


### PR DESCRIPTION
* Use minimum of best visited child's eval and parent eval when a node
has not been visited.
* Update AUTHORS (to be compliant with my company policy which allows me to contribute).
* Based on @Eddh's totalvp work in #827.