### PR TITLE
Fix debug data chunking

### DIFF
--- a/src/Training.cpp
+++ b/src/Training.cpp
@@ -269,11 +269,12 @@ void Training::dump_debug(const std::string& filename) {
 }
 
 void Training::dump_debug(OutputChunker& outchunk) {
+    auto debug_str = std::string{};
     {
         auto out = std::stringstream{};
         out << "2" << std::endl; // File format version
         out << cfg_resignpct << " " << cfg_weightsfile << std::endl;
-        outchunk.append(out.str());
+        debug_str.append(out.str());
     }
     for (const auto& step : m_data) {
         auto out = std::stringstream{};
@@ -281,8 +282,9 @@ void Training::dump_debug(OutputChunker& outchunk) {
             << " " << step.root_uct_winrate
             << " " << step.child_uct_winrate
             << " " << step.bestmove_visits << std::endl;
-        outchunk.append(out.str());
+        debug_str.append(out.str());
     }
+    outchunk.append(debug_str);
 }
 
 void Training::process_game(GameState& state, size_t& train_pos, int who_won,


### PR DESCRIPTION
In validation set change CHUNK_SIZE was decreased to 32 causing the debug data to be split in many chunks since it called `OutputChunker.append` for each line. This change adds temporary string variable so that append is only called once.