### PR TITLE
Turn off TimeManagement only for initial random moves

### DIFF
--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -66,7 +66,7 @@ static void parse_commandline(int argc, char *argv[]) {
                      "Weaken engine by limiting the number of visits.")
         ("timemanage", po::value<std::string>()->default_value("auto"),
                        "[auto|on|off] Enable extra time management features.\n"
-                       "auto = off when using -m, otherwise on")
+                       "auto = off for early random moves, otherwise on")
         ("lagbuffer,b", po::value<int>()->default_value(cfg_lagbuffer_cs),
                         "Safety margin for time usage in centiseconds.")
         ("resignpct,r", po::value<int>()->default_value(cfg_resignpct),
@@ -230,10 +230,6 @@ static void parse_commandline(int argc, char *argv[]) {
             myprintf("Invalid timemanage value.\n");
             exit(EXIT_FAILURE);
         }
-    }
-    if (cfg_timemanage == TimeManagement::AUTO) {
-        cfg_timemanage =
-            cfg_random_cnt ? TimeManagement::OFF : TimeManagement::ON;
     }
 
     if (vm.count("lagbuffer")) {

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -416,7 +416,9 @@ bool UCTSearch::stop_thinking(int elapsed_centis, int time_for_move) const {
                 || visits >= m_maxvisits
                 || elapsed_centis >= time_for_move;
 
-    if (stop || cfg_timemanage == TimeManagement::OFF) {
+    auto movenum = static_cast<int>(m_rootstate.get_movenum());
+    if (stop || cfg_timemanage == TimeManagement::OFF
+        || (cfg_timemanage == TimeManagement::AUTO && movenum < cfg_random_cnt)) {
         return stop;
     }
 


### PR DESCRIPTION
Instead of tuning off time management completely for self play, those can gain the benefits of stopping early when there's a dominant best move.