### PR TITLE
Small Timemanage fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ source and remove the line that says "#define USE_OPENCL".
     Double-click the leela-zero2015.sln or leela-zero2017.sln corresponding
     to the Visual Studio version you have.
     # Build from Visual Studio 2015 or 2017
-    # Download and extract <https://sjeng.org/zero/best_v1.txt.zip> to msvc/x64/Release
-    # msvc/x64/Release/leela-zero --weights weights.txt
+    # Download and extract <https://sjeng.org/zero/best_v1.txt.zip> to msvc\x64\Release
+    msvc\x64\Release\leelaz.exe --weights weights.txt
 
 ## Example of compiling and running - CMake (macOS/Ubuntu)
 

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -460,7 +460,7 @@ void UCTWorker::operator()() {
         if (result.valid()) {
             m_search->increment_playouts();
         }
-    } while(m_search->is_running() && !m_search->stop_thinking());
+    } while(m_search->is_running());
 }
 
 void UCTSearch::increment_playouts() {

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -436,7 +436,9 @@ bool UCTSearch::stop_thinking(int elapsed_centis, int time_for_move) const {
     if ((m_maxplayouts - playouts < Nfirst - Nsecond)
         || (m_maxvisits - visits < Nfirst - Nsecond)) {
         stop = true;
-    } else if (elapsed_centis > 0) {
+    } else if (elapsed_centis > 100 && playouts > 100) {
+        // Wait for at least 1 second and 100 playouts
+        // so we get a reliable playout_rate.
         auto playout_rate = 1.0f * playouts / elapsed_centis;
         auto time_left = time_for_move - elapsed_centis;
         auto est_playouts_left = playout_rate * time_left;


### PR DESCRIPTION
Wait for at least 1 second and 100 playouts so we get a reliable playout_rate.

roy7 saw this on his machine. Most moves he gets over 2000n/s. But on the very first playout the measured average is much lower. This fix adds a minimum time and playout count so we have a reliable average playout_rate to work with.

Example of the problem: http://termbin.com/9zrg
After only 1st playout it measured 33n/s instead of 2000n/s, and triggered the stop.
```
Thinking at most 25.0 seconds...
NN eval=0.492506
25.0s left
Stopping early.

 G14 ->    1483 (V: 51.69%) (N: 44.95%) PV: G14 H11 J13 K13 J18 H18 K17 J16 H17 J19 K18 G17 H16 H15 G16 G15 F16 F14 J15 K15 F15
 H11 ->     211 (V: 50.01%) (N:  8.07%) PV: H11 G14 H14 G15 F14 H10 G10 F11 H9 H12 H13

1996 visits, 359952 nodes, 1 playouts, 33 n/s

= G14
```
