### PR TITLE
Use parent evaluation instead of m_init_eval.

### DIFF
--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -39,7 +39,7 @@ public:
 
     using node_ptr_t = std::unique_ptr<UCTNode>;
 
-    explicit UCTNode(int vertex, float score, float init_eval);
+    explicit UCTNode(int vertex, float score);
     UCTNode() = delete;
     ~UCTNode() = default;
     bool first_visit() const;
@@ -57,7 +57,6 @@ public:
     float get_eval(int tomove) const;
     double get_blackevals() const;
     void set_visits(int visits);
-    void set_blackevals(double blacevals);
     void accumulate_eval(float eval);
     void virtual_loss(void);
     void virtual_loss_undo(void);
@@ -76,9 +75,9 @@ public:
     SMP::Mutex& get_mutex();
 
 private:
+    float get_pure_eval(int tomove) const;
     void link_nodelist(std::atomic<int>& nodecount,
-                       std::vector<Network::scored_node>& nodelist,
-                       float init_eval);
+                       std::vector<Network::scored_node>& nodelist);
     // Note : This class is very size-sensitive as we are going to create
     // tens of millions of instances of these.  Please put extra caution
     // if you want to add/remove/reorder any variables here.
@@ -90,7 +89,6 @@ private:
     std::atomic<int> m_visits{0};
     // UCT eval
     float m_score;
-    float m_init_eval;
     std::atomic<double> m_blackevals{0};
     // node alive (not superko)
     std::atomic<bool> m_valid{true};

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -42,7 +42,7 @@ UCTSearch::UCTSearch(GameState& g)
     : m_rootstate(g) {
     set_playout_limit(cfg_max_playouts);
     set_visit_limit(cfg_max_visits);
-    m_root = std::make_unique<UCTNode>(FastBoard::PASS, 0.0f, 0.5f);
+    m_root = std::make_unique<UCTNode>(FastBoard::PASS, 0.0f);
 }
 
 bool UCTSearch::advance_to_new_rootstate() {
@@ -104,7 +104,7 @@ void UCTSearch::update_root() {
 #endif
 
     if (!advance_to_new_rootstate() || !m_root) {
-        m_root = std::make_unique<UCTNode>(FastBoard::PASS, 0.0f, 0.5f);
+        m_root = std::make_unique<UCTNode>(FastBoard::PASS, 0.0f);
     }
     // Clear last_rootstate to prevent accidental use.
     m_last_rootstate.reset(nullptr);
@@ -488,6 +488,7 @@ int UCTSearch::think(int color, passflag_t passflag) {
     float root_eval;
     if (!m_root->has_children()) {
         m_root->create_children(m_nodes, m_rootstate, root_eval);
+        m_root->update(root_eval);
     } else {
         root_eval = m_root->get_eval(color);
     }


### PR DESCRIPTION
Instead of storing the original parent eval in all the child nodes, get
the current parent evaluation during node selection.