### PR TITLE
change UCT numerator to double

### DIFF
--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -322,7 +322,7 @@ UCTNode* UCTNode::uct_select_child(int color) {
         }
     }
 
-    auto numerator = static_cast<float>(std::sqrt((double)parentvisits));
+    auto numerator = std::sqrt((double)parentvisits);
     auto fpu_reduction = cfg_fpu_reduction * std::sqrt(total_visited_policy);
 
     for (const auto& child : m_children) {


### PR DESCRIPTION
on line 344 `value == best_value` (for the node that's ultimately selected) about 1 in every 500 playouts.
This means that 1 in 1000 playouts play_simulation explores the 2nd best child.

With the change `puct` and `value` are now doubles and at 100,000 playouts I see no identical `best_value` (if you want to test this you can look at [this branch](https://github.com/gcp/leela-zero/compare/next...sethtroisi:v__uct_work_debug?expand=1)

**pros**
*  More correctly evaluates UCT value
*  Fixes 1 in 1000 exploration of 2nd best child
*  Makes `uct_select_child` not dependent on internal sort order

**cons**
*  double calculation is slightly more expensive (In testing this is <0.5%)
*  2nd best child is very close to 1st best child so eval isn't wasted just not technically correct

-----

**Testing**

``` (400 playouts on 1080TI)
leelaz-next v leelaz-double (96/200 games)
board size: 19   komi: 7.5
                wins              black         white       avg cpu
leelaz-next       46 47.92%       24 50.00%     22 45.83%     16.54
leelaz-double     50 52.08%       26 54.17%     24 50.00%     16.48
                                  50 52.08%     46 47.92%
```
``` (400 playouts on slow GPU)
leelaz-next v leelaz-double (41/200 games)
board size: 19   komi: 7.5
                wins              black         white       avg cpu
leelaz-next       22 53.66%       11 52.38%     11 55.00%     27.00
leelaz-double     19 46.34%       9  45.00%     10 47.62%     27.18
                                  20 48.78%     21 51.22%
```

Proof problem exists
```
D4 score: 0.288220, winrate: 0.502505, visits: 327
D16 score: 0.234812, winrate: 0.502314, visits: 264
```
scores matches the heatmap of 
`echo -e "time_settings 0 1 0\nplay black q16\nheatmap 3" | ./leelaz  -w weights --noponder -m0 -t1 -s1 --timemanage off -g -p10000`
