### PR TITLE
Reduce the memory consumption of nodes v2

### DIFF
--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -43,7 +43,8 @@ public:
     ~UCTNode() = default;
     bool first_visit() const;
     bool has_children() const;
-    bool create_children(std::atomic<int>& score_count, GameState& state, float& eval);
+    bool create_children(std::atomic<int>& score_count,
+                         GameState& state, float& eval);
     float eval_state(GameState& state);
     void kill_superkos(const KoState& state);
     void invalidate();
@@ -63,7 +64,7 @@ public:
     void update(float eval);
 
     UCTNode* uct_select_child(int color);
-    UCTNode* get_first_child() const;
+    UCTNode* get_first_child();
     UCTNode* get_nopass_child(FastState& state);
     const std::vector<node_ptr_t>& get_children() const;
     size_t count_nodes() const;
@@ -73,12 +74,12 @@ public:
     UCTNode& get_best_root_child(int color);
     SMP::Mutex& get_mutex();
 
-    // Expand out all child nodes.
+    // Expand out all child_scores.
     void expand_all();
 
 private:
     UCTNode* expand(size_t child);
-    size_t best_child();
+    size_t best_child_score();
 
     // Note : This class is very size-sensitive as we are going to create
     // tens of millions of instances of these.  Please put extra caution

--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -43,8 +43,7 @@ public:
     ~UCTNode() = default;
     bool first_visit() const;
     bool has_children() const;
-    bool create_children(std::atomic<int>& nodecount,
-                         GameState& state, float& eval);
+    bool create_children(std::atomic<int>& score_count, GameState& state, float& eval);
     float eval_state(GameState& state);
     void kill_superkos(const KoState& state);
     void invalidate();
@@ -65,17 +64,22 @@ public:
 
     UCTNode* uct_select_child(int color);
     UCTNode* get_first_child() const;
-    UCTNode* get_nopass_child(FastState& state) const;
+    UCTNode* get_nopass_child(FastState& state);
     const std::vector<node_ptr_t>& get_children() const;
     size_t count_nodes() const;
+    size_t count_scores() const;
     node_ptr_t find_child(const int move);
     void sort_children(int color);
     UCTNode& get_best_root_child(int color);
     SMP::Mutex& get_mutex();
 
+    // Expand out all child nodes.
+    void expand_all();
+
 private:
-    void link_nodelist(std::atomic<int>& nodecount,
-                       std::vector<Network::scored_node>& nodelist);
+    UCTNode* expand(size_t child);
+    size_t best_child();
+
     // Note : This class is very size-sensitive as we are going to create
     // tens of millions of instances of these.  Please put extra caution
     // if you want to add/remove/reorder any variables here.
@@ -98,7 +102,10 @@ private:
 
     // Tree data
     std::atomic<bool> m_has_children{false};
-    std::vector<node_ptr_t> m_children;
+    // (move, score) pairs.
+    std::vector<std::pair<int16_t, float>> m_child_scores;
+    // pointers to expanded nodes.
+    std::vector<node_ptr_t> m_expanded;
 };
 
 #endif

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -181,7 +181,7 @@ void UCTSearch::dump_stats(KoState & state, UCTNode & parent) {
     }
 
     if (parent.get_children().size() < 2) {
-        // There's a small change only one child has been expanded and debug
+        // There's a small chance only one child has been expanded and debug
         // below would print 0 or 1 children. this should only rarely happen
         // and a small number of extra expand_alls is fine.
         parent.expand_all();

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -100,7 +100,7 @@ void UCTSearch::update_root() {
     m_playouts = 0;
 
 #ifndef NDEBUG
-    auto start_nodes = m_root->count_nodes();
+    auto start_nodes = m_root->count_nodes() + m_root->count_scores();
 #endif
 
     if (!advance_to_new_rootstate() || !m_root) {
@@ -110,7 +110,7 @@ void UCTSearch::update_root() {
     m_last_rootstate.reset(nullptr);
 
     // Check how big our search tree (reused or new) is.
-    m_nodes = m_root->count_nodes();
+    m_nodes = m_root->count_nodes() + m_root->count_scores();
 
 #ifndef NDEBUG
     if (m_nodes > 0) {
@@ -175,10 +175,17 @@ void UCTSearch::dump_stats(KoState & state, UCTNode & parent) {
 
     // sort children, put best move on top
     parent.sort_children(color);
-
-
-    if (parent.get_first_child()->first_visit()) {
+    auto first_child = parent.get_first_child();
+    if (first_child == nullptr || first_child->first_visit()) {
         return;
+    }
+
+    if (parent.get_children().size() < 2) {
+        // There's a small change only one child has been expanded and debug
+        // below would print 0 or 1 children. this should only rarely happen
+        // and a small number of extra expand_alls is fine.
+        parent.expand_all();
+        parent.sort_children(color);
     }
 
     int movecount = 0;
@@ -264,7 +271,8 @@ bool UCTSearch::should_resign(passflag_t passflag, float bestscore) {
 int UCTSearch::get_best_move(passflag_t passflag) {
     int color = m_rootstate.board.get_to_move();
 
-    // Make sure best is first
+    // Expand all and sort for simplicity.
+    m_root->expand_all();
     m_root->sort_children(color);
 
     // Check whether to randomize the best move proportional
@@ -483,8 +491,6 @@ int UCTSearch::think(int color, passflag_t passflag) {
 
     myprintf("Thinking at most %.1f seconds...\n", time_for_move/100.0f);
 
-    // create a sorted list off legal moves (make sure we
-    // play something legal and decent even in time trouble)
     float root_eval;
     if (!m_root->has_children()) {
         m_root->create_children(m_nodes, m_rootstate, root_eval);
@@ -492,7 +498,11 @@ int UCTSearch::think(int color, passflag_t passflag) {
     } else {
         root_eval = m_root->get_eval(color);
     }
+
+    // Expanding all nodes and removing superkos in root removes many edge cases
+    m_root->expand_all();
     m_root->kill_superkos(m_rootstate);
+
     if (cfg_noise) {
         m_root->dirichlet_noise(0.25f, 0.03f);
     }
@@ -547,10 +557,11 @@ int UCTSearch::think(int color, passflag_t passflag) {
     Time elapsed;
     int elapsed_centis = Time::timediff_centis(start, elapsed);
     if (elapsed_centis+1 > 0) {
-        myprintf("%d visits, %d nodes, %d playouts, %d n/s\n\n",
+        myprintf("%d visits, %d nodes (%d scores), %d playouts, %d n/s\n\n",
                  m_root->get_visits(),
-                 static_cast<int>(m_nodes),
-                 static_cast<int>(m_playouts),
+                 m_root->count_nodes(),
+                 m_root->count_scores(),
+                 m_playouts.load(),
                  (m_playouts * 100) / (elapsed_centis+1));
     }
     int bestmove = get_best_move(passflag);

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -102,6 +102,7 @@ private:
     GameState & m_rootstate;
     std::unique_ptr<GameState> m_last_rootstate;
     std::unique_ptr<UCTNode> m_root;
+    // Approximate number of nodes + unexpanded scores
     std::atomic<int> m_nodes{0};
     std::atomic<int> m_playouts{0};
     std::atomic<bool> m_run{false};


### PR DESCRIPTION
Status: **Fixing problems with get_children()**

This is an updated version of @ywrt  https://github.com/gcp/leela-zero/pull/574

The core idea is to only create `UCTNode` children nodes (which cost ~60 bytes of memory) for the root node and just before they are used in `play_simulation` otherwise children (a move and a score) are stored in a `vector<pair<float, short>>` of their parent (~6 bytes).

**Results**
* **66%** reduction in memory (From ~60 Bytes to ~20 Bytes) 
* increase in max_tree_size from **100 to 300 million positions** (allowing for closer to 1M playouts per position, maybe ~500K with tree reuse)
* **+6-12% speed**, measured with --benchmark -p 25000 on three machines

This change adds more complexity to UCTNode (having to lock the mutex in a many more methods, having `expand` calls mixed in with uct_select_child). As UCTNode becomes more complex the risk of low frequency rarely seen threading bugs increases. After this is checked in I promise to do a pass through UCTSearch and UCTNode and see if I can reduce the complexity and number of methods

----
**Testing** all tests performed in both debug and normal build

**--benchmark** matches for several thousand but then diverges because of network eval.
`./leelaz -w weights --noponder --benchmark -p 2323`

Hand inspected the first `uct_select_child` instance that don't match with both gpu and cpu paths, difference is in 5th sig fig of winrate calculation

0.519917 = 0.503896 + 0.234812, 564 D16
0.519903 = 0.503882 + 0.234812, 564 D16

**--benchmark** with -p 10000 and -p 100,000 to verify memory usage

	Command being timed: "./leelaz -w weights --noponder --benchmark -p 10000"
	Maximum resident set size (kbytes): 178920
        vs
	Maximum resident set size (kbytes): 388100
        and
	Maximum resident set size (kbytes): 612792
        vs
	Maximum resident set size (kbytes): 2686648


**low playouts**
`(yes "go" | head -n 60) | ./leelaz -w weights -s1 -t1 --noponder -p {1,2,5,10,20}`
Hash and Ko-Hash match for all playouts
(this discovered https://github.com/gcp/leela-zero/pull/948)

**Ringmaster** with 0fb68ccf (400 playouts)
```
leelaz-next v leelaz-small-node (200/200 games)
board size: 19   komi: 7.5
                    wins              black          white       avg cpu
leelaz-next          101 50.50%       56  56.00%     45 45.00%     11.36
leelaz-small-node     99 49.50%       55  55.00%     44 44.00%     10.81
                                      111 55.50%     89 44.50%
```

**Ringmaster** with weights.txt (400 playouts)
```
leelaz-next v leelaz-small-node (200/200 games)
board size: 19   komi: 7.5
                    wins              black          white       avg cpu
leelaz-next          101 50.50%       55  55.00%     46 46.00%     13.50
leelaz-small-node     99 49.50%       54  54.00%     45 45.00%     12.81
                                      109 54.50%     91 45.50%
```

**Ringmaster** with weights.txt  (800 playouts on debug with -t4)
```
leelaz-next v leelaz-small-node (400/400 games)
board size: 19   komi: 7.5
                    wins              black          white        avg cpu
leelaz-next          202 50.50%       115 57.50%     87  43.50%     36.06
leelaz-small-node    198 49.50%       113 56.50%     85  42.50%     36.12
                                      228 57.00%     172 43.00%
```

Ringmaster had two failures earlier, I found a possible race condition with an assert and fixed that. I tested 600 more games with ringmaster and separately tested with gdb for 10 hours with no failures.

----
**Backup**

Edges (https://github.com/gcp/leela-zero/pull/878) theoretically requires 30% of original memory and in practice requires 60% of the old memory.

Unexpanded theoretically requires 15% of original memory and in practice requires 30% BUT comes at the cost of more complexity in `uct_select_child` and `UCTSearch` (having to call expand_child in a couple of extra places)

I believe the "practical limits" for playouts (on my UNIX 16 gigs machine) are
Next ~200K playouts
Edges ~300K playouts
Unexpanded ~1500K playouts

IMHO none of this really matters for self-play only for people who want to run large number of playouts.

|playouts|leelaz-next|leelaz-edges|leelaz-unexpanded|
|:---|---:|---:|---:|
|5,000|253144|199096|148932|
|50,000|1409680|874620|369920|
|250,000|6291676|3630720|1070976|

None of this has a notable impact on speed on either my fast GPU or slow GPU

----

**Peculiarities**
Currently `uct_select_child` depends on m_children sort order more than IMHO it should which makes verifying this is a no-op slightly harder. If you want to test

add to uct_select_child on line ~343 
```    if (parentvisits == 0) {
        // sort by score.
        parentvisits = 1;
    }
```