### PR TITLE
Simplify m_init_eval to m_net_eval

### DIFF
--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -38,7 +38,7 @@ public:
 
     using node_ptr_t = std::unique_ptr<UCTNode>;
 
-    explicit UCTNode(int vertex, float score, float init_eval);
+    explicit UCTNode(int vertex, float score);
     UCTNode() = delete;
     ~UCTNode() = default;
     bool first_visit() const;
@@ -54,6 +54,7 @@ public:
     float get_score() const;
     void set_score(float score);
     float get_eval(int tomove) const;
+    float get_net_eval(int tomove) const;
     double get_blackevals() const;
     void accumulate_eval(float eval);
     void virtual_loss(void);
@@ -74,8 +75,7 @@ public:
 
 private:
     void link_nodelist(std::atomic<int>& nodecount,
-                       std::vector<Network::scored_node>& nodelist,
-                       float init_eval);
+                       std::vector<Network::scored_node>& nodelist);
     // Note : This class is very size-sensitive as we are going to create
     // tens of millions of instances of these.  Please put extra caution
     // if you want to add/remove/reorder any variables here.
@@ -87,7 +87,7 @@ private:
     std::atomic<int> m_visits{0};
     // UCT eval
     float m_score;
-    float m_init_eval;
+    float m_net_eval{0};  // Original net eval for this node (not children).
     std::atomic<double> m_blackevals{0};
     // node alive (not superko)
     std::atomic<bool> m_valid{true};

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -42,7 +42,7 @@ UCTSearch::UCTSearch(GameState& g)
     : m_rootstate(g) {
     set_playout_limit(cfg_max_playouts);
     set_visit_limit(cfg_max_visits);
-    m_root = std::make_unique<UCTNode>(FastBoard::PASS, 0.0f, 0.5f);
+    m_root = std::make_unique<UCTNode>(FastBoard::PASS, 0.0f);
 }
 
 bool UCTSearch::advance_to_new_rootstate() {
@@ -104,7 +104,7 @@ void UCTSearch::update_root() {
 #endif
 
     if (!advance_to_new_rootstate() || !m_root) {
-        m_root = std::make_unique<UCTNode>(FastBoard::PASS, 0.0f, 0.5f);
+        m_root = std::make_unique<UCTNode>(FastBoard::PASS, 0.0f);
     }
     // Clear last_rootstate to prevent accidental use.
     m_last_rootstate.reset(nullptr);


### PR DESCRIPTION
Rather than have each child store its parent's net eval, have every node store the net eval of its own game state. No change in behaviour (verified with --benchmark).