### PR TITLE
Duplicate entry for nick and proper name in AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,7 +14,7 @@ Mankit Pong
 Peter Wen
 Xingcan LAN
 tux3
-Antti Korhonen
+Antti Korhonen(zediir)
 Ashley Griffiths
 Barry Becker
 Ed Lee
@@ -29,5 +29,4 @@ Virgile Andreani
 afalturki
 cheshirecats
 gaieepo
-zediir
 Пахотин Иван


### PR DESCRIPTION
I was listed twice in AUTHORS both by my nick and by my proper name.