### PR TITLE
V2pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ source and remove the line that says "#define USE_OPENCL".
     Double-click the leela-zero2015.sln or leela-zero2017.sln corresponding
     to the Visual Studio version you have.
     # Build from Visual Studio 2015 or 2017
-    # Download and extract <https://sjeng.org/zero/best_v1.txt.zip> to msvc/x64/Release
-    # msvc/x64/Release/leela-zero --weights weights.txt
+    # Download and extract <https://sjeng.org/zero/best_v1.txt.zip> to msvc\x64\Release
+    msvc\x64\Release\leelaz.exe --weights weights.txt
 
 ## Example of compiling and running - CMake (macOS/Ubuntu)
 

--- a/training/tf/parse.py
+++ b/training/tf/parse.py
@@ -43,7 +43,7 @@ BATCH_SIZE = 512
 
 # Use a random sample of 1/16th of the input data read. This helps
 # improve the spread of games in the shuffle buffer.
-DOWN_SAMPLE = 8
+DOWN_SAMPLE = 16
 
 def remap_vertex(vertex, symmetry):
     """
@@ -107,7 +107,7 @@ class ChunkParser:
         # set the down-sampling rate
         self.sample = sample
 
-        # V2 Format (see 'PackedMove' in Training.h)
+        # V2 Format
         # int32 version (4 bytes)
         # (19*19+1) float32 probabilities (1448 bytes)
         # 19*19*16 packed bit planes (722 bytes)
@@ -184,7 +184,6 @@ class ChunkParser:
         probs = probabilities.tobytes()
         assert(len(probs) == 362 * 4)
 
-
         # Load the game winner color.
         winner = float(text_item[18])
         assert winner == 1.0 or winner == -1.0
@@ -256,7 +255,7 @@ class ChunkParser:
             #print("V2 chunkdata")
             items = [ chunkdata[i:i+self.v2_struct.size]
                         for i in range(0, len(chunkdata), self.v2_struct.size) ]
-            if self.sample > 0:
+            if self.sample > 1:
                 # Downsample to 1/Nth of the items.
                 items = random.sample(items, len(items) // self.sample)
             return items
@@ -266,7 +265,7 @@ class ChunkParser:
 
             result = []
             for i in range(0, len(file_chunkdata), DATA_ITEM_LINES):
-                if self.sample > 0:
+                if self.sample > 1:
                     # Downsample, using only 1/Nth of the items.
                     if random.randint(0, self.sample-1) != 0:
                         continue  # Skip this record.

--- a/training/tf/parse.py
+++ b/training/tf/parse.py
@@ -247,13 +247,6 @@ class ChunkParser:
 
         return self.raw_struct.pack(winner, probs.tobytes(), planes)
 
-    def load_chunk_file(self, filename):
-        """
-            Read chunk file off disk
-        """
-        with gzip.open(filename, 'r') as chunk_file:
-            return chunk_file.read()
-
     def convert_chunkdata_to_v2(self, chunkdata):
         """
             Take chunk of unknown format, and return it as a list of

--- a/training/tf/parse.py
+++ b/training/tf/parse.py
@@ -16,16 +16,22 @@
 #    You should have received a copy of the GNU General Public License
 #    along with Leela Zero.  If not, see <http://www.gnu.org/licenses/>.
 
-import sys
+
+from tfprocess import TFProcess
+import binascii
 import glob
 import gzip
-import random
+import itertools
 import math
 import multiprocessing as mp
 import numpy as np
-import time
+import queue
+import random
+import struct
+import sys
 import tensorflow as tf
-from tfprocess import TFProcess
+import time
+import threading
 
 # 16 planes, 1 side to move, 1 x 362 probs, 1 winner = 19 lines
 DATA_ITEM_LINES = 16 + 1 + 1 + 1
@@ -34,6 +40,10 @@ DATA_ITEM_LINES = 16 + 1 + 1 + 1
 # of RAM in your GPU and the network size. You need to adjust the learning rate
 # if you change this.
 BATCH_SIZE = 512
+
+# Use a random sample of 1/16th of the input data read. This helps
+# improve the spread of games in the shuffle buffer.
+DOWN_SAMPLE = 8
 
 def remap_vertex(vertex, symmetry):
     """
@@ -52,7 +62,36 @@ def remap_vertex(vertex, symmetry):
     return y * 19 + x
 
 class ChunkParser:
-    def __init__(self, chunks, workers=None):
+    def __init__(self, chunkdatagen, shuffle_size=1, sample=1, buffer_size=1, workers=None):
+        """
+            Read data and yield batches of raw tensors.
+
+            'chunkdatagen' is a generator yeilding chunkdata
+            'shuffle_size' is the size of the shuffle buffer.
+            'sample' is the rate to down-sample.
+            'workers' is the number of child workers to use.
+
+            The data is represented in a number of formats through this dataflow
+            pipeline. In order, they are:
+
+            chunk: The name of a file containing chunkdata
+
+            chunkdata: type Bytes. Either mutiple records of v1 format, or multiple records
+            of v2 format.
+
+            v1: The original text format describing a move. 19 lines long. VERY slow
+            to decode. Typically around 2500 bytes long. Used only for backward
+            compatability.
+
+            v2: Packed binary representation of v1. Fixed length, no record seperator.
+            The most compact format. Data in the shuffle buffer is held in this
+            format as it allows the largest possible shuffle buffer. Very fast to
+            decode. Preferred format to use on disk. 2176 bytes long.
+
+            raw: A byte string holding raw tensors contenated together. This is used
+            to pass data from the workers to the parent. Exists because TensorFlow doesn't
+            have a fast way to unpack bit vectors. 7950 bytes long.
+        """
         # Build probility reflection tables. The last element is 'pass' and is identity mapped.
         self.prob_reflection_table = [[remap_vertex(vertex, sym) for vertex in range(361)]+[361] for sym in range(8)]
         # Build full 16-plane reflection tables.
@@ -65,28 +104,50 @@ class ChunkParser:
         # Build the all-zeros and all-ones flat planes, used for color-to-move.
         self.flat_planes = [ b'\0' * 361, b'\1' * 361 ]
 
+        # set the down-sampling rate
+        self.sample = sample
+
+        # V2 Format (see 'PackedMove' in Training.h)
+        # int32 version (4 bytes)
+        # (19*19+1) float32 probabilities (1448 bytes)
+        # 19*19*16 packed bit planes (722 bytes)
+        # uint8 side_to_move (1 byte)
+        # uint8 is_winner (1 byte)
+        self.v2_struct = struct.Struct('4s1448s722sBB')
+
+        # Struct used to return data from child workers.
+        # float32 winner
+        # float32*392 probs
+        # uint*6498 planes
+        # (order is to ensure that no padding is required to make float32 be 32-bit aligned)
+        self.raw_struct = struct.Struct('4s1448s6498s')
+
         # Start worker processes, leave 2 for TensorFlow
         if workers is None:
             workers = max(1, mp.cpu_count() - 2)
         print("Using {} worker processes.".format(workers))
+
+        # Spread shuffle buffer over workers.
+        self.shuffle_size = int(shuffle_size / workers)
+
+        # Start the child workers running
         self.readers = []
         for _ in range(workers):
-            read, write = mp.Pipe(False)
+            read, write = mp.Pipe(duplex=False)
             mp.Process(target=self.task,
-                       args=(chunks, write)).start()
+                    args=(chunkdatagen, write)).start()
             self.readers.append(read)
+            write.close()
 
-    def convert_train_data(self, text_item, symmetry):
+    def convert_v1_to_v2(self, text_item):
         """
-            Convert textual training data to a tf.train.Example
+            Convert v1 text format to v2 packed binary format
 
-            Converts a set of 19 lines of text into a pythonic dataformat.
+            Converts a set of 19 lines of text into a byte string
             [[plane_1],[plane_2],...],...
             [probabilities],...
             winner,...
         """
-        assert symmetry >= 0 and symmetry < 8
-
         # We start by building a list of 16 planes, each being a 19*19 == 361 element array
         # of type np.uint8
         planes = []
@@ -104,19 +165,69 @@ class ChunkParser:
 
         # We flatten to a single array of len 16*19*19, type=np.uint8
         planes = np.concatenate(planes)
+        # and then to a byte string
+        planes = np.packbits(planes).tobytes()
 
+        # Get the 'side to move'
+        stm = text_item[16][0]
+        assert stm == "0" or stm == "1"
+        stm = int(stm)
+
+        # Load the probabilities.
+        probabilities = np.array(text_item[17].split()).astype(np.float32)
+        if np.any(np.isnan(probabilities)):
+            # Work around a bug in leela-zero v0.3, skipping any
+            # positions that have a NaN in the probabilities list.
+            return False, None
+        assert len(probabilities) == 362
+
+        probs = probabilities.tobytes()
+        assert(len(probs) == 362 * 4)
+
+
+        # Load the game winner color.
+        winner = float(text_item[18])
+        assert winner == 1.0 or winner == -1.0
+        winner = int((winner + 1) / 2)
+
+        version = struct.pack('i', 1)
+
+        return True, self.v2_struct.pack(version, probs, planes, stm, winner)
+        #return True, b''.join([b'\1\0\0\0', probs, planes, b'\0\1'[stm:stm+1], b'\0\1'[winner:winner+1]])
+
+    def convert_v2_to_raw(self, symmetry, content):
+        """
+            Convert v2 binary training data to packed tensors 
+
+            v2 struct format is
+                int32 ver
+                float probs[19*18+1]
+                byte planes[19*19*16/8]
+                byte to_move
+                byte winner
+
+            packed tensor format is
+                float32 winner
+                float32*362 probs
+                uint8*6498 planes
+        """
+        assert symmetry >= 0 and symmetry < 8
+
+        (ver, probs, planes, to_move, winner) = self.v2_struct.unpack(content)
+
+        planes = np.unpackbits(np.frombuffer(planes, dtype=np.uint8))
         # We use the full length reflection tables to apply symmetry
         # to all 16 planes simultaneously
         planes = planes[self.full_reflection_table[symmetry]]
+        assert len(planes) == 19*19*16
         # Convert the array to a byte string
         planes = [ planes.tobytes() ]
 
         # Now we add the two final planes, being the 'color to move' planes.
         # These already a fully symmetric, so we add them directly as byte
         # strings of length 361.
-        stm = text_item[16][0]
-        assert stm == "0" or stm == "1"
-        stm = int(stm)
+        stm = to_move
+        assert stm == 0 or stm == 1
         planes.append(self.flat_planes[1 - stm])
         planes.append(self.flat_planes[stm])
 
@@ -124,56 +235,132 @@ class ChunkParser:
         planes = b''.join(planes)
         assert len(planes) == (18 * 19 * 19)
 
-        # Load the probabilities.
-        probabilities = np.array(text_item[17].split()).astype(float)
-        if np.any(np.isnan(probabilities)):
-            # Work around a bug in leela-zero v0.3, skipping any
-            # positions that have a NaN in the probabilities list.
-            return False, None
+        probs = np.frombuffer(probs, dtype=np.float32)
         # Apply symmetries to the probabilities.
-        probabilities = probabilities[self.prob_reflection_table[symmetry]]
-        assert len(probabilities) == 362
+        probs = probs[self.prob_reflection_table[symmetry]]
+        assert len(probs) == 362
 
-        # Load the game winner color.
-        winner = float(text_item[18])
+        winner = float(winner * 2 - 1)
         assert winner == 1.0 or winner == -1.0
 
-        # Construct the Example protobuf
-        example = tf.train.Example(features=tf.train.Features(feature={
-            'planes' : tf.train.Feature(bytes_list=tf.train.BytesList(value=[planes])),
-            'probs' : tf.train.Feature(float_list=tf.train.FloatList(value=probabilities)),
-            'winner' : tf.train.Feature(float_list=tf.train.FloatList(value=[winner]))}))
-        return True, example.SerializeToString()
+        winner = struct.pack('f', winner)
 
-    def task(self, chunks, writer):
-        while True:
-            random.shuffle(chunks)
-            for chunk in chunks:
-                with gzip.open(chunk, 'r') as chunk_file:
-                    file_content = chunk_file.read().splitlines()
-                    item_count = len(file_content) // DATA_ITEM_LINES
-                    # Pick only 1 in every 16 positions
-                    picked_items = random.sample(range(item_count),
-                                                 (item_count + 15) // 16)
-                    for item_idx in picked_items:
-                        pick_offset = item_idx * DATA_ITEM_LINES
-                        item = file_content[pick_offset:pick_offset + DATA_ITEM_LINES]
-                        str_items = [str(line, 'ascii') for line in item]
-                        # Pick a random symmetry to apply
-                        symmetry = random.randrange(8)
-                        success, data = self.convert_train_data(str_items, symmetry)
-                        if success:
-                            # Send it down the pipe.
-                            writer.send_bytes(data)
+        return self.raw_struct.pack(winner, probs.tobytes(), planes)
 
-    def parse_chunk(self):
+    def load_chunk_file(self, filename):
+        """
+            Read chunk file off disk
+        """
+        with gzip.open(filename, 'r') as chunk_file:
+            return chunk_file.read()
+
+    def convert_chunkdata_to_v2(self, chunkdata):
+        """
+            Take chunk of unknown format, and return it as a list of
+            v2 format records.
+        """
+        if chunkdata[0:4] == b'\1\0\0\0':
+            #print("V2 chunkdata")
+            items = [ chunkdata[i:i+self.v2_struct.size]
+                        for i in range(0, len(chunkdata), self.v2_struct.size) ]
+            if self.sample > 0:
+                # Downsample to 1/Nth of the items.
+                items = random.sample(items, len(items) // self.sample)
+            return items
+        else:
+            #print("V1 chunkdata")
+            file_chunkdata = chunkdata.splitlines()
+
+            result = []
+            for i in range(0, len(file_chunkdata), DATA_ITEM_LINES):
+                if self.sample > 0:
+                    # Downsample, using only 1/Nth of the items.
+                    if random.randint(0, self.sample-1) != 0:
+                        continue  # Skip this record.
+                item = file_chunkdata[i:i+DATA_ITEM_LINES]
+                str_items = [str(line, 'ascii') for line in item]
+                success, data = self.convert_v1_to_v2(str_items)
+                if success:
+                    result.append(data)
+            return result
+
+
+    def task(self, chunkdatagen, writer):
+        """
+            Run in fork'ed process, read data off disk, parsing, shuffling and
+            sending raw data through pipe back to main process.
+        """
+        moves = []
+        for chunkdata in chunkdatagen:
+            items = self.convert_chunkdata_to_v2(chunkdata)
+            moves.extend(items)
+            if len(moves) <= self.shuffle_size:
+                continue
+            # randomize the order of the loaded moves.
+            random.shuffle(moves)
+            while len(moves) > self.shuffle_size:
+                move = moves.pop()
+                # Pick a random symmetry to apply
+                symmetry = random.randrange(8)
+                data = self.convert_v2_to_raw(symmetry, move)
+                writer.send_bytes(data)
+
+    def convert_raw_to_tuple(self, data):
+        """
+            Convert packed tensors to tuple of raw tensors
+        """
+        (winner, probs, planes) = self.raw_struct.unpack(data)
+        return (planes, probs, winner)
+
+    def chunk_gen(self):
+        """
+            Read packed tensors from child workers and yield
+            tuples of raw tensors
+        """
         while True:
-            for r in self.readers:
-                yield r.recv_bytes();
+            for r in mp.connection.wait(self.readers):
+                try:
+                    s = r.recv_bytes()
+                except EOFError:
+                    print("Reader EOF")
+                    self.readers.remove(r)
+                yield self.convert_raw_to_tuple(s)
+
+    def batch_gen(self, gen):
+        """
+            Pack multiple records into a single batch
+        """
+        # Get N records. We flatten the returned generator to
+        # a list because we need to reuse it.
+        while True:
+            s = list(itertools.islice(gen, BATCH_SIZE))
+            if not len(s):
+                return
+            yield ( b''.join([x[0] for x in s]),
+                    b''.join([x[1] for x in s]),
+                    b''.join([x[2] for x in s]) )
+
+    def parse(self):
+        """
+            Read data from child workers and yield batches
+            of raw tensors
+        """
+        for b in self.batch_gen(self.chunk_gen()):
+            yield b
 
 def get_chunks(data_prefix):
     return glob.glob(data_prefix + "*.gz")
 
+def build_chunkgen(chunks):
+    """
+        generator yeilding chunkdata from chunk files.
+    """
+    yield b''  # To ensure that the shuffle happens in child workers.
+    while True:
+        random.shuffle(chunks)
+        for filename in chunks:
+            with gzip.open(filename, 'rb') as chunk_file:
+                yield chunk_file.read()
 
 #
 # Tests to check that records can round-trip successfully
@@ -193,16 +380,18 @@ def generate_fake_pos():
     winner = [ 2 * float(np.random.randint(2)) - 1 ]
     return (planes, probs, winner)
 
-def run_test(parser):
+def run_test():
     """
-        Test game position decoding.
-    """
+        Test game position decoding pipeline.
 
+        We generate a V1 record, and feed it all the way
+        through the parsing pipeline to final tensors,
+        checking that what we get out is what we put in.
+    """
     # First, build a random game position.
     planes, probs, winner = generate_fake_pos()
 
-    # Convert that to a text record in the same format
-    # generated by dump_supervised
+    # Convert that to a v1 text record.
     items = []
     for p in range(16):
         # generate first 360 bits
@@ -210,63 +399,98 @@ def run_test(parser):
         # then add the stray single bit
         h += str(planes[p][360]) + "\n"
         items.append(h)
-    # then who to move
+    # then side to move
     items.append(str(int(planes[17][0])) + "\n")
-    # then probs
+    # then probabilities
     items.append(' '.join([str(x) for x in probs]) + "\n")
-    # and finally a winner
+    # and finally if the side to move is a winner
     items.append(str(int(winner[0])) + "\n")
 
-    # Have an input string. Running it through parsing to see
-    # if it gives the same result we started with.
-    # We need a tf.Session() as we're going to use the tensorflow
-    # decoding framework for part of the parsing.
-    with tf.Session() as sess:
-        # We apply and check every symmetry.
-        for symmetry in range(8):
-            result = parser.convert_train_data(items, symmetry)
-            assert result[0] == True
-            # We got back a serialized tf.train.Example, which we need to decode.
-            graph = _parse_function(result[1])
-            data = sess.run(graph)
-            data = (data[0].tolist(), data[1].tolist(), data[2].tolist())
+    # Convert to a chunkdata byte string.
+    chunkdata = ''.join(items).encode('ascii')
 
+    # feed BATCH_SIZE copies into parser
+    parser = ChunkParser(
+            (chunkdata for _ in range(BATCH_SIZE)),
+            shuffle_size=1, workers=1)
+
+    # Get one batch from the parser.
+    batchgen = parser.parse()
+    batch = next(batchgen)
+
+    # We need a tf.Session() as we're going to use the tensorflow
+    # decoding framework to decode the raw byte strings into tensors.
+    with tf.Session() as sess:
+        graph = _parse_function(*batch)
+        data = sess.run(graph)
+
+    # Convert tensors to python lists.
+    batch = (data[0].tolist(), data[1].tolist(), data[2].tolist())
+
+    # Check that every record in the batch is a some valid symmetry
+    # of the original data.
+    for i in range(BATCH_SIZE):
+        data = (batch[0][i], batch[1][i], batch[2][i])
+
+        # We have an unknown symmetry, so search for a matching one.
+        result = False
+        for symmetry in range(8):
             # Apply the symmetry to the original
             sym_planes = [ [ plane[remap_vertex(vertex, symmetry)] for vertex in range(361) ] for plane in planes ]
             sym_probs = [ probs[remap_vertex(vertex, symmetry)] for vertex in range(361)] + [probs[361]]
 
             # Check that what we got out matches what we put in.
-            assert data == (sym_planes, sym_probs, winner)
+            if data == (sym_planes, sym_probs, winner):
+                result = True
+                break
+        # Check that there is at least one matching symmetry.
+        assert(result == True)
     print("Test parse passes")
 
-
-# Convert a tf.train.Example protobuf into a tuple of tensors
-# NB: This conversion is done in the tensorflow graph, NOT in python.
-def _parse_function(example_proto):
-    features = {"planes": tf.FixedLenFeature((1), tf.string),
-                "probs": tf.FixedLenFeature((19*19+1), tf.float32),
-                "winner": tf.FixedLenFeature((1), tf.float32)}
-    parsed_features = tf.parse_single_example(example_proto, features)
-    # We receives the planes as a byte array, but we really want
-    # floats of shape (18, 19*19), so decode, cast, and reshape.
-    planes = tf.decode_raw(parsed_features["planes"], tf.uint8)
-    planes = tf.to_float(planes)
-    planes = tf.reshape(planes, (18, 19*19))
-    # the other features are already in the correct shape as return as-is.
-    return planes, parsed_features["probs"], parsed_features["winner"]
-
 def benchmark(parser):
-    gen = parser.parse_chunk()
+    """
+        Benchmark for parser
+    """
+    gen = parser.parse()
+    batch=100
     while True:
         start = time.time()
-        for _ in range(10000):
+        for _ in range(batch):
             next(gen)
         end = time.time()
-        print("{} pos/sec {} secs".format( 10000. / (end - start), (end - start)))
+        print("{} pos/sec {} secs".format( BATCH_SIZE * batch / (end - start), (end - start)))
+
+def benchmark1(t):
+    """
+        Benchmark for full input pipeline, including tensorflow conversion
+    """
+    batch=100
+    while True:
+        start = time.time()
+        for _ in range(batch):
+            t.session.run([t.next_batch],
+                feed_dict={t.training: True, t.handle: t.train_handle, t.learning_rate: 0.05})
+
+        end = time.time()
+        print("{} pos/sec {} secs".format( BATCH_SIZE * batch / (end - start), (end - start)))
+
 
 def split_chunks(chunks, test_ratio):
     splitpoint = 1 + int(len(chunks) * (1.0 - test_ratio))
     return (chunks[:splitpoint], chunks[splitpoint:])
+
+def _parse_function(planes, probs, winner):
+    planes = tf.decode_raw(planes, tf.uint8)
+    probs = tf.decode_raw(probs, tf.float32)
+    winner = tf.decode_raw(winner, tf.float32)
+
+    planes = tf.to_float(planes)
+
+    planes = tf.reshape(planes, (BATCH_SIZE, 18, 19*19))
+    probs = tf.reshape(probs, (BATCH_SIZE, 19*19 + 1))
+    winner = tf.reshape(winner, (BATCH_SIZE, 1))
+
+    return (planes, probs, winner)
 
 def main(args):
     train_data_prefix = args.pop(0)
@@ -284,28 +508,30 @@ def main(args):
     print("Training with {0} chunks, validating on {1} chunks".format(
         len(training), len(test)))
 
-    #run_test(parser)
-    #benchmark(parser)
+    #run_test()
 
-    train_parser = ChunkParser(training)
+    train_parser = ChunkParser(build_chunkgen(training),
+            shuffle_size=1<<19, sample=DOWN_SAMPLE)
     dataset = tf.data.Dataset.from_generator(
-        train_parser.parse_chunk, output_types=(tf.string))
-    dataset = dataset.shuffle(1 << 18)
+        train_parser.parse, output_types=(tf.string, tf.string, tf.string))
     dataset = dataset.map(_parse_function)
-    dataset = dataset.batch(BATCH_SIZE)
     dataset = dataset.prefetch(4)
     train_iterator = dataset.make_one_shot_iterator()
 
-    test_parser = ChunkParser(test)
+    test_parser = ChunkParser(build_chunkgen(test))
     dataset = tf.data.Dataset.from_generator(
-        test_parser.parse_chunk, output_types=(tf.string))
+        test_parser.parse, output_types=(tf.string, tf.string, tf.string))
     dataset = dataset.map(_parse_function)
-    dataset = dataset.batch(BATCH_SIZE)
     dataset = dataset.prefetch(4)
     test_iterator = dataset.make_one_shot_iterator()
 
+    #benchmark(train_parser)
+
     tfprocess = TFProcess()
     tfprocess.init(dataset, train_iterator, test_iterator)
+
+    #benchmark1(tfprocess)
+
     if args:
         restore_file = args.pop(0)
         tfprocess.restore(restore_file)


### PR DESCRIPTION
Refactor the training input pipeline.

1. Introduce a binary format (v2).
2. Use the v2 format for the shuffle buffer (shrinks RAM by ~2x)
3. Support for loading v2 format off disk (much faster to parse)
4. Amend test to be full end-to-end test, including worker interfaces.
5. Add benchmark for the tensorflow frontend.
6. Change worker->main process communication to be fixed size binary format instead of protobuf.

Net result is that the pipeline now saturates at about 45,000 moves/sec into tensorflow (aka ~88 batches/sec with n=512).