### PR TITLE
Normalize policy to uniform when the sum is denorm.

### DIFF
--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -104,11 +104,16 @@ bool UCTNode::create_children(std::atomic<int> & nodecount,
         }
     }
 
-    // If the sum is 0 or a denormal, then don't try to normalize.
     if (legal_sum > std::numeric_limits<float>::min()) {
         // re-normalize after removing illegal moves.
         for (auto& node : nodelist) {
             node.first /= legal_sum;
+        }
+    } else {
+        // This can happen with new randomized nets.
+        auto uniform_prob = 1.0f / nodelist.size();
+        for (auto& node : nodelist) {
+            node.first = uniform_prob;
         }
     }
 


### PR DESCRIPTION
See also https://github.com/glinscott/leela-chess/pull/72

I guess we avoided this issue because LZ's initial random net was very small. @Ttl showed a new random 5x32 net was not so uniform, but the heatmap of the first LZ 1x8 random net looked fine (totally uniform policy, near 50% value).

But this code seems like a good safeguard.
