### PR TITLE
Turn off the quiet mode in case of critical error.

### DIFF
--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -112,6 +112,7 @@ static void parse_commandline(int argc, char *argv[]) {
                   .options(all).positional(p_desc).run(), vm);
         po::notify(vm);
     }  catch(const boost::program_options::error& e) {
+        cfg_quiet = false;
         myprintf("ERROR: %s\n", e.what());
         license_blurb();
         std::cout << v_desc << std::endl;
@@ -129,6 +130,7 @@ static void parse_commandline(int argc, char *argv[]) {
             }
             ev = EXIT_FAILURE;
         }
+        cfg_quiet = false;
         license_blurb();
         std::cout << v_desc << std::endl;
         exit(ev);
@@ -163,6 +165,7 @@ static void parse_commandline(int argc, char *argv[]) {
     if (vm.count("weights")) {
         cfg_weightsfile = vm["weights"].as<std::string>();
     } else {
+        cfg_quiet = false;
         myprintf("A network weights file is required to use the program.\n");
         exit(EXIT_FAILURE);
     }
@@ -205,6 +208,7 @@ static void parse_commandline(int argc, char *argv[]) {
     if (vm.count("playouts")) {
         cfg_max_playouts = vm["playouts"].as<int>();
         if (!vm.count("noponder")) {
+            cfg_quiet = false;
             myprintf("Nonsensical options: Playouts are restricted but "
                      "thinking on the opponent's time is still allowed. "
                      "Add --noponder if you want a weakened engine.\n");
@@ -233,6 +237,7 @@ static void parse_commandline(int argc, char *argv[]) {
         } else if (tm == "off") {
             cfg_timemanage = TimeManagement::OFF;
         } else {
+            cfg_quiet = false;
             myprintf("Invalid timemanage value.\n");
             exit(EXIT_FAILURE);
         }

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -58,6 +58,7 @@ bool Utils::input_pending(void) {
 
     if (pipe) {
         if (!PeekNamedPipe(inh, NULL, 0, NULL, &dw, NULL)) {
+            cfg_quiet = false;
             myprintf("Nothing at other end - exiting\n");
             exit(EXIT_FAILURE);
         }
@@ -65,6 +66,7 @@ bool Utils::input_pending(void) {
         return dw;
     } else {
         if (!GetNumberOfConsoleInputEvents(inh, &dw)) {
+            cfg_quiet = false;
             myprintf("Nothing at other end - exiting\n");
             exit(EXIT_FAILURE);
         }


### PR DESCRIPTION
The critical errors should never be silenced.
Fixes #935 