### PR TITLE
Split UCTNode into UCTFullNode and UCTNode

### DIFF
--- a/msvc/VS2015/leela-zero.vcxproj
+++ b/msvc/VS2015/leela-zero.vcxproj
@@ -93,6 +93,7 @@
     <ClCompile Include="..\..\src\Training.cpp" />
     <ClCompile Include="..\..\src\Tuner.cpp" />
     <ClCompile Include="..\..\src\UCTNode.cpp" />
+    <ClCompile Include="..\..\src\UCTNodeRoot.cpp" />
     <ClCompile Include="..\..\src\UCTSearch.cpp" />
     <ClCompile Include="..\..\src\Utils.cpp" />
     <ClCompile Include="..\..\src\Zobrist.cpp" />

--- a/msvc/VS2015/leela-zero.vcxproj.filters
+++ b/msvc/VS2015/leela-zero.vcxproj.filters
@@ -143,6 +143,9 @@
     <ClCompile Include="..\..\src\UCTNode.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\UCTNodeRoot.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\UCTSearch.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/msvc/VS2017/leela-zero.vcxproj
+++ b/msvc/VS2017/leela-zero.vcxproj
@@ -68,6 +68,7 @@
     <ClCompile Include="..\..\src\Training.cpp" />
     <ClCompile Include="..\..\src\Tuner.cpp" />
     <ClCompile Include="..\..\src\UCTNode.cpp" />
+    <ClCompile Include="..\..\src\UCTNodeRoot.cpp" />
     <ClCompile Include="..\..\src\UCTSearch.cpp" />
     <ClCompile Include="..\..\src\Utils.cpp" />
     <ClCompile Include="..\..\src\Zobrist.cpp" />

--- a/msvc/VS2017/leela-zero.vcxproj.filters
+++ b/msvc/VS2017/leela-zero.vcxproj.filters
@@ -143,6 +143,9 @@
     <ClCompile Include="..\..\src\UCTNode.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\UCTNodeRoot.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\UCTSearch.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/src/Makefile
+++ b/src/Makefile
@@ -49,7 +49,7 @@ sources = Network.cpp FullBoard.cpp KoState.cpp Training.cpp \
 	  TimeControl.cpp UCTSearch.cpp GameState.cpp Leela.cpp \
 	  SGFParser.cpp Timing.cpp Utils.cpp FastBoard.cpp \
 	  SGFTree.cpp Zobrist.cpp FastState.cpp GTP.cpp Random.cpp \
-	  SMP.cpp UCTNode.cpp OpenCL.cpp OpenCLScheduler.cpp \
+	  SMP.cpp UCTNode.cpp UCTNodeRoot.cpp OpenCL.cpp OpenCLScheduler.cpp \
 	  NNCache.cpp Tuner.cpp
 
 objects = $(sources:.cpp=.o)

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -27,19 +27,15 @@
 #include <iterator>
 #include <limits>
 #include <numeric>
-#include <random>
 #include <utility>
 #include <vector>
 
 #include "UCTNode.h"
 #include "FastBoard.h"
 #include "FastState.h"
-#include "FullBoard.h"
 #include "GTP.h"
 #include "GameState.h"
-#include "KoState.h"
 #include "Network.h"
-#include "Random.h"
 #include "Utils.h"
 
 using namespace Utils;
@@ -142,86 +138,10 @@ void UCTNode::link_nodelist(std::atomic<int>& nodecount,
     m_has_children = true;
 }
 
-void UCTNode::kill_superkos(const KoState& state) {
-    for (auto& child : m_children) {
-        auto move = child->get_move();
-        if (move != FastBoard::PASS) {
-            KoState mystate = state;
-            mystate.play_move(move);
-
-            if (mystate.superko()) {
-                // Don't delete nodes for now, just mark them invalid.
-                child->invalidate();
-            }
-        }
-    }
-
-    // Now do the actual deletion.
-    m_children.erase(
-        std::remove_if(begin(m_children), end(m_children),
-                       [](const auto &child) { return !child->valid(); }),
-        end(m_children)
-    );
+const std::vector<UCTNode::node_ptr_t>& UCTNode::get_children() const {
+    return m_children;
 }
 
-void UCTNode::dirichlet_noise(float epsilon, float alpha) {
-    auto child_cnt = m_children.size();
-
-    auto dirichlet_vector = std::vector<float>{};
-    std::gamma_distribution<float> gamma(alpha, 1.0f);
-    for (auto i = size_t{0}; i < child_cnt; i++) {
-        dirichlet_vector.emplace_back(gamma(Random::get_Rng()));
-    }
-
-    auto sample_sum = std::accumulate(begin(dirichlet_vector),
-                                      end(dirichlet_vector), 0.0f);
-
-    // If the noise vector sums to 0 or a denormal, then don't try to
-    // normalize.
-    if (sample_sum < std::numeric_limits<float>::min()) {
-        return;
-    }
-
-    for (auto& v: dirichlet_vector) {
-        v /= sample_sum;
-    }
-
-    child_cnt = 0;
-    for (auto& child : m_children) {
-        auto score = child->get_score();
-        auto eta_a = dirichlet_vector[child_cnt++];
-        score = score * (1 - epsilon) + epsilon * eta_a;
-        child->set_score(score);
-    }
-}
-
-void UCTNode::randomize_first_proportionally() {
-    auto accum = std::uint64_t{0};
-    auto accum_vector = std::vector<decltype(accum)>{};
-    for (const auto& child : m_children) {
-        accum += child->get_visits();
-        accum_vector.emplace_back(accum);
-    }
-
-    auto pick = Random::get_Rng().randuint64(accum);
-    auto index = size_t{0};
-    for (auto i = size_t{0}; i < accum_vector.size(); i++) {
-        if (pick < accum_vector[i]) {
-            index = i;
-            break;
-        }
-    }
-
-    // Take the early out
-    if (index == 0) {
-        return;
-    }
-
-    assert(m_children.size() >= index);
-
-    // Now swap the child at index with the first child
-    std::iter_swap(begin(m_children), begin(m_children) + index);
-}
 
 int UCTNode::get_move() const {
     return m_move;
@@ -373,17 +293,6 @@ UCTNode& UCTNode::get_best_root_child(int color) {
                               NodeComp(color))->get());
 }
 
-UCTNode* UCTNode::get_first_child() const {
-    if (m_children.empty()) {
-        return nullptr;
-    }
-    return m_children.front().get();
-}
-
-const std::vector<UCTNode::node_ptr_t>& UCTNode::get_children() const {
-    return m_children;
-}
-
 size_t UCTNode::count_nodes() const {
     auto nodecount = size_t{0};
     if (m_has_children) {
@@ -393,34 +302,6 @@ size_t UCTNode::count_nodes() const {
         }
     }
     return nodecount;
-}
-
-// Used to find new root in UCTSearch
-UCTNode::node_ptr_t UCTNode::find_child(const int move) {
-    if (m_has_children) {
-        for (auto& child : m_children) {
-            if (child->get_move() == move) {
-                return std::move(child);
-            }
-        }
-    }
-
-    // Can happen if we resigned or children are not expanded
-    return nullptr;
-}
-
-UCTNode* UCTNode::get_nopass_child(FastState& state) const {
-    for (const auto& child : m_children) {
-        /* If we prevent the engine from passing, we must bail out when
-           we only have unreasonable moves to pick, like filling eyes.
-           Note that this knowledge isn't required by the engine,
-           we require it because we're overruling its moves. */
-        if (child->m_move != FastBoard::PASS
-            && !state.board.is_eye(state.get_to_move(), child->m_move)) {
-            return child.get();
-        }
-    }
-    return nullptr;
 }
 
 void UCTNode::invalidate() {

--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -38,14 +38,23 @@ public:
 
     using node_ptr_t = std::unique_ptr<UCTNode>;
 
+    // Defined in UCTNode.cpp
     explicit UCTNode(int vertex, float score);
     UCTNode() = delete;
     ~UCTNode() = default;
-    bool first_visit() const;
-    bool has_children() const;
+
     bool create_children(std::atomic<int>& nodecount,
                          GameState& state, float& eval);
-    void kill_superkos(const KoState& state);
+
+    const std::vector<node_ptr_t>& get_children() const;
+    void sort_children(int color);
+    UCTNode& get_best_root_child(int color);
+    UCTNode* uct_select_child(int color);
+
+    size_t count_nodes() const;
+    SMP::Mutex& get_mutex();
+    bool first_visit() const;
+    bool has_children() const;
     void invalidate();
     bool valid() const;
     int get_move() const;
@@ -58,23 +67,21 @@ public:
     void accumulate_eval(float eval);
     void virtual_loss(void);
     void virtual_loss_undo(void);
-    void dirichlet_noise(float epsilon, float alpha);
-    void randomize_first_proportionally();
     void update(float eval);
 
-    UCTNode* uct_select_child(int color);
+    // Defined in UCTNodeRoot.cpp, only to be called on m_root in UCTSearch
+    void kill_superkos(const KoState& state);
+    void dirichlet_noise(float epsilon, float alpha);
+    void randomize_first_proportionally();
+
     UCTNode* get_first_child() const;
     UCTNode* get_nopass_child(FastState& state) const;
-    const std::vector<node_ptr_t>& get_children() const;
-    size_t count_nodes() const;
     node_ptr_t find_child(const int move);
-    void sort_children(int color);
-    UCTNode& get_best_root_child(int color);
-    SMP::Mutex& get_mutex();
 
 private:
     void link_nodelist(std::atomic<int>& nodecount,
                        std::vector<Network::scored_node>& nodelist);
+
     // Note : This class is very size-sensitive as we are going to create
     // tens of millions of instances of these.  Please put extra caution
     // if you want to add/remove/reorder any variables here.

--- a/src/UCTNodeRoot.cpp
+++ b/src/UCTNodeRoot.cpp
@@ -1,0 +1,156 @@
+/*
+    This file is part of Leela Zero.
+    Copyright (C) 2018 Gian-Carlo Pascutto
+
+    Leela Zero is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Leela Zero is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Leela Zero.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include <algorithm>
+#include <cassert>
+#include <iterator>
+#include <numeric>
+#include <random>
+#include <utility>
+#include <vector>
+
+#include "UCTNode.h"
+#include "FastBoard.h"
+#include "FastState.h"
+#include "KoState.h"
+#include "Random.h"
+#include "UCTNode.h"
+
+/*
+ * These functions belong to UCTNode but should only be called on the root node
+ * of UCTSearch and have been seperated to increase code clarity.
+ */
+
+UCTNode* UCTNode::get_first_child() const {
+    if (m_children.empty()) {
+        return nullptr;
+    }
+
+    return m_children.front().get();
+}
+
+void UCTNode::kill_superkos(const KoState& state) {
+    for (auto& child : m_children) {
+        auto move = child->get_move();
+        if (move != FastBoard::PASS) {
+            KoState mystate = state;
+            mystate.play_move(move);
+
+            if (mystate.superko()) {
+                // Don't delete nodes for now, just mark them invalid.
+                child->invalidate();
+            }
+        }
+    }
+
+    // Now do the actual deletion.
+    m_children.erase(
+        std::remove_if(begin(m_children), end(m_children),
+                       [](const auto &child) { return !child->valid(); }),
+        end(m_children)
+    );
+}
+
+void UCTNode::dirichlet_noise(float epsilon, float alpha) {
+    auto child_cnt = m_children.size();
+
+    auto dirichlet_vector = std::vector<float>{};
+    std::gamma_distribution<float> gamma(alpha, 1.0f);
+    for (size_t i = 0; i < child_cnt; i++) {
+        dirichlet_vector.emplace_back(gamma(Random::get_Rng()));
+    }
+
+    auto sample_sum = std::accumulate(begin(dirichlet_vector),
+                                      end(dirichlet_vector), 0.0f);
+
+    // If the noise vector sums to 0 or a denormal, then don't try to
+    // normalize.
+    if (sample_sum < std::numeric_limits<float>::min()) {
+        return;
+    }
+
+    for (auto& v: dirichlet_vector) {
+        v /= sample_sum;
+    }
+
+    child_cnt = 0;
+    for (auto& child : m_children) {
+        auto score = child->get_score();
+        auto eta_a = dirichlet_vector[child_cnt++];
+        score = score * (1 - epsilon) + epsilon * eta_a;
+        child->set_score(score);
+    }
+}
+
+void UCTNode::randomize_first_proportionally() {
+    auto accum = std::uint64_t{0};
+    auto accum_vector = std::vector<decltype(accum)>{};
+    for (const auto& child : m_children) {
+        accum += child->get_visits();
+        accum_vector.emplace_back(accum);
+    }
+
+    auto pick = Random::get_Rng().randuint64(accum);
+    auto index = size_t{0};
+    for (size_t i = 0; i < accum_vector.size(); i++) {
+        if (pick < accum_vector[i]) {
+            index = i;
+            break;
+        }
+    }
+
+    // Take the early out
+    if (index == 0) {
+        return;
+    }
+
+    assert(m_children.size() >= index);
+
+    // Now swap the child at index with the first child
+    std::iter_swap(begin(m_children), begin(m_children) + index);
+}
+
+UCTNode* UCTNode::get_nopass_child(FastState& state) const {
+    for (const auto& child : m_children) {
+        /* If we prevent the engine from passing, we must bail out when
+           we only have unreasonable moves to pick, like filling eyes.
+           Note that this knowledge isn't required by the engine,
+           we require it because we're overruling its moves. */
+        if (child->m_move != FastBoard::PASS
+            && !state.board.is_eye(state.get_to_move(), child->m_move)) {
+            return child.get();
+        }
+    }
+    return nullptr;
+}
+
+// Used to find new root in UCTSearch
+UCTNode::node_ptr_t UCTNode::find_child(const int move) {
+    if (m_has_children) {
+        for (auto& child : m_children) {
+            if (child->get_move() == move) {
+                return std::move(child);
+            }
+        }
+    }
+
+    // Can happen if we resigned or children are not expanded
+    return nullptr;
+}


### PR DESCRIPTION
UCTFullNode contains all the methods that should/are only called on root nodes (kill_superkos, dirichlet_noise, randomize_first_proportionally). I'm slightly prefer the name "UCTRootNode" but I went with the project convention.

Pros
* UCTNode was getting quite large: 450 lines with 7 helper methods used once each from UCTSearch
* UCTFullNode code is UCTSearch specific and disjoint generally disjoint from UCTNode logic.
* Helpful for small_node pull (UCTFullNode can have the invariant that it's fully expanded)

Cons:
* UCTFullNode doesn't have additional data, in practice every UCTNode is actually a UCTFullNode.
* dump_stats  (useful when debugging) can only be called on UCTFullnode and will require a static_cast when debugging.
* std::unique_ptr don't support automatically casting to a base class which can complicate things later.[[1]](https://stackoverflow.com/questions/17473900/unique-ptr-to-a-base-class)