### PR TITLE
Reduced processing of unvisited nodes in UCTNode::uct_select_child()

### DIFF
--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -211,7 +211,7 @@ void UCTNode::accumulate_eval(float eval) {
 
 UCTNode* UCTNode::uct_select_child(int color) {
     UCTNode* best = nullptr;
-    auto best_unvisited_psa = -1000.0;
+    auto best_unvisited_psa = -DBL_MAX;
 
     LOCK(get_mutex(), lock);
 
@@ -236,9 +236,10 @@ UCTNode* UCTNode::uct_select_child(int color) {
     }
 
     auto numerator = std::sqrt((double)parentvisits);
-    auto best_value = -1000.0;
+    auto best_value = -DBL_MAX;
+    auto best_unvisited_value = -DBL_MAX;
 
-    if (best_unvisited_psa > -1000.0) {
+    if (best_unvisited_psa > -DBL_MAX) {
         // Estimated eval for unknown nodes = original parent NN eval - reduction
         auto fpu_reduction = cfg_fpu_reduction * std::sqrt(total_visited_policy);
         auto fpu_eval = get_net_eval(color) - fpu_reduction;
@@ -256,7 +257,7 @@ UCTNode* UCTNode::uct_select_child(int color) {
         auto denom = 1.0 + child->get_visits();
         auto puct = cfg_puct * psa * (numerator / denom);
         auto value = winrate + puct;
-        assert(value > -1000.0);
+        assert(value > -DBL_MAX);
 
         if (value > best_value) {
             best_value = value;

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -26,6 +26,7 @@
 #include <functional>
 #include <iterator>
 #include <limits>
+#include <cfloat>
 #include <numeric>
 #include <utility>
 #include <vector>

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -237,7 +237,6 @@ UCTNode* UCTNode::uct_select_child(int color) {
 
     auto numerator = std::sqrt((double)parentvisits);
     auto best_value = -DBL_MAX;
-    auto best_unvisited_value = -DBL_MAX;
 
     if (best_unvisited_psa > -DBL_MAX) {
         // Estimated eval for unknown nodes = original parent NN eval - reduction


### PR DESCRIPTION
For unvisited nodes the score is proportional to the calculated value. Therefore for the unvisited nodes the best score can be found whilst counting the parent visits and used once to calculate the best value for those nodes. This then allows the second loop to only process nodes that have visits > 0.

$ time ./leelaz -w weights -t 1 --noponder -p 100000 --benchmark
Before:
100001 visits, 34766701 nodes, 100000 playouts, 950 n/s
real    1m48.873s
After:
100001 visits, 34766701 nodes, 100000 playouts, 960 n/s
real    1m47.830s

Edit: with latest next and 75603ad2
Before:
100001 visits, 34320429 nodes, 100000 playouts, 458 n/s
real    3m41.455s
After:
100001 visits, 34320429 nodes, 100000 playouts, 460 n/s
real    3m40.657s