### PR TITLE
Stop visiting doomed root children

### DIFF
--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -313,7 +313,7 @@ UCTNode* UCTNode::uct_select_child(int color) {
     auto fpu_eval = get_net_eval(color) - fpu_reduction;
 
     for (const auto& child : m_children) {
-        if (!child->valid()) {
+        if (!child->active()) {
             continue;
         }
 
@@ -424,9 +424,19 @@ UCTNode* UCTNode::get_nopass_child(FastState& state) const {
 }
 
 void UCTNode::invalidate() {
-    m_valid = false;
+    m_status = INVALID;
+}
+
+void UCTNode::set_active(const bool active) {
+    if (valid()) {
+        m_status = active ? ACTIVE : PRUNED;
+    }
 }
 
 bool UCTNode::valid() const {
-    return m_valid;
+    return m_status != INVALID;
+}
+
+bool UCTNode::active() const {
+    return m_status == ACTIVE;
 }

--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -47,7 +47,9 @@ public:
                          GameState& state, float& eval);
     void kill_superkos(const KoState& state);
     void invalidate();
+    void set_active(const bool active);
     bool valid() const;
+    bool active() const;
     int get_move() const;
     int get_visits() const;
     float get_score() const;
@@ -73,6 +75,11 @@ public:
     SMP::Mutex& get_mutex();
 
 private:
+    enum Status {
+        INVALID, // superko
+        PRUNED,
+        ACTIVE
+    };
     void link_nodelist(std::atomic<int>& nodecount,
                        std::vector<Network::scored_node>& nodelist);
     // Note : This class is very size-sensitive as we are going to create
@@ -88,8 +95,7 @@ private:
     float m_score;
     float m_net_eval{0};  // Original net eval for this node (not children).
     std::atomic<double> m_blackevals{0};
-    // node alive (not superko)
-    std::atomic<bool> m_valid{true};
+    std::atomic<Status> m_status{ACTIVE};
     // Is someone adding scores to this node?
     // We don't need to unset this.
     bool m_is_expanding{false};

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -20,6 +20,7 @@
 #include "UCTSearch.h"
 
 #include <cassert>
+#include <cmath>
 #include <cstddef>
 #include <limits>
 #include <memory>
@@ -401,48 +402,49 @@ bool UCTSearch::is_running() const {
     return m_run && m_nodes < MAX_TREE_SIZE;
 }
 
-bool UCTSearch::stop_thinking(int elapsed_centis, int time_for_move) const {
-    auto visits = m_root->get_visits();
-    auto playouts = static_cast<int>(m_playouts);
-    auto stop = playouts >= m_maxplayouts
-                || visits >= m_maxvisits
-                || elapsed_centis >= time_for_move;
+int UCTSearch::est_playouts_left(int elapsed_centis, int time_for_move) const
+{
+    auto playouts = m_playouts.load();
+    const auto playouts_left = std::min(m_maxplayouts - playouts,
+                                        m_maxvisits - m_root->get_visits());
 
-    if (stop || cfg_timemanage == TimeManagement::OFF) {
-        return stop;
+    // Wait for at least 1 second and 100 playouts
+    // so we get a reliable playout_rate.
+    if (elapsed_centis < 100 || playouts < 100) {
+        return playouts_left;
     }
+    const auto playout_rate = 1.0f * playouts / elapsed_centis;
+    const auto time_left = time_for_move - elapsed_centis;
+    return std::min(playouts_left, static_cast<int>(std::ceil(playout_rate * time_left)));
+}
 
+size_t UCTSearch::prune_noncontenders(int elapsed_centis, int time_for_move) {
     auto Nfirst = 0;
-    auto Nsecond = 0;
     for (const auto& node : m_root->get_children()) {
         if (node->valid()) {
-             auto N = node->get_visits();
-             if (N > Nfirst) {
-                 Nsecond = Nfirst;
-                 Nfirst = N;
-             } else if (N > Nsecond) {
-                 Nsecond = N;
+             Nfirst = std::max(Nfirst, node->get_visits());
+        }
+    }
+    const auto min_required_visits = Nfirst - est_playouts_left(elapsed_centis, time_for_move);
+    auto pruned_nodes = size_t{0};
+    for (const auto& node : m_root->get_children()) {
+        if (node->valid()) {
+             const auto has_enough_visits = node->get_visits() >= min_required_visits;
+             node->set_active(has_enough_visits);
+             if (!has_enough_visits) {
+                 ++pruned_nodes;
              }
         }
     }
-    if ((m_maxplayouts - playouts < Nfirst - Nsecond)
-        || (m_maxvisits - visits < Nfirst - Nsecond)) {
-        stop = true;
-    } else if (elapsed_centis > 100 && playouts > 100) {
-        // Wait for at least 1 second and 100 playouts
-        // so we get a reliable playout_rate.
-        auto playout_rate = 1.0f * playouts / elapsed_centis;
-        auto time_left = time_for_move - elapsed_centis;
-        auto est_playouts_left = playout_rate * time_left;
-        if (est_playouts_left < Nfirst - Nsecond) {
-            stop = true;
-            myprintf("%.1fs left\n", time_left/100.0f);
-        }
-    }
-    if (stop) {
-        myprintf("Stopping early.\n");
-    }
-    return stop;
+
+    assert(pruned_nodes < m_root->get_children().size());
+    return pruned_nodes;
+}
+
+bool UCTSearch::stop_thinking(int elapsed_centis, int time_for_move) const {
+    return m_playouts >= m_maxplayouts
+           || m_root->get_visits() >= m_maxvisits
+           || elapsed_centis >= time_for_move;
 }
 
 void UCTWorker::operator()() {
@@ -520,7 +522,19 @@ int UCTSearch::think(int color, passflag_t passflag) {
         }
         keeprunning  = is_running();
         keeprunning &= !stop_thinking(elapsed_centis, time_for_move);
+        if (keeprunning && cfg_timemanage == TimeManagement::ON) {
+            if (prune_noncontenders(elapsed_centis, time_for_move) == m_root->get_children().size() - 1) {
+                myprintf("%.1fs left\n", (time_for_move - elapsed_centis)/100.0f);
+                myprintf("Stopping early.\n");
+                keeprunning = false;
+            }
+        }
     } while(keeprunning);
+
+    // reactivate all pruned root children
+    for (const auto& node : m_root->get_children()) {
+        node->set_active(true);
+    }
 
     // stop the search
     m_run = false;

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -86,6 +86,8 @@ public:
     void set_visit_limit(int visits);
     void ponder();
     bool is_running() const;
+    int est_playouts_left(int elapsed_centis, int time_for_move) const;
+    size_t prune_noncontenders(int elapsed_centis = 0, int time_for_move = 0);
     bool stop_thinking(int elapsed_centis = 0, int time_for_move = 0) const;
     void increment_playouts();
     SearchResult play_simulation(GameState& currstate, UCTNode* const node);


### PR DESCRIPTION
This generalizes the time management code such that it stops visiting any root child the moment it can no longer overtake the current best. Might provide a slight speed and/or performance boost.