### PR TITLE
Add tree_stats to compute stats search tree

### DIFF
--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -195,6 +195,47 @@ void UCTSearch::dump_stats(FastState & state, UCTNode & parent) {
             node->get_score() * 100.0f,
             pv.c_str());
     }
+    tree_stats(parent);
+}
+
+void tree_stats_helper(UCTNode* node, size_t depth,
+                       size_t& nodes, size_t& non_leaf_nodes,
+                       size_t& depth_sum, size_t& max_depth,
+                       size_t& children_count) {
+    nodes += 1;
+    non_leaf_nodes += node->get_visits() > 1;
+    depth_sum += depth;
+    if (depth > max_depth) max_depth = depth;
+
+    for (const auto& child : node->get_children()) {
+        if (!child->first_visit()) children_count += 1;
+
+        tree_stats_helper(child.get(), depth+1,
+                          nodes, non_leaf_nodes, depth_sum,
+                          max_depth, children_count);
+    }
+}
+
+void UCTSearch::tree_stats(UCTNode& node) {
+    if (cfg_quiet || !node.has_children()) {
+        return;
+    }
+
+    size_t nodes = 0;
+    size_t non_leaf_nodes = 0;
+    size_t depth_sum = 0;
+    size_t max_depth = 0;
+    size_t children_count = 0;
+    tree_stats_helper(&node, 0,
+                      nodes, non_leaf_nodes, depth_sum,
+                      max_depth, children_count);
+
+    if (nodes > 0) {
+        myprintf("%.1f average depth, %d max depth\n",
+                 (1.0f*depth_sum) / nodes, max_depth);
+        myprintf("%d non leaf nodes, %.2f average children\n",
+                 non_leaf_nodes, (1.0f*children_count) / non_leaf_nodes);
+    }
 }
 
 bool UCTSearch::should_resign(passflag_t passflag, float bestscore) {

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -92,6 +92,7 @@ public:
 
 private:
     void dump_stats(FastState& state, UCTNode& parent);
+    void tree_stats(UCTNode& node);
     std::string get_pv(FastState& state, UCTNode& parent);
     void dump_analysis(int playouts);
     bool should_resign(passflag_t passflag, float bestscore);


### PR DESCRIPTION
Calculates average node depth, max depth, number of "leaf nodes" (nodes  more than 1 children), average number of children.

I added this to the end of dump_stats which prints at the end of think (so 2 extra lines per move)

Example output of benchmark, weights = b8adb7da (my personal favorite network)

`./leelaz -w weights --benchmark --noponder -p 1000`
```
Thinking at most 2678400.0 seconds...
NN eval=0.476396

  D4 ->     313 (V: 50.26%) (N: 28.82%) PV: D4 D16 Q4 C3 C4 D3 E3 E2 F2 F3 E4 G2 D2 F1 C2 R3 R4 Q3 P3 P2
  Q4 ->     262 (V: 50.15%) (N: 25.25%) PV: Q4 D4 D16 R3 Q3 R4 R5 S5 S6 R6 Q5 S7 S4 T6 S3 C17 D17 C16 C15
 D16 ->     250 (V: 50.24%) (N: 23.48%) PV: D16 Q4 D4 C17 D17 C16 C15 B15 B14 C14 D15 B13 B16 A14 B17 C18 B18 C3 D3 C4
  R4 ->      38 (V: 50.03%) (N:  3.76%) PV: R4 D4 D16 C17 D17 C16 C15
  Q3 ->      30 (V: 50.08%) (N:  2.86%) PV: Q3 D4 D16 C17 C16 D17
 C16 ->      28 (V: 50.48%) (N:  2.41%) PV: C16 D4 Q4 R3 R4 Q3
 R17 ->      24 (V: 49.47%) (N:  3.06%) PV: R17 Q17 R16 R15 S15 S14 R14 Q15 S13 S16 T14 S17 Q4 D16 D4
  D3 ->      21 (V: 50.04%) (N:  2.21%) PV: D3 D16 Q4 R3 Q3 R4
  C4 ->      17 (V: 49.62%) (N:  2.03%) PV: C4 D16 Q4 R3 Q3 R4
 D17 ->      17 (V: 49.31%) (N:  2.28%) PV: D17 Q4 D4 C3 D3 C4
 9.0 average depth, 21 max depth
 790 non leaf nodes, 1.27 average children
1001 visits, 353373 nodes, 1000 playouts, 1265 n/s
```

With `-p 250000`
```
 D16 ->   71966 (V: 50.61%) (N: 23.48%) PV: D16 D4 Q4 R3 Q3 R4 R5 S5 S6 R6 Q5 S7 S4 T6 S3 C17 D17 C16 C15 B15 B14 C14 D15 B13 B16 A14 B17 C18 B18 D14 C6 F4 B4 E15 F16 E16
 ...[other nodes omitted]...
 R17 ->     835 (V: 49.27%) (N:  3.06%) PV: R17 Q17 R16 R15 S15 S14 R14 Q15 S13 S16 T14 S17 Q4 D16 D4 R3 R4 Q3 P3 P2 O2 O3 P4 N2 Q2 O1 R2
 20.3 average depth, 53 max depth
 197505 non leaf nodes, 1.27 average children
250001 visits, 85478206 nodes, 250000 playouts, 1350 n/s
```