### PR TITLE
Autogtp: Add self play only option

### DIFF
--- a/autogtp/Management.cpp
+++ b/autogtp/Management.cpp
@@ -42,7 +42,8 @@ Management::Management(const int gpus,
                        const int ver,
                        const int maxGames,
                        const QString& keep,
-                       const QString& debug)
+                       const QString& debug,
+                       const bool onlySelfPlay)
 
     : m_syncMutex(),
     m_gamesThreads(gpus * games),
@@ -54,6 +55,7 @@ Management::Management(const int gpus,
     m_gamesPlayed(0),
     m_keepPath(keep),
     m_debugPath(debug),
+    m_onlySelfPlay(onlySelfPlay),
     m_version(ver),
     m_fallBack(Order::Error),
     m_gamesLeft(maxGames),
@@ -125,7 +127,7 @@ void Management::giveAssignments() {
                 m_gamesThreads[thread_index]->order(getWork(finfo));
             } else {
                 m_gamesThreads[thread_index]->order(getWork());
-            }            
+            }
             m_gamesThreads[thread_index]->start();
         }
     }
@@ -309,7 +311,7 @@ Order Management::getWorkInternal(bool tuning) {
 #endif
     prog_cmdline.append(" -s -J");
     prog_cmdline.append(" http://zero.sjeng.org/get-task/");
-    if (tuning) {
+    if (tuning || m_onlySelfPlay) {
         prog_cmdline.append("0");
     } else {
         prog_cmdline.append(QString::number(AUTOGTP_VERSION));
@@ -591,8 +593,8 @@ void Management::sendAllGames() {
         QLockFile lf(fileInfo.fileName()+".lock");
         if (!lf.tryLock(10)) {
             continue;
-        }        
-        QFile file (fileInfo.fileName());        
+        }
+        QFile file (fileInfo.fileName());
         if (!file.open(QFile::ReadOnly)) {
             continue;
         }
@@ -730,7 +732,7 @@ void Management::uploadResult(const QMap<QString,QString> &r, const QMap<QString
 http://zero.sjeng.org/submit
 */
 
-void Management::uploadData(const QMap<QString,QString> &r, const QMap<QString,QString> &l) { 
+void Management::uploadData(const QMap<QString,QString> &r, const QMap<QString,QString> &l) {
     QTextStream(stdout) << "Uploading game: " << r["file"] << ".sgf for network " << l["network"] << endl;
     archiveFiles(r["file"]);
     gzipFile(r["file"] + ".sgf");

--- a/autogtp/Management.h
+++ b/autogtp/Management.h
@@ -40,7 +40,8 @@ public:
                const int ver,
                const int maxGame,
                const QString& keep,
-               const QString& debug);
+               const QString& debug,
+               const bool onlySelfPlay);
     ~Management() = default;
     void giveAssignments();
     void incMoves() { m_movesMade++; }
@@ -70,6 +71,7 @@ private:
     QAtomicInt m_movesMade;
     QString m_keepPath;
     QString m_debugPath;
+    bool m_onlySelfPlay;
     int m_version;
     std::chrono::high_resolution_clock::time_point m_start;
     int m_storeGames;

--- a/autogtp/main.cpp
+++ b/autogtp/main.cpp
@@ -62,14 +62,15 @@ int main(int argc, char *argv[]) {
     QCommandLineOption keepDebugOption(
         { "d", "debug" }, "Save training and extra debug files after each self-play game.",
                           "output directory");
+    QCommandLineOption onlySelfPlayOption(
+        { "o", "onlySelfPlay" },
+               "Only request self play games from server.");
     QCommandLineOption timeoutOption(
         { "t", "timeout" }, "Save running games after the timeout (in minutes) is passed and then exit.",
                           "time in minutes");
-
     QCommandLineOption singleOption(
         { "s", "single" }, "Exit after the first game is completed.",
                           "");
-
     QCommandLineOption maxOption(
         { "m", "maxgames" }, "Exit after the given number of games is completed.",
                           "max number of games");
@@ -78,6 +79,7 @@ int main(int argc, char *argv[]) {
     parser.addOption(gpusOption);
     parser.addOption(keepSgfOption);
     parser.addOption(keepDebugOption);
+    parser.addOption(onlySelfPlayOption);
     parser.addOption(timeoutOption);
     parser.addOption(singleOption);
     parser.addOption(maxOption);
@@ -108,7 +110,7 @@ int main(int argc, char *argv[]) {
     if(parser.isSet(singleOption)) {
         gamesNum = 1;
         gpusNum = 1;
-        maxNum = 0;      
+        maxNum = 0;
     }
 
     // Map streams
@@ -131,7 +133,8 @@ int main(int argc, char *argv[]) {
     }
     Console *cons = nullptr;
     Management *boss = new Management(gpusNum, gamesNum, gpusList, AUTOGTP_VERSION, maxNum,
-                                      parser.value(keepSgfOption), parser.value(keepDebugOption));
+                                      parser.value(keepSgfOption), parser.value(keepDebugOption),
+                                      parser.isSet(onlySelfPlayOption));
     QObject::connect(&app, &QCoreApplication::aboutToQuit, boss, &Management::storeGames);
     QTimer *timer = new QTimer();
     boss->giveAssignments();


### PR DESCRIPTION
Self play only allows clients who only want to run self play games to do
so. Especially important for slow/flaky networks and video card issues.