### PR TITLE
Add support for training on mini-batches larger than GPU RAM size.

### DIFF
--- a/training/tf/chunkparser.py
+++ b/training/tf/chunkparser.py
@@ -303,7 +303,7 @@ class ChunkParser:
                 item = self.v2_apply_symmetry(symmetry, item)
                 writer.send_bytes(item)
 
-    def chunk_gen(self):
+    def v2_gen(self):
         """
             Read v2 records from child workers, shuffle, and yield
             records.
@@ -355,7 +355,7 @@ class ChunkParser:
             Read data from child workers and yield batches
             of raw tensors
         """
-        gen = self.chunk_gen()     # read from workers
+        gen = self.v2_gen()        # read from workers
         gen = self.tuple_gen(gen)  # convert v2->tuple
         gen = self.batch_gen(gen)  # assemble into batches
         for b in gen:

--- a/training/tf/parse.py
+++ b/training/tf/parse.py
@@ -31,7 +31,8 @@ import time
 
 # Sane values are from 4096 to 64 or so.
 # You need to adjust the learning rate if you change this. Should be
-# a multiple of RAM_BATCH_SIZE
+# a multiple of RAM_BATCH_SIZE. NB: It's rare that large batch sizes are
+# actually required.
 BATCH_SIZE = 512
 # Number of examples in a GPU batch. Higher values are more efficient.
 # The maximum depends on the amount of RAM in your GPU and the network size.
@@ -50,9 +51,8 @@ class FileDataSrc:
         data source yielding chunkdata from chunk files.
     """
     def __init__(self, chunks):
-        self.chunks = chunks
-        random.shuffle(self.chunks)
-        self.done = []
+        self.done = chunks
+        self.chunks = []
     def next(self):
         if not self.chunks:
             self.chunks = self.done

--- a/training/tf/tfprocess.py
+++ b/training/tf/tfprocess.py
@@ -352,7 +352,7 @@ class TFProcess:
             return tf.layers.batch_normalization(
                     net,
                     epsilon=1e-5, axis=1, fused=True,
-                    center=True, scale=True,
+                    center=False, scale=False,
                     training=self.training)
 
 

--- a/training/tf/tfprocess.py
+++ b/training/tf/tfprocess.py
@@ -16,17 +16,18 @@
 #    You should have received a copy of the GNU General Public License
 #    along with Leela Zero.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import numpy as np
-import time
+import os
+import random
 import tensorflow as tf
+import time
 
 def weight_variable(shape):
     """Xavier initialization"""
     stddev = np.sqrt(2.0 / (sum(shape)))
     initial = tf.truncated_normal(shape, stddev=stddev)
     weights = tf.Variable(initial)
-    tf.add_to_collection(tf.GraphKeys.REGULARIZATION_LOSSES, weights)
+    tf.add_to_collection(tf.GraphKeys.WEIGHTS, weights)
     return weights
 
 # Bias weights for layers not followed by BatchNorm
@@ -46,6 +47,40 @@ def conv2d(x, W):
     return tf.nn.conv2d(x, W, data_format='NCHW',
                         strides=[1, 1, 1, 1], padding='SAME')
 
+# Class holding statistics
+class Stats:
+    def __init__(self):
+        self.s = {}
+    def add(self, stat_dict):
+        for (k,v) in stat_dict.items():
+            if k not in self.s:
+                self.s[k] = []
+            self.s[k].append(v)
+    def n(self, name):
+        return len(self.s[name] or [])
+    def mean(self, name):
+        return np.mean(self.s[name] or [0])
+    def stddev_mean(self, name):
+        # standard deviation in the sample mean.
+        return math.sqrt(np.var(self.s[name] or [0]) / max(0.0001, (len(self.s[name]) - 1)))
+    def str(self):
+        return ', '.join([ "{}={:g}".format(k, np.mean(v or [0])) for k,v in self.s.items()])
+    def clear(self):
+        self.s = {}
+    def summaries(self, tags):
+        return [ tf.Summary.Value(tag=k, simple_value=self.mean(v)) for k,v in tags.items() ]
+
+# Simple timer
+class Timer:
+    def __init__(self):
+        self.last = time.time()
+    def elapsed(self):
+        # Return time since last call to 'elapsed()'
+        t = time.time()
+        e = t - self.last
+        self.last = t
+        return e
+
 class TFProcess:
     def __init__(self):
         # Network structure
@@ -62,20 +97,33 @@ class TFProcess:
         self.training = tf.placeholder(tf.bool)
         self.global_step = tf.Variable(0, name='global_step', trainable=False)
 
-    def init(self, dataset, train_iterator, test_iterator):
-        # TF variables
-        self.handle = tf.placeholder(tf.string, shape=[])
-        iterator = tf.data.Iterator.from_string_handle(
-            self.handle, dataset.output_types, dataset.output_shapes)
-        self.next_batch = iterator.get_next()
-        self.train_handle = self.session.run(train_iterator.string_handle())
-        self.test_handle = self.session.run(test_iterator.string_handle())
-        self.init_net(self.next_batch)
+    def init(self, batch_size, macrobatch=1, logbase='leelalogs'):
+        self.batch_size = batch_size
+        self.macrobatch = macrobatch
+        self.logbase = logbase
+        # Input batch placeholders
+        self.planes = tf.placeholder(tf.string, name='in_planes')
+        self.probs = tf.placeholder(tf.string, name='in_probs')
+        self.winner = tf.placeholder(tf.string, name='in_winner')
 
-    def init_net(self, next_batch):
-        self.x = next_batch[0]  # tf.placeholder(tf.float32, [None, 18, 19 * 19])
-        self.y_ = next_batch[1] # tf.placeholder(tf.float32, [None, 362])
-        self.z_ = next_batch[2] # tf.placeholder(tf.float32, [None, 1])
+        # Mini-batches come as raw packed strings. Decode
+        # into tensors to feed into network.
+        planes = tf.decode_raw(self.planes, tf.uint8)
+        probs = tf.decode_raw(self.probs, tf.float32)
+        winner = tf.decode_raw(self.winner, tf.float32)
+
+        planes = tf.to_float(planes)
+
+        planes = tf.reshape(planes, (batch_size, 18, 19*19))
+        probs = tf.reshape(probs, (batch_size, 19*19 + 1))
+        winner = tf.reshape(winner, (batch_size, 1))
+
+        self.init_net(planes, probs, winner)
+
+    def init_net(self, planes, probs, winner):
+        self.x = planes  # (tf.float32, [None, 18, 19 * 19])
+        self.y_ = probs  # (tf.float32, [None, 362])
+        self.z_ = winner # (tf.float32, [None, 1])
         self.batch_norm_count = 0
         self.y_conv, self.z_conv = self.construct_net(self.x)
 
@@ -91,7 +139,7 @@ class TFProcess:
 
         # Regularizer
         regularizer = tf.contrib.layers.l2_regularizer(scale=0.0001)
-        reg_variables = tf.get_collection(tf.GraphKeys.REGULARIZATION_LOSSES)
+        reg_variables = tf.get_collection(tf.GraphKeys.WEIGHTS)
         self.reg_term = \
             tf.contrib.layers.apply_regularization(regularizer, reg_variables)
 
@@ -101,34 +149,58 @@ class TFProcess:
 
         # You need to change the learning rate here if you are training
         # from a self-play training set, for example start with 0.005 instead.
-        opt_op = tf.train.MomentumOptimizer(
+        opt = tf.train.MomentumOptimizer(
             learning_rate=0.05, momentum=0.9, use_nesterov=True)
 
+        # Compute and accumulate gradients
         self.update_ops = tf.get_collection(tf.GraphKeys.UPDATE_OPS)
+        total_grad=[]
+        grad_ops=[]
+        clear_var=[]
         with tf.control_dependencies(self.update_ops):
-            self.train_op = \
-                opt_op.minimize(loss, global_step=self.global_step)
+            self.grad_op_real = opt.compute_gradients(loss)
+            for (g, v) in self.grad_op_real:
+                if g is None:
+                    total_grad.append((g,v))
+                name = v.name.split(':')[0]
+                gsum = tf.get_variable(name='gsum/'+name,
+                                       shape=g.shape,
+                                       trainable=False,
+                                       initializer=tf.zeros_initializer)
+                total_grad.append((gsum, v))
+                grad_ops.append(tf.assign_add(gsum, g))
+                clear_var.append(gsum)
+        # Op to compute gradients and add to running total in 'gsum/'
+        self.grad_op = tf.group(*grad_ops)
+
+        # Op to apply accmulated gradients
+        self.train_op = opt.apply_gradients(total_grad)
+
+        zero_ops = []
+        for g in clear_var:
+            zero_ops.append(tf.assign(g, tf.zeros(shape=g.shape, dtype=g.dtype)))
+        # Op to clear accumulated gradients
+        self.clear_op = tf.group(*zero_ops)
+
+        # Op to increment global step counter
+        self.step_op = tf.assign_add(self.global_step, 1)
 
         correct_prediction = \
             tf.equal(tf.argmax(self.y_conv, 1), tf.argmax(self.y_, 1))
         correct_prediction = tf.cast(correct_prediction, tf.float32)
         self.accuracy = tf.reduce_mean(correct_prediction)
 
-        self.avg_policy_loss = []
-        self.avg_mse_loss = []
-        self.avg_reg_term = []
-        self.time_start = None
-
         # Summary part
         self.test_writer = tf.summary.FileWriter(
-            os.path.join(os.getcwd(), "leelalogs/test"), self.session.graph)
+            os.path.join(os.getcwd(), self.logbase + "/test"), self.session.graph)
         self.train_writer = tf.summary.FileWriter(
-            os.path.join(os.getcwd(), "leelalogs/train"), self.session.graph)
+            os.path.join(os.getcwd(), self.logbase + "/train"), self.session.graph)
 
-        self.init = tf.global_variables_initializer()
+        # Build checkpoint saver
         self.saver = tf.train.Saver()
 
-        self.session.run(self.init)
+        # Initialize all variables
+        self.session.run(tf.global_variables_initializer())
 
     def replace_weights(self, new_weights):
         for e, weights in enumerate(self.weights):
@@ -169,76 +241,67 @@ class TFProcess:
         print("Restoring from {0}".format(file))
         self.saver.restore(self.session, file)
 
-    def process(self, batch_size):
-        if not self.time_start:
-            self.time_start = time.time()
-        # Run training for this batch
-        policy_loss, mse_loss, reg_term, _, _ = self.session.run(
-            [self.policy_loss, self.mse_loss, self.reg_term, self.train_op,
-                self.next_batch],
-            feed_dict={self.training: True, self.handle: self.train_handle})
-        steps = tf.train.global_step(self.session, self.global_step)
-        # Keep running averages
-        # Google's paper scales MSE by 1/4 to a [0, 1] range, so do the same to
-        # get comparable values.
-        mse_loss = mse_loss / 4.0
-        self.avg_policy_loss.append(policy_loss)
-        self.avg_mse_loss.append(mse_loss)
-        self.avg_reg_term.append(reg_term)
-        if steps % 1000 == 0:
-            time_end = time.time()
-            speed = 0
-            if self.time_start:
-                elapsed = time_end - self.time_start
-                speed = batch_size * (1000.0 / elapsed)
-            avg_policy_loss = np.mean(self.avg_policy_loss or [0])
-            avg_mse_loss = np.mean(self.avg_mse_loss or [0])
-            avg_reg_term = np.mean(self.avg_reg_term or [0])
-            print("step {}, policy={:g} mse={:g} reg={:g} total={:g} ({:g} pos/s)".format(
-                steps, avg_policy_loss, avg_mse_loss, avg_reg_term,
-                # Scale mse_loss back to the original to reflect the actual
-                # value being optimized.
-                # If you changed the factor in the loss formula above, you need
-                # to change it here as well for correct outputs.
-                avg_policy_loss + 1.0 * 4.0 * avg_mse_loss + avg_reg_term,
-                speed))
-            train_summaries = tf.Summary(value=[
-                tf.Summary.Value(tag="Policy Loss", simple_value=avg_policy_loss),
-                tf.Summary.Value(tag="MSE Loss", simple_value=avg_mse_loss)])
-            self.train_writer.add_summary(train_summaries, steps)
-            self.time_start = time_end
-            self.avg_policy_loss, self.avg_mse_loss, self.avg_reg_term = [], [], []
-        if steps % 8000 == 0:
-            sum_accuracy = 0
-            sum_mse = 0
-            sum_policy = 0
-            test_batches = 800
-            for _ in range(0, test_batches):
-                test_policy, test_accuracy, test_mse, _ = self.session.run(
-                    [self.policy_loss, self.accuracy, self.mse_loss,
-                     self.next_batch],
-                    feed_dict={self.training: False,
-                               self.handle: self.test_handle})
-                sum_accuracy += test_accuracy
-                sum_mse += test_mse
-                sum_policy += test_policy
-            sum_accuracy /= test_batches
-            sum_policy /= test_batches
-            # Additionally rescale to [0, 1] so divide by 4
-            sum_mse /= (4.0 * test_batches)
-            test_summaries = tf.Summary(value=[
-                tf.Summary.Value(tag="Accuracy", simple_value=sum_accuracy),
-                tf.Summary.Value(tag="Policy Loss", simple_value=sum_policy),
-                tf.Summary.Value(tag="MSE Loss", simple_value=sum_mse)])
-            self.test_writer.add_summary(test_summaries, steps)
-            print("step {}, policy={:g} training accuracy={:g}%, mse={:g}".\
-                format(steps, sum_policy, sum_accuracy*100.0, sum_mse))
-            path = os.path.join(os.getcwd(), "leelaz-model")
-            save_path = self.saver.save(self.session, path, global_step=steps)
-            print("Model saved in file: {}".format(save_path))
-            leela_path = path + "-" + str(steps) + ".txt"
-            self.save_leelaz_weights(leela_path)
-            print("Leela weights saved to {}".format(leela_path))
+    def measure_loss(self, batch, training=False):
+        # Measure loss over one batch. If training is true, also
+        # accumulate the gradient and increment the global step.
+        ops = [self.policy_loss, self.mse_loss, self.reg_term, self.accuracy ]
+        if training:
+            ops += [self.grad_op, self.step_op],
+        r = self.session.run(ops, feed_dict={self.training: training,
+                           self.planes: batch[0], self.probs: batch[1], self.winner: batch[2]})
+        # Google's paper scales mse by 1/4 to a [0,1] range, so we do the same here
+        return {'policy': r[0], 'mse': r[1]/4., 'reg': r[2],
+                'accuracy': r[3], 'total': r[0]+r[1]+r[2] }
+
+    def process(self, train_data, test_data):
+        info_steps=1000
+        stats = Stats()
+        timer = Timer()
+        while True:
+            batch = next(train_data)
+            # Measure losses and compute gradients for this batch.
+            losses = self.measure_loss(batch, training=True)
+            stats.add(losses)
+            # fetch the current global step.
+            steps = tf.train.global_step(self.session, self.global_step)
+            if steps % self.macrobatch == (self.macrobatch-1):
+                # Apply the accumulated gradients to the weights.
+                self.session.run([self.train_op])
+                # Clear the accumulated gradient.
+                self.session.run([self.clear_op])
+
+            if steps % info_steps == 0:
+                speed = info_steps * self.batch_size / timer.elapsed()
+                print("step {}, policy={:g} mse={:g} reg={:g} total={:g} ({:g} pos/s)".format(
+                    steps, stats.mean('policy'), stats.mean('mse'), stats.mean('reg'),
+                    stats.mean('total'), speed))
+                summaries = stats.summaries({'Policy Loss': 'policy', 'MSE Loss': 'mse'})
+                self.train_writer.add_summary(tf.Summary(value=summaries), steps)
+                stats.clear()
+
+            if steps % 8000 == 0:
+                test_stats = Stats()
+                test_batches = 800 # reduce sample mean variance by ~28x
+                for _ in range(0, test_batches):
+                    test_batch = next(test_data)
+                    losses = self.measure_loss(test_batch, training=False)
+                    test_stats.add(losses)
+                summaries = test_stats.summaries({'Policy Loss': 'policy',
+                                                  'MSE Loss': 'mse',
+                                                  'Accuracy': 'accuracy'})
+                self.test_writer.add_summary(tf.Summary(value=summaries), steps)
+                print("step {}, policy={:g} training accuracy={:g}%, mse={:g}".\
+                    format(steps, test_stats.mean('policy'),
+                        test_stats.mean('accuracy')*100.0, test_stats.mean('mse')))
+
+                # Write out current model and checkpoint
+                path = os.path.join(os.getcwd(), "leelaz-model")
+                save_path = self.saver.save(self.session, path, global_step=steps)
+                print("Model saved in file: {}".format(save_path))
+                leela_path = path + "-" + str(steps) + ".txt"
+                self.save_leelaz_weights(leela_path)
+                print("Leela weights saved to {}".format(leela_path))
+                # Things have likely changed enough that stats are no longer valid.
 
     def save_leelaz_weights(self, filename):
         with open(filename, "w") as file:
@@ -278,66 +341,60 @@ class TFProcess:
         self.batch_norm_count += 1
         return result
 
+    def batch_norm(self, net):
+        # The weights are internal to the batchnorm layer, so apply
+        # a unique scope that we can store, and use to look them back up
+        # later on.
+        scope = self.get_batchnorm_key()
+        self.weights.append(scope + "/batch_normalization/moving_mean:0")
+        self.weights.append(scope + "/batch_normalization/moving_variance:0")
+        with tf.variable_scope(scope):
+            return tf.layers.batch_normalization(
+                    net,
+                    epsilon=1e-5, axis=1, fused=True,
+                    center=True, scale=True,
+                    training=self.training)
+
+
     def conv_block(self, inputs, filter_size, input_channels, output_channels):
         W_conv = weight_variable([filter_size, filter_size,
                                   input_channels, output_channels])
         b_conv = bn_bias_variable([output_channels])
         self.weights.append(W_conv)
         self.weights.append(b_conv)
-        # The weights are internal to the batchnorm layer, so apply
-        # a unique scope that we can store, and use to look them back up
-        # later on.
-        weight_key = self.get_batchnorm_key()
-        self.weights.append(weight_key + "/batch_normalization/moving_mean:0")
-        self.weights.append(weight_key + "/batch_normalization/moving_variance:0")
 
-        with tf.variable_scope(weight_key):
-            h_bn = \
-                tf.layers.batch_normalization(
-                    conv2d(inputs, W_conv),
-                    epsilon=1e-5, axis=1, fused=True,
-                    center=False, scale=False,
-                    training=self.training)
-        h_conv = tf.nn.relu(h_bn)
-        return h_conv
+        net = inputs
+        net = conv2d(net, W_conv)
+        net = self.batch_norm(net)
+        net = tf.nn.relu(net)
+        return net
 
     def residual_block(self, inputs, channels):
-        # First convnet
-        orig = tf.identity(inputs)
+        # First convnet weights
         W_conv_1 = weight_variable([3, 3, channels, channels])
         b_conv_1 = bn_bias_variable([channels])
         self.weights.append(W_conv_1)
         self.weights.append(b_conv_1)
-        weight_key_1 = self.get_batchnorm_key()
-        self.weights.append(weight_key_1 + "/batch_normalization/moving_mean:0")
-        self.weights.append(weight_key_1 + "/batch_normalization/moving_variance:0")
 
-        # Second convnet
+        # Second convnet weights
         W_conv_2 = weight_variable([3, 3, channels, channels])
         b_conv_2 = bn_bias_variable([channels])
         self.weights.append(W_conv_2)
         self.weights.append(b_conv_2)
-        weight_key_2 = self.get_batchnorm_key()
-        self.weights.append(weight_key_2 + "/batch_normalization/moving_mean:0")
-        self.weights.append(weight_key_2 + "/batch_normalization/moving_variance:0")
 
-        with tf.variable_scope(weight_key_1):
-            h_bn1 = \
-                tf.layers.batch_normalization(
-                    conv2d(inputs, W_conv_1),
-                    epsilon=1e-5, axis=1, fused=True,
-                    center=False, scale=False,
-                    training=self.training)
-        h_out_1 = tf.nn.relu(h_bn1)
-        with tf.variable_scope(weight_key_2):
-            h_bn2 = \
-                tf.layers.batch_normalization(
-                    conv2d(h_out_1, W_conv_2),
-                    epsilon=1e-5, axis=1, fused=True,
-                    center=False, scale=False,
-                    training=self.training)
-        h_out_2 = tf.nn.relu(tf.add(h_bn2, orig))
-        return h_out_2
+        # Construct network
+        net = inputs
+        orig = tf.identity(net)
+        net = conv2d(net, W_conv_1)
+        net = self.batch_norm(net)
+        net = tf.nn.relu(net)
+
+        net = conv2d(net, W_conv_2)
+        net = self.batch_norm(net)
+        net = tf.add(net, orig)
+        net = tf.nn.relu(net)
+
+        return net
 
     def construct_net(self, planes):
         # NCHW format

--- a/training/tf/v2_write_training.py
+++ b/training/tf/v2_write_training.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+#
+# Used to dump training games in V2 format from MongoDB or V1 chunk files.
+#
+# Usage: v2_write_training [chunk_prefix]
+#   If run without a chunk_prefix it reads from MongoDB.
+#  With a chunk prefix, it uses all chunk files with that prefix
+#  as input.
+#
+# Sets up a dataflow pipeline that:
+# 1. Reads from input (MongoDB or v1 chunk files)
+# 2. Split into a test set and a training set.
+# 3. Converts from v1 format to v2 format.
+# 4. Shuffle V2 records.
+# 5. Write out to compressed v2 chunk files.
+#
+
+from chunkparser import ChunkParser
+import gzip
+import itertools
+import multiprocessing as mp
+import numpy as np
+import pymongo
+import sys
+
+def mongo_fetch_games(q_out, num_games):
+    """
+        Read V1 format games from MongoDB and put them
+        in the output queue (q_out)
+
+        Reads a network list from MongoDB from most recents,
+        and then reads games produced by those network until
+        'num_games' has been read.
+    """
+    client = pymongo.MongoClient()
+    db = client.test
+    # MongoDB closes idle cursors after 10 minutes unless specific
+    # options are given. That means this query will time out before
+    # we finish. Rather than keeping it alive, increase the default
+    # batch size so we're sure to get all networks in the first fetch.
+    networks = db.networks.find(None, {"_id": False, "hash": True}).\
+        sort("_id", pymongo.DESCENDING).batch_size(5000)
+
+    game_count = 0
+    for net in networks:
+        print("Searching for {}".format(net['hash']))
+
+        games = db.games.\
+            find({"networkhash": net['hash']},
+                 {"_id": False, "data": True})
+
+        for game in games:
+            game_data = game['data']
+            q_out.put(game_data.encode("ascii"))
+
+            game_count += 1
+            if game_count >= num_games:
+                q_out.put('STOP')
+                return
+            if game_count % 1000 == 0:
+                print("{} games".format(game_count))
+
+def disk_fetch_games(q_out, prefix):
+    """
+        Fetch chunk files off disk.
+
+        Chunk files can be either v1 or v2 format.
+    """
+    files = glob.glob(prefix + "*.gz")
+    for f in files:
+        with gzip.open(f, 'rb') as chunk_file:
+            v = chunk_file.read()
+            q_out.put(v)
+            print("In {}".format(f))
+    q_out.put('STOP')
+
+def fake_fetch_games(q_out, num_games):
+    """
+        Generate V1 format fake games. Used for testing and benchmarking
+    """
+    for _ in range(num_games):
+        # Generate a 200 move 'game'
+        # Generate a random game move.
+        # 1. 18 binary planes of length 361
+        planes = [np.random.randint(2, size=361).tolist() for plane in range(16)]
+        stm = float(np.random.randint(2))
+        planes.append([stm] * 361)
+        planes.append([1. - stm] * 361)
+        # 2. 362 probs
+        probs = np.random.randint(3, size=362).tolist()
+        # 3. And a winner: 1 or -1
+        winner = [ 2 * float(np.random.randint(2)) - 1 ]
+
+        # Convert that to a v1 text record.
+        items = []
+        for p in range(16):
+            # generate first 360 bits
+            h = np.packbits([int(x) for x in planes[p][0:360]]).tobytes().hex()
+            # then add the stray single bit
+            h += str(planes[p][360]) + "\n"
+            items.append(h)
+        # then side to move
+        items.append(str(int(planes[17][0])) + "\n")
+        # then probabilities
+        items.append(' '.join([str(x) for x in probs]) + "\n")
+        # and finally if the side to move is a winner
+        items.append(str(int(winner[0])) + "\n")
+        game = ''.join(items)
+        game = game * 200
+        game = game.encode('ascii')
+
+        q_out.put(game)
+    q_out.put('STOP')
+
+def queue_gen(q, out_qs):
+    """
+        Turn a queue into a generator
+
+        Yields items pulled from 'q' until a 'STOP' item is seen.
+        The STOP item will be propogated to all the queues in
+        the list 'out_qs' (if any).
+    """
+    while True:
+        try:
+            item = q.get()
+        except:
+            break
+        if item == 'STOP':
+            break
+        yield item
+    # There might be multiple workers reading from this queue,
+    # and they all need to be stopped, so put the STOP token
+    # back in the queue.
+    q.put('STOP')
+    # Stop any listed output queues as well
+    for x in out_qs:
+        x.put('STOP')
+
+def split_train_test(q_in, q_train, q_test):
+    """
+        Stream a stream of chunks into separate train and test
+        pools. 10% of the chunks are assigned to test.
+
+        Uses hash sharding, so multiple runs will split chunks
+        in the same way.
+    """
+    for item in queue_gen(q_in, [q_train, q_test]):
+        # Use the hash of the game to determine the split. This means
+        # that test games will never be used for training.
+        h = hash(item) & 0xfff
+        if h < 0.1*0xfff:
+            # a test game.
+            q_test.put(item)
+        else:
+            q_train.put(item)
+
+class QueueChunkSrc:
+    def __init__(self, q):
+        self.q = q
+        self.gen = None
+    def next(self):
+        print("Queue next")
+        if self.gen is None:
+            self.gen = queue_gen(self.q,[])
+        try:
+            return next(self.gen)
+        except:
+            return None
+
+
+def chunk_parser(q_in, q_out, shuffle_size, chunk_size):
+    """
+        Parse input chunks from 'q_in', shuffle, and put
+        chunks of moves in v2 format into 'q_out'
+
+        Each output chunk contains 'chunk_size' moves.
+        Moves are shuffled in a buffer of 'shuffle_size' moves.
+        (A 2^20 items shuffle buffer is ~ 2.2GB of RAM).
+    """
+    workers = max(1, mp.cpu_count() - 2)
+    parse = ChunkParser(QueueChunkSrc(q_in),
+                        shuffle_size=shuffle_size,
+                        workers=workers)
+    gen = parse.v2_gen()
+    while True:
+        s = list(itertools.islice(gen, chunk_size))
+        if not len(s):
+            break
+        s = b''.join(s)
+        q_out.put(s)
+    q_out.put('STOP')
+
+def chunk_writer(q_in, namesrc):
+    """
+        Write a batch of moves out to disk as a compressed file.
+
+        Filenames are taken from the generator 'namegen'.
+    """
+    for chunk in queue_gen(q_in,[]):
+        filename = namesrc.next()
+        chunk_file = gzip.open(filename, 'w', 1)
+        chunk_file.write(chunk)
+        chunk_file.close()
+    print("chunk_writer completed")
+
+class NameSrc:
+    """
+        Generator a sequence of names, starting with 'prefix'.
+    """
+    def __init__(self, prefix):
+        self.prefix = prefix
+        self.n = 0
+    def next(self):
+        print("Name next")
+        self.n += 1
+        return self.prefix + "{:0>8d}.gz".format(self.n)
+
+def main(args):
+    # Build the pipeline.
+    procs=[]
+    # Read from input.
+    q_games = mp.SimpleQueue()
+    if args:
+        prefix = args.pop(0)
+        print("Reading from chunkfiles {}".format(prefix))
+        procs.append(mp.Process(target=disk_fetch_games, args=(q_games, prefix)))
+    else:
+        print("Reading from MongoDB")
+        #procs.append(mp.Process(target=fake_fetch_games, args=(q_games, 20)))
+        procs.append(mp.Process(target=mongo_fetch_games, args=(q_games, 275000)))
+    # Split into train/test
+    q_test = mp.SimpleQueue()
+    q_train = mp.SimpleQueue()
+    procs.append(mp.Process(target=split_train_test, args=(q_games, q_train, q_test)))
+    # Convert v1 to v2 format and shuffle, writing 8192 moves per chunk.
+    q_write_train = mp.SimpleQueue()
+    q_write_test = mp.SimpleQueue()
+    # Shuffle buffer is ~ 2.2GB of RAM with 2^20 (~1e6) entries. A game is ~500 moves, so
+    # there's ~2000 games in the shuffle buffer. Selecting 8k moves gives an expected
+    # number of ~4 moves from the same game in a given chunk file.
+    #
+    # The output files are in parse.py via another 1e6 sized shuffle buffer. At 8192 moves
+    # per chunk, there's ~ 128 chunks in the shuffle buffer. With a batch size of 4096,
+    # the expected max number of moves from the same game in the batch is < 1.14
+    procs.append(mp.Process(target=chunk_parser, args=(q_train, q_write_train, 1<<20, 8192)))
+    procs.append(mp.Process(target=chunk_parser, args=(q_test, q_write_test, 1<<16, 8192)))
+    # Write to output files
+    procs.append(mp.Process(target=chunk_writer, args=(q_write_train, NameSrc('train_'))))
+    procs.append(mp.Process(target=chunk_writer, args=(q_write_test, NameSrc('test_'))))
+
+    # Start all the child processes running.
+    for p in procs:
+        p.start()
+    # Wait for everything to finish.
+    for p in procs:
+        p.join()
+    # All done!
+
+if __name__ == "__main__":
+    mp.set_start_method('spawn')
+    main(sys.argv[1:])

--- a/training/tf/v2_write_training.py
+++ b/training/tf/v2_write_training.py
@@ -16,6 +16,7 @@
 #
 
 from chunkparser import ChunkParser
+import glob
 import gzip
 import itertools
 import multiprocessing as mp


### PR DESCRIPTION
Add support for mini-batches larger than GPU RAM size.
    
    1. Minor bugfix to use correctly use WEIGHTS instead of REGULARIZATION_LOSSES.
    2. Refactor out statistics into a separate class.
    3. Refactor out timing into a separate class.
    4. Refactor out batch_norm
    5. Refactor out measuring loss
    6. Drop use of tf.Dataset: instead, feed batches directly into placeholders.  (Simplifies code)
    7. Run 'while True' loop inside tfprocess.py instead of parse.py
    8. Split out training into 'compute_gradient' + 'apply gradient'.
    9. Accumulate gradient until a full macrobatch has been processed before applying.

(NB: This is based on #959)
Should be fully backward compatible with previous iterations of training scripts.
