### PR TITLE
README: explicit link to autogtp's readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ after each game. You can just close the autogtp window to stop it.
 ## macOS and Linux
 
 Follow the instructions below to compile the leelaz binary, then go into
-the autogtp subdirectory and follow the instructions there to build the
+the autogtp subdirectory and follow [the instructions there](autogtp/README.md) to build the
 autogtp binary. Copy the leelaz binary into the autogtp dir, and launch
 autogtp.
 


### PR DESCRIPTION
It's easy to overlook the existence of the other readme, as what happened [here](https://www.reddit.com/r/cbaduk/comments/83a4jl/i_need_help_to_get_automatic_leela_zero_training/).