### PR TITLE
Fixes to prevent pondering from running forever.

### DIFF
--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -593,11 +593,11 @@ int UCTSearch::think(int color, passflag_t passflag) {
     Time elapsed;
     int elapsed_centis = Time::timediff_centis(start, elapsed);
     if (elapsed_centis+1 > 0) {
-        myprintf("%d visits, %d nodes, %d playouts, %d n/s\n\n",
+        myprintf("%d visits, %d nodes, %d playouts, %.0f n/s\n\n",
                  m_root->get_visits(),
                  static_cast<int>(m_nodes),
                  static_cast<int>(m_playouts),
-                 (m_playouts * 100) / (elapsed_centis+1));
+                 (m_playouts * 100.0) / (elapsed_centis+1));
     }
     int bestmove = get_best_move(passflag);
 
@@ -641,6 +641,7 @@ void UCTSearch::set_playout_limit(int playouts) {
                                       decltype(m_maxplayouts)>::value,
                   "Inconsistent types for playout amount.");
     if (playouts == 0) {
+        // Divide max by 2 to prevent overflow corner cases.
         m_maxplayouts = std::numeric_limits<decltype(m_maxplayouts)>::max()/2;
     } else {
         m_maxplayouts = playouts;
@@ -652,6 +653,7 @@ void UCTSearch::set_visit_limit(int visits) {
                                       decltype(m_maxvisits)>::value,
                   "Inconsistent types for visits amount.");
     if (visits == 0) {
+        // Divide max by 2 to prevent overflow corner cases.
         m_maxvisits = std::numeric_limits<decltype(m_maxvisits)>::max()/2;
     } else {
         m_maxvisits = visits;

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -615,13 +615,16 @@ void UCTSearch::ponder() {
     for (int i = 1; i < cpus; i++) {
         tg.add_task(UCTWorker(m_rootstate, this, m_root.get()));
     }
+    auto keeprunning = true;
     do {
         auto currstate = std::make_unique<GameState>(m_rootstate);
         auto result = play_simulation(*currstate, m_root.get());
         if (result.valid()) {
             increment_playouts();
         }
-    } while(!Utils::input_pending() && is_running());
+        keeprunning  = is_running();
+        keeprunning &= !stop_thinking(0, 1);
+    } while(!Utils::input_pending() && keeprunning);
 
     // stop the search
     m_run = false;
@@ -638,7 +641,7 @@ void UCTSearch::set_playout_limit(int playouts) {
                                       decltype(m_maxplayouts)>::value,
                   "Inconsistent types for playout amount.");
     if (playouts == 0) {
-        m_maxplayouts = std::numeric_limits<decltype(m_maxplayouts)>::max();
+        m_maxplayouts = std::numeric_limits<decltype(m_maxplayouts)>::max()/2;
     } else {
         m_maxplayouts = playouts;
     }
@@ -649,7 +652,7 @@ void UCTSearch::set_visit_limit(int visits) {
                                       decltype(m_maxvisits)>::value,
                   "Inconsistent types for visits amount.");
     if (visits == 0) {
-        m_maxvisits = std::numeric_limits<decltype(m_maxvisits)>::max();
+        m_maxvisits = std::numeric_limits<decltype(m_maxvisits)>::max()/2;
     } else {
         m_maxvisits = visits;
     }


### PR DESCRIPTION
Fixes to prevent pondering from running forever. Stop after m_maxvisits or m_maxplayouts. I think this is probably close to what a user expects when they use `-v` but leave pondering on. Without `-v` in normal cases it will stop on MAX_TREE_SIZE. But in some endgame cases the tree is not growing, so this change also prevents overflowing m_visits in nodes. See more here https://github.com/gcp/leela-zero/issues/994#issuecomment-371999812

I just picked numeric_limits::max/2, that should be more than enough I think. Another possibility is subtract something like 1000 from max just to prevent multiple threads from causing it to go past max.

This fixes one possible cause for #994. I think we need to do something more dynamic about MAX_TREE_SIZE to prevent using all memory and slowing a user's machine to a crawl. Anyone have an idea for that?
