### PR TITLE
Multi-GPU thread scalability improvements

### DIFF
--- a/src/OpenCL.h
+++ b/src/OpenCL.h
@@ -69,6 +69,10 @@ private:
     cl::Buffer m_pinnedOutBuffer_pol;
     cl::Buffer m_pinnedOutBuffer_val;
     bool m_buffers_allocated{false};
+
+public:
+    int m_gpu_num;
+    ThreadData(int gpu_num) : m_gpu_num(gpu_num) {}
 };
 
 class OpenCL_Network {
@@ -200,7 +204,7 @@ private:
     bool m_init_ok{false};
 };
 
-extern thread_local ThreadData opencl_thread_data;
+extern thread_local std::unique_ptr<ThreadData> opencl_thread_data;
 extern const std::string sourceCode_sgemm;
 
 #endif

--- a/src/OpenCLScheduler.cpp
+++ b/src/OpenCLScheduler.cpp
@@ -36,7 +36,6 @@ void OpenCLScheduler::initialize(const int channels) {
         m_thread_data_count = 0;
         // on a multi-gpu situation, we are going to maintain a thread data pool.
 
-        m_thread_data.resize(cfg_gpus.size());
         for (auto gpu : cfg_gpus) {
             // create opencl thread data explicitly here with the right 'gnum'.
             opencl_thread_data = std::make_unique<ThreadData>(gnum);
@@ -50,8 +49,9 @@ void OpenCLScheduler::initialize(const int channels) {
             // starting next GPU, let's not dump full list of GPUs
             silent = true;
 
-            m_thread_data[gnum].push_back(std::move(opencl_thread_data));
-            m_thread_data[gnum].emplace_back( new ThreadData(gnum) );
+            m_thread_data.emplace_back(new ThreadDataQueue());
+            m_thread_data[gnum]->push_back(std::move(opencl_thread_data));
+            m_thread_data[gnum]->emplace_back( new ThreadData(gnum) );
 
             m_thread_data_count += 2;
             gnum++;
@@ -90,7 +90,7 @@ void OpenCLScheduler::forward(const std::vector<net_t>& input,
         // while trying to avoid the most recently scheduled thread.
         for(auto i = size_t{0}; i<m_thread_data.size(); i++) {
             auto gnum = (i + m_thread_data_recently_scheduled + 1) % m_thread_data.size();
-            auto sz = m_thread_data[gnum].size();
+            auto sz = m_thread_data[gnum]->size();
             if (sz > max_gnum_cnt) {
                 max_gnum = gnum;
                 max_gnum_cnt = sz;
@@ -98,8 +98,8 @@ void OpenCLScheduler::forward(const std::vector<net_t>& input,
         }
        
         assert(max_gnum_cnt > 0); 
-        opencl_thread_data = std::move(m_thread_data[max_gnum].front());
-        m_thread_data[max_gnum].pop_front();
+        opencl_thread_data = std::move(m_thread_data[max_gnum]->front());
+        m_thread_data[max_gnum]->pop_front();
         m_thread_data_recently_scheduled = max_gnum;
         m_thread_data_count--;
     }
@@ -113,7 +113,7 @@ void OpenCLScheduler::forward(const std::vector<net_t>& input,
         std::lock_guard<std::mutex> lk(m_mutex);
 
         int gnum = opencl_thread_data->m_gpu_num;
-        m_thread_data[gnum].push_back(std::move(opencl_thread_data));
+        m_thread_data[gnum]->push_back(std::move(opencl_thread_data));
         m_thread_data_count++;
         m_cv.notify_one();
     }

--- a/src/OpenCLScheduler.cpp
+++ b/src/OpenCLScheduler.cpp
@@ -33,7 +33,10 @@ void OpenCLScheduler::initialize(const int channels) {
         auto silent{false};
         int gnum = 0;
 
+        m_thread_data_count = 0;
         // on a multi-gpu situation, we are going to maintain a thread data pool.
+
+        m_thread_data.resize(cfg_gpus.size());
         for (auto gpu : cfg_gpus) {
             // create opencl thread data explicitly here with the right 'gnum'.
             opencl_thread_data = std::make_unique<ThreadData>(gnum);
@@ -47,9 +50,10 @@ void OpenCLScheduler::initialize(const int channels) {
             // starting next GPU, let's not dump full list of GPUs
             silent = true;
 
-            m_thread_data.push_back(std::move(opencl_thread_data));
-            m_thread_data.emplace_back( new ThreadData(gnum) );
+            m_thread_data[gnum].push_back(std::move(opencl_thread_data));
+            m_thread_data[gnum].emplace_back( new ThreadData(gnum) );
 
+            m_thread_data_count += 2;
             gnum++;
         }
     } else {
@@ -76,22 +80,41 @@ void OpenCLScheduler::forward(const std::vector<net_t>& input,
     // acquire a thread context.
     {
         std::unique_lock<std::mutex> lk(m_mutex);
-        if (m_thread_data.empty()) {
-            m_cv.wait(lk, [this]() { return !m_thread_data.empty(); });
-        }
+        m_cv.wait(lk, [this]() { return (m_thread_data_count > 0);});
         
-        assert(!m_thread_data.empty());
-        opencl_thread_data = std::move(m_thread_data.front());
-        m_thread_data.pop_front();
+        assert(m_thread_data_count > 0);
+        auto max_gnum = size_t{0};
+        auto max_gnum_cnt = size_t{0};
+
+        // Acquire the GPU with the most number of contexts available
+        // while trying to avoid the most recently scheduled thread.
+        for(auto i = size_t{0}; i<m_thread_data.size(); i++) {
+            auto gnum = (i + m_thread_data_recently_scheduled + 1) % m_thread_data.size();
+            auto sz = m_thread_data[gnum].size();
+            if (sz > max_gnum_cnt) {
+                max_gnum = gnum;
+                max_gnum_cnt = sz;
+            }
+        }
+       
+        assert(max_gnum_cnt > 0); 
+        opencl_thread_data = std::move(m_thread_data[max_gnum].front());
+        m_thread_data[max_gnum].pop_front();
+        m_thread_data_recently_scheduled = max_gnum;
+        m_thread_data_count--;
     }
 
+    assert(opencl_thread_data != nullptr);
     // run it.
     m_networks[opencl_thread_data->m_gpu_num]->forward(input, output_pol, output_val);
 
     // ...and release the thread context
     {
         std::lock_guard<std::mutex> lk(m_mutex);
-        m_thread_data.push_back(std::move(opencl_thread_data));
+
+        int gnum = opencl_thread_data->m_gpu_num;
+        m_thread_data[gnum].push_back(std::move(opencl_thread_data));
+        m_thread_data_count++;
         m_cv.notify_one();
     }
 }

--- a/src/OpenCLScheduler.h
+++ b/src/OpenCLScheduler.h
@@ -21,7 +21,7 @@
 #include "config.h"
 
 #include <vector>
-#include <list>
+#include <deque>
 #include <future>
 
 #include "OpenCL.h"
@@ -50,7 +50,9 @@ private:
 
     std::vector<std::unique_ptr<OpenCL_Network>> m_networks;
     std::vector<std::unique_ptr<OpenCL>> m_opencl;
-    std::vector<std::list<std::unique_ptr<ThreadData>>> m_thread_data;
+
+    typedef std::deque<std::unique_ptr<ThreadData>> ThreadDataQueue;
+    std::vector<std::unique_ptr<ThreadDataQueue>> m_thread_data;
     int m_thread_data_count = 0;
     int m_thread_data_recently_scheduled = 0;
     std::mutex m_mutex;

--- a/src/OpenCLScheduler.h
+++ b/src/OpenCLScheduler.h
@@ -21,6 +21,7 @@
 #include "config.h"
 
 #include <vector>
+#include <list>
 #include <future>
 
 #include "OpenCL.h"
@@ -49,7 +50,9 @@ private:
 
     std::vector<std::unique_ptr<OpenCL_Network>> m_networks;
     std::vector<std::unique_ptr<OpenCL>> m_opencl;
-    std::deque<std::unique_ptr<ThreadData>> m_thread_data;
+    std::vector<std::list<std::unique_ptr<ThreadData>>> m_thread_data;
+    int m_thread_data_count = 0;
+    int m_thread_data_recently_scheduled = 0;
     std::mutex m_mutex;
     std::condition_variable m_cv;
 };

--- a/src/OpenCLScheduler.h
+++ b/src/OpenCLScheduler.h
@@ -49,7 +49,9 @@ private:
 
     std::vector<std::unique_ptr<OpenCL_Network>> m_networks;
     std::vector<std::unique_ptr<OpenCL>> m_opencl;
-    Utils::ThreadPool m_threadpool;
+    std::deque<std::unique_ptr<ThreadData>> m_thread_data;
+    std::mutex m_mutex;
+    std::condition_variable m_cv;
 };
 
 extern OpenCLScheduler opencl;


### PR DESCRIPTION
- Instead of using worker threads, maintain a pool of thread contexts
- This means that any thread can acquire any GPU, but reduces the number thread-to-thread communication

'netbench 2000' performance on my i7-8700 + GTX 1080 + GTX 1050 setup:

- Before this patch:
2t 1567n/s
3t 2579n/s
4t 2970n/s
5t 3381n/s
- After this patch
2t 1276n/s
3t 2637n/s
4t 3101n/s
5t 3438n/s

Probably will need some more comparisons on bigger machines.