### PR TITLE
Next 709 fast board tests bb

### DIFF
--- a/src/FastBoard.cpp
+++ b/src/FastBoard.cpp
@@ -25,8 +25,6 @@
 #include <queue>
 #include <sstream>
 #include <string>
-#include <cstdarg>
-#include <cstdio>
 
 #include "Utils.h"
 #include "config.h"

--- a/src/FastBoard.cpp
+++ b/src/FastBoard.cpp
@@ -19,11 +19,14 @@
 #include "FastBoard.h"
 
 #include <cassert>
+#include <boost/format.hpp>
 #include <array>
 #include <iostream>
 #include <queue>
 #include <sstream>
 #include <string>
+#include <cstdarg>
+#include <cstdio>
 
 #include "Utils.h"
 #include "config.h"
@@ -277,48 +280,58 @@ float FastBoard::area_score(float komi) const {
     return black - white - komi;
 }
 
-void FastBoard::display_board(int lastmove) {
-    int boardsize = get_boardsize();
 
-    myprintf("\n   ");
-    print_columns();
-    for (int j = boardsize-1; j >= 0; j--) {
-        myprintf("%2d", j+1);
-        if (lastmove == get_vertex(0, j))
-            myprintf("(");
-        else
-            myprintf(" ");
-        for (int i = 0; i < boardsize; i++) {
-            if (get_square(i,j) == WHITE) {
-                myprintf("O");
-            } else if (get_square(i,j) == BLACK)  {
-                myprintf("X");
-            } else if (starpoint(boardsize, i, j)) {
-                myprintf("+");
-            } else {
-                myprintf(".");
-            }
-            if (lastmove == get_vertex(i, j)) myprintf(")");
-            else if (i != boardsize-1 && lastmove == get_vertex(i, j)+1) myprintf("(");
-            else myprintf(" ");
-        }
-        myprintf("%2d\n", j+1);
-    }
-    myprintf("   ");
-    print_columns();
-    myprintf("\n");
+void FastBoard::display_board(int lastmove) {
+    myprintf("%s", FastBoard::serialize_board(lastmove).c_str());
 }
 
-void FastBoard::print_columns() {
-    for (int i = 0; i < get_boardsize(); i++) {
-        if (i < 25) {
-            myprintf("%c ", (('a' + i < 'i') ? 'a' + i : 'a' + i + 1));
+std::string FastBoard::serialize_board(int lastmove) {
+    
+    int boardsize = get_boardsize();
+    std::ostringstream oss;
+
+    oss << "\n   ";
+    oss << get_columns();
+    for (int j = boardsize-1; j >= 0; j--) {
+        oss << boost::format("%2d") % (j + 1);
+        if (lastmove == get_vertex(0, j))
+            oss << "(";
+        else
+            oss << " ";
+        for (int i = 0; i < boardsize; i++) {
+            if (get_square(i,j) == WHITE) {
+                oss << "O";
+            } else if (get_square(i,j) == BLACK)  {
+                oss << "X";
+            } else if (starpoint(boardsize, i, j)) {
+                oss << "+";
+            } else {
+                oss << ".";
+            }
+            if (lastmove == get_vertex(i, j)) 
+                oss << ")";
+            else if (i != boardsize-1 && lastmove == get_vertex(i, j)+1) 
+                oss << "(";
+            else oss << " ";
         }
-        else {
-            myprintf("%c ", (('A' + (i - 25) < 'I') ? 'A' + (i - 25) : 'A' + (i - 25) + 1));
-        }
+        oss << boost::format("%2d\n") % (j + 1);
     }
-    myprintf("\n");
+    oss << "   ";
+    oss << get_columns();
+    oss << "\n";
+    return oss.str();
+}
+
+std::string FastBoard::get_columns() {
+    std::ostringstream oss;
+    for (int i = 0; i < get_boardsize(); i++) {
+        char c =  (i < 25) ?
+            (('a' + i < 'i') ? 'a' + i : 'a' + i + 1) :
+            (('A' + (i - 25) < 'I') ? 'A' + (i - 25) : 'A' + (i - 25) + 1);
+        oss << c << " ";
+    }
+    oss << "\n";
+    return oss.str();
 }
 
 void FastBoard::merge_strings(const int ip, const int aip) {

--- a/src/FastBoard.h
+++ b/src/FastBoard.h
@@ -96,6 +96,7 @@ public:
 
     void reset_board(int size);
     void display_board(int lastmove = -1);
+    std::string serialize_board(int lastmove = -1);
 
     static bool starpoint(int size, int point);
     static bool starpoint(int size, int x, int y);
@@ -131,7 +132,7 @@ protected:
     void merge_strings(const int ip, const int aip);
     void add_neighbour(const int i, const int color);
     void remove_neighbour(const int i, const int color);
-    void print_columns();
+    std::string get_columns();
 };
 
 #endif

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -44,13 +44,14 @@ namespace Utils {
 
     template<typename T>
     T rotl(const T x, const int k) {
-	    return (x << k) | (x >> (std::numeric_limits<T>::digits - k));
+        return (x << k) | (x >> (std::numeric_limits<T>::digits - k));
     }
 
     inline bool is7bit(int c) {
         return c >= 0 && c <= 127;
     }
 
+    /* Returns the smallest multiple of b that is larger than a */
     size_t ceilMultiple(size_t a, size_t b);
 }
 

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -51,7 +51,7 @@ namespace Utils {
         return c >= 0 && c <= 127;
     }
 
-    /* Returns the smallest multiple of b that is larger than a */
+    /* Returns the smallest multiple of b that is larger than or equal to a */
     size_t ceilMultiple(size_t a, size_t b);
 }
 

--- a/src/tests/FastBoard_unittest.cpp
+++ b/src/tests/FastBoard_unittest.cpp
@@ -21,10 +21,8 @@
 #include <limits>
 #include <vector>
 
-#include "Utils.h"
 #include "FastBoard.h"
 
-using namespace Utils;
 
 TEST(FastBoardTest, Board3x3) {
     FastBoard b;
@@ -33,4 +31,34 @@ TEST(FastBoardTest, Board3x3) {
         "\n   a b c \n 3 . . .  3\n 2 . . .  2\n 1 . . .  1\n   a b c \n\n",  
         b.serialize_board()
     );
+}
+
+TEST(FastBoardTest, MakeBlackMoveOn19x19) {
+    FastBoard b;
+    b.reset_board(19);
+    b.set_square(b.get_vertex(2, 1), FastBoard::BLACK);
+    
+    const char *expected = "\n"
+        "   a b c d e f g h j k l m n o p q r s t \n"
+        "19 . . . . . . . . . . . . . . . . . . . 19\n"
+        "18 . . . . . . . . . . . . . . . . . . . 18\n"
+        "17 . . . . . . . . . . . . . . . . . . . 17\n"
+        "16 . . . + . . . . . + . . . . . + . . . 16\n"
+        "15 . . . . . . . . . . . . . . . . . . . 15\n"
+        "14 . . . . . . . . . . . . . . . . . . . 14\n"
+        "13 . . . . . . . . . . . . . . . . . . . 13\n"
+        "12 . . . . . . . . . . . . . . . . . . . 12\n"
+        "11 . . . . . . . . . . . . . . . . . . . 11\n"
+        "10 . . . + . . . . . + . . . . . + . . . 10\n"
+        " 9 . . . . . . . . . . . . . . . . . . .  9\n"
+        " 8 . . . . . . . . . . . . . . . . . . .  8\n"
+        " 7 . . . . . . . . . . . . . . . . . . .  7\n"
+        " 6 . . . . . . . . . . . . . . . . . . .  6\n" 
+        " 5 . . . . . . . . . . . . . . . . . . .  5\n"
+        " 4 . . . + . . . . . + . . . . . + . . .  4\n"
+        " 3 . . . . . . . . . . . . . . . . . . .  3\n"
+        " 2 . . X . . . . . . . . . . . . . . . .  2\n"
+        " 1 . . . . . . . . . . . . . . . . . . .  1\n"
+        "   a b c d e f g h j k l m n o p q r s t \n\n";
+    EXPECT_EQ(expected, b.serialize_board());
 }

--- a/src/tests/FastBoard_unittest.cpp
+++ b/src/tests/FastBoard_unittest.cpp
@@ -158,7 +158,8 @@ TEST(FastBoardTest, GetXYFromVertex) {
     EXPECT_EQ(std::make_pair(18, 18), b.get_xy(418));
     
     // Negative test to check assertion
-    ASSERT_DEATH({ b.get_xy(7);}, ".*FastBoard.cpp.* Assertion `y >= 0 && y < m_boardsize' failed.");
+    // Commenting out until assertions are enable in CI build.
+    //ASSERT_DEATH({ b.get_xy(7);}, ".*FastBoard.cpp.* Assertion `y >= 0 && y < m_boardsize' failed.");
 }
 
 TEST(FastBoardTest, GetSquare) {

--- a/src/tests/FastBoard_unittest.cpp
+++ b/src/tests/FastBoard_unittest.cpp
@@ -16,15 +16,27 @@
     along with Leela Zero.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#undef NDEBUG
+#include <cassert>
 #include <cstddef>
 #include <gtest/gtest.h>
 #include <limits>
 #include <vector>
 
-#include "FastBoard.h"
+#include "FastBoard.h" 
 
+FastBoard create_filled_3x3() {
+    FastBoard b;
+    b.reset_board(3);
+    b.set_square(1, 1, FastBoard::BLACK);
+    b.set_square(2, 1, FastBoard::BLACK);
+    b.set_square(0, 1, FastBoard::WHITE);
+    b.set_square(1, 0, FastBoard::WHITE);
+    b.set_square(2, 2, FastBoard::BLACK);
+    return b;
+  }
 
-FastBoard createSemiFilled5x5() {
+FastBoard create_filled_5x5() {
     FastBoard b;
     b.reset_board(5);
     b.set_square(1, 1, FastBoard::BLACK);
@@ -38,8 +50,7 @@ FastBoard createSemiFilled5x5() {
     return b;
 }
 
-
-FastBoard createSemiFilled9x9() {
+FastBoard create_filled_9x9() {
     FastBoard b;
     b.reset_board(9);
     b.set_square(5, 4, FastBoard::WHITE);
@@ -57,15 +68,15 @@ FastBoard createSemiFilled9x9() {
 }
 
 /*
-         a b c d e
-       5 . . O O .  5
-       4 . . O . O  4
-       3 O O O O .  3
-       2 . . O . .  2
-       1 . . O . .  1
-         a b c d e
+      a b c d e
+    5 . . O O .  5
+    4 . . O . O  4
+    3 O O O O .  3
+    2 . . O . .  2
+    1 . . O . .  1
+      a b c d e
 */
-FastBoard create5x5AllWhiteField() {
+FastBoard create_5x5_all_white_field() {
     FastBoard b;
     b.reset_board(5);
     b.set_square(1, 2, FastBoard::WHITE);
@@ -90,7 +101,6 @@ TEST(FastBoardTest, Board3x3) {
         " 3 . . .  3\n"
         " 2 . . .  2\n"
         " 1 . . .  1\n"
-        
         "   a b c \n\n";
     
     EXPECT_EQ(expected,  b.serialize_board());
@@ -147,6 +157,7 @@ TEST(FastBoardTest, GetXYFromVertex) {
     EXPECT_EQ(std::make_pair(2, 3), b.get_xy(87));
     EXPECT_EQ(std::make_pair(18, 18), b.get_xy(418));
     
+    //assert(3 > 5); this fails
     EXPECT_EQ(std::make_pair(6, -1), b.get_xy(7)); // should fail
     //ASSERT_DEATH({ b.get_xy(7);}, "failed assertion");
 }
@@ -163,7 +174,7 @@ TEST(FastBoardTest, GetSquare) {
 }
 
 TEST(FastBoardTest, SemiFilled5x5Board) {
-    FastBoard b = createSemiFilled5x5();
+    FastBoard b = create_filled_5x5();
     
     const char *expected = "\n"
         "   a b c d e \n"
@@ -177,20 +188,21 @@ TEST(FastBoardTest, SemiFilled5x5Board) {
     EXPECT_EQ(expected,  b.serialize_board());
 }
 
+// Results will make more sense in FullBuard test
 TEST(FastBoardTest, CountRealLibertiesOn5x5) {
-    FastBoard b = createSemiFilled5x5();
+    FastBoard b = create_filled_5x5();
     EXPECT_EQ(2, b.count_pliberties(b.get_vertex(0, 0)));
     EXPECT_EQ(4, b.count_pliberties(b.get_vertex(1, 1)));
     EXPECT_EQ(4, b.count_pliberties(b.get_vertex(2, 1)));
-    EXPECT_EQ(4, b.count_pliberties(b.get_vertex(3, 1))); // ?
-    EXPECT_EQ(3, b.count_pliberties(b.get_vertex(4, 1))); // ?
-    EXPECT_EQ(4, b.count_pliberties(b.get_vertex(2, 2))); // ? 
-    EXPECT_EQ(4, b.count_pliberties(b.get_vertex(3, 2))); // ?
+    EXPECT_EQ(4, b.count_pliberties(b.get_vertex(3, 1)));
+    EXPECT_EQ(3, b.count_pliberties(b.get_vertex(4, 1)));
+    EXPECT_EQ(4, b.count_pliberties(b.get_vertex(2, 2)));
+    EXPECT_EQ(4, b.count_pliberties(b.get_vertex(3, 2)));
     EXPECT_EQ(3, b.count_pliberties(b.get_vertex(0, 3)));
 }
 
 TEST(FastBoardTest, SemiFilled9x9Board) {
-    FastBoard b = createSemiFilled9x9();
+    FastBoard b = create_filled_9x9();
     
     const char *expected = "\n"
         "   a b c d e f g h j \n"
@@ -209,7 +221,7 @@ TEST(FastBoardTest, SemiFilled9x9Board) {
 }
 
 TEST(FastBoardTest, CountRealLibertiesOn9x9) {
-    FastBoard b = createSemiFilled5x5();
+    FastBoard b = create_filled_5x5();
     
     EXPECT_EQ(2, b.count_pliberties(b.get_vertex(0, 0)));
     EXPECT_EQ(4, b.count_pliberties(b.get_vertex(1, 2)));
@@ -218,6 +230,7 @@ TEST(FastBoardTest, CountRealLibertiesOn9x9) {
     EXPECT_EQ(0, b.count_pliberties(b.get_vertex(5, 4)));
 }
 
+// Results will make more sense in FullBuard test
 TEST(FastBoardTest, IsSuicideWhenNotForBlack) {
     FastBoard b;
     b.reset_board(5);  
@@ -226,12 +239,103 @@ TEST(FastBoardTest, IsSuicideWhenNotForBlack) {
     EXPECT_EQ(false, b.is_suicide(b.get_vertex(2, 1), FastBoard::BLACK));
 }
 
+// Results will make more sense in FullBuard test
 TEST(FastBoardTest, IsSuicideWhenForBlackInAllWhiteField) {
-    FastBoard b = create5x5AllWhiteField();
+    FastBoard b = create_5x5_all_white_field();
 
     EXPECT_EQ(false, b.is_suicide(b.get_vertex(1, 1), FastBoard::BLACK));
     EXPECT_EQ(false, b.is_suicide(b.get_vertex(3, 3), FastBoard::BLACK));
     EXPECT_EQ(false, b.is_suicide(b.get_vertex(4, 4), FastBoard::BLACK));
     EXPECT_EQ(false, b.is_suicide(b.get_vertex(4, 2), FastBoard::BLACK));
     EXPECT_EQ(false, b.is_suicide(b.get_vertex(4, 4), FastBoard::BLACK));
+}
+
+TEST(FastBoardTest, CalcAreaScore) {
+    FastBoard b = create_filled_5x5();
+    EXPECT_EQ(-6.5, b.area_score(6.5F)); 
+    EXPECT_EQ(-.5, b.area_score(0.5F));
+    EXPECT_EQ(-9.0, b.area_score(9.0F)); 
+}
+
+TEST(FastBoardTest, CalcAreaScoreOnWhiteField) {
+    FastBoard b = create_5x5_all_white_field();
+    EXPECT_EQ(-31.5, b.area_score(6.5F)); 
+    EXPECT_EQ(-25.5, b.area_score(0.5F));
+    EXPECT_EQ(-34.0, b.area_score(9.0F)); 
+}
+
+TEST(FastBoardTest, CalcAreaScoreOnSemiFilled9x9) {
+    FastBoard b = create_filled_9x9();
+    EXPECT_EQ(-7.5, b.area_score(6.5F)); 
+    EXPECT_EQ(-1.5, b.area_score(0.5F));
+    EXPECT_EQ(-10.0, b.area_score(9.0F)); 
+}
+
+TEST(FastBoardTest, ToMove) {
+    FastBoard b = create_filled_5x5();
+    EXPECT_EQ(FastBoard::BLACK, b.get_to_move());
+    EXPECT_EQ(true, b.black_to_move());
+    b.set_to_move(FastBoard::WHITE);
+    EXPECT_EQ(FastBoard::WHITE, b.get_to_move());
+    EXPECT_EQ(false, b.black_to_move());
+}
+
+TEST(FastBoardTest, MoveToText) {
+    FastBoard b = create_filled_3x3();
+    EXPECT_EQ("B1", b.move_to_text(b.get_vertex(1, 0)));
+    EXPECT_EQ("A2", b.move_to_text(b.get_vertex(0, 1)));
+    EXPECT_EQ("pass", b.move_to_text(FastBoard::PASS));
+    EXPECT_EQ("resign", b.move_to_text(FastBoard::RESIGN));
+}
+
+TEST(FastBoardTest, MoveToTextSgf) {
+    FastBoard b = create_filled_3x3();
+    EXPECT_EQ("bc", b.move_to_text_sgf(b.get_vertex(1, 0)));
+    EXPECT_EQ("ab", b.move_to_text_sgf(b.get_vertex(0, 1)));
+    EXPECT_EQ("ca", b.move_to_text_sgf(b.get_vertex(2, 2)));
+    EXPECT_EQ("tt", b.move_to_text_sgf(FastBoard::PASS));
+    EXPECT_EQ("tt", b.move_to_text_sgf(FastBoard::RESIGN));
+}
+
+TEST(FastBoardTest, GetStoneList) {
+    FastBoard emptyBoard;
+    emptyBoard.reset_board(3);
+    EXPECT_EQ("", emptyBoard.get_stone_list());
+    
+    FastBoard b = create_filled_5x5();
+    EXPECT_EQ("A4 B2 C2 C3 C4 C5 D2 D3", b.get_stone_list());
+    
+    FastBoard whiteFieldBoard = create_5x5_all_white_field();
+    EXPECT_EQ("A3 B3 C1 C2 C3 C4 C5 D3 D5 E4", whiteFieldBoard.get_stone_list());
+}
+
+TEST(FastBoardTest, StarPoint9x9) {
+    
+    EXPECT_EQ(true, FastBoard::starpoint(9, 2, 2)); 
+    EXPECT_EQ(true, FastBoard::starpoint(9, 4, 4)); 
+    EXPECT_EQ(false, FastBoard::starpoint(9, 5, 5));
+    EXPECT_EQ(false, FastBoard::starpoint(9, 3, 4)); 
+}
+
+TEST(FastBoardTest, StarPoint13x13) {
+    
+    EXPECT_EQ(false, FastBoard::starpoint(13, 2, 2));
+    EXPECT_EQ(true, FastBoard::starpoint(13, 3, 3));
+    EXPECT_EQ(false, FastBoard::starpoint(13, 4, 4));
+    EXPECT_EQ(true, FastBoard::starpoint(13, 6, 6));
+    EXPECT_EQ(false, FastBoard::starpoint(13, 2, 3)); 
+    EXPECT_EQ(false, FastBoard::starpoint(13, 8, 8)); 
+}
+
+TEST(FastBoardTest, StarPoint19x19) {
+    
+    EXPECT_EQ(false, FastBoard::starpoint(19, 2, 2)); 
+    EXPECT_EQ(false, FastBoard::starpoint(19, 4, 4)); 
+    EXPECT_EQ(false, FastBoard::starpoint(19, 2, 3)); 
+    EXPECT_EQ(true, FastBoard::starpoint(19, 3, 3)); 
+    EXPECT_EQ(true, FastBoard::starpoint(19, 15, 15)); 
+    EXPECT_EQ(false, FastBoard::starpoint(19, 14, 14)); 
+    EXPECT_EQ(false, FastBoard::starpoint(19, 3, 14)); 
+    EXPECT_EQ(true, FastBoard::starpoint(19, 3, 15)); 
+    EXPECT_EQ(true, FastBoard::starpoint(19, 3, 9)); 
 }

--- a/src/tests/FastBoard_unittest.cpp
+++ b/src/tests/FastBoard_unittest.cpp
@@ -24,13 +24,77 @@
 #include "FastBoard.h"
 
 
+FastBoard createSemiFilled5x5() {
+    FastBoard b;
+    b.reset_board(5);
+    b.set_square(1, 1, FastBoard::BLACK);
+    b.set_square(2, 1, FastBoard::BLACK);
+    b.set_square(3, 1, FastBoard::WHITE);
+    b.set_square(2, 2, FastBoard::WHITE);
+    b.set_square(3, 2, FastBoard::BLACK);
+    b.set_square(0, 3, FastBoard::BLACK);
+    b.set_square(2, 3, FastBoard::WHITE);
+    b.set_square(2, 4, FastBoard::WHITE);
+    return b;
+}
+
+
+FastBoard createSemiFilled9x9() {
+    FastBoard b;
+    b.reset_board(9);
+    b.set_square(5, 4, FastBoard::WHITE);
+    b.set_square(5, 3, FastBoard::BLACK);
+    b.set_square(4, 5, FastBoard::WHITE);
+    b.set_square(2, 2, FastBoard::BLACK);
+    b.set_square(4, 3, FastBoard::WHITE);
+    b.set_square(1, 2, FastBoard::BLACK);
+    b.set_square(6, 3, FastBoard::WHITE);
+    b.set_square(2, 3, FastBoard::BLACK);
+    b.set_square(5, 2, FastBoard::WHITE);
+    b.set_square(0, 0, FastBoard::BLACK);
+    b.set_square(6, 6, FastBoard::WHITE);
+    return b;
+}
+
+/*
+         a b c d e
+       5 . . O O .  5
+       4 . . O . O  4
+       3 O O O O .  3
+       2 . . O . .  2
+       1 . . O . .  1
+         a b c d e
+*/
+FastBoard create5x5AllWhiteField() {
+    FastBoard b;
+    b.reset_board(5);
+    b.set_square(1, 2, FastBoard::WHITE);
+    b.set_square(2, 1, FastBoard::WHITE);
+    b.set_square(2, 2, FastBoard::WHITE);
+    b.set_square(2, 3, FastBoard::WHITE);
+    b.set_square(2, 4, FastBoard::WHITE);
+    b.set_square(3, 2, FastBoard::WHITE);
+    b.set_square(3, 4, FastBoard::WHITE);
+    b.set_square(4, 3, FastBoard::WHITE);
+    b.set_square(0, 2, FastBoard::WHITE);
+    b.set_square(2, 0, FastBoard::WHITE);
+    return b;
+}
+
+
 TEST(FastBoardTest, Board3x3) {
     FastBoard b;
     b.reset_board(3);
-    EXPECT_EQ(
-        "\n   a b c \n 3 . . .  3\n 2 . . .  2\n 1 . . .  1\n   a b c \n\n",  
-        b.serialize_board()
-    );
+    const char *expected = "\n"
+        "   a b c \n"
+        " 3 . . .  3\n"
+        " 2 . . .  2\n"
+        " 1 . . .  1\n"
+        
+        "   a b c \n\n";
+    
+    EXPECT_EQ(expected,  b.serialize_board());
+    EXPECT_EQ(3, b.get_boardsize());
 }
 
 TEST(FastBoardTest, MakeBlackMoveOn19x19) {
@@ -61,4 +125,113 @@ TEST(FastBoardTest, MakeBlackMoveOn19x19) {
         " 1 . . . . . . . . . . . . . . . . . . .  1\n"
         "   a b c d e f g h j k l m n o p q r s t \n\n";
     EXPECT_EQ(expected, b.serialize_board());
+}
+
+TEST(FastBoardTest, GetVertexOn19x19) {
+    FastBoard b;
+    b.reset_board(19);
+    EXPECT_EQ(22, b.get_vertex(0, 0));
+    EXPECT_EQ(43, b.get_vertex(0, 1));
+    EXPECT_EQ(44, b.get_vertex(1, 1));
+    EXPECT_EQ(87, b.get_vertex(2, 3));
+    EXPECT_EQ(418, b.get_vertex(18, 18));
+}
+
+TEST(FastBoardTest, GetXYFromVertex) {
+    FastBoard b;
+    b.reset_board(19);
+    EXPECT_EQ(std::make_pair(0, 0), b.get_xy(22));
+    EXPECT_EQ(std::make_pair(0, 1), b.get_xy(43));
+    EXPECT_EQ(std::make_pair(1, 1), b.get_xy(44));
+    EXPECT_EQ(std::make_pair(2, 1), b.get_xy(45));
+    EXPECT_EQ(std::make_pair(2, 3), b.get_xy(87));
+    EXPECT_EQ(std::make_pair(18, 18), b.get_xy(418));
+    
+    EXPECT_EQ(std::make_pair(6, -1), b.get_xy(7)); // should fail
+    //ASSERT_DEATH({ b.get_xy(7);}, "failed assertion");
+}
+
+TEST(FastBoardTest, GetSquare) {
+    FastBoard b;
+    b.reset_board(19);
+    EXPECT_EQ(FastBoard::EMPTY, b.get_square(43));
+    EXPECT_EQ(FastBoard::EMPTY, b.get_square(0, 1));
+    b.set_square(43, FastBoard::BLACK);
+    EXPECT_EQ(FastBoard::BLACK, b.get_square(43));
+    b.set_square(43, FastBoard::WHITE);
+    EXPECT_EQ(FastBoard::WHITE, b.get_square(43));
+}
+
+TEST(FastBoardTest, SemiFilled5x5Board) {
+    FastBoard b = createSemiFilled5x5();
+    
+    const char *expected = "\n"
+        "   a b c d e \n"
+        " 5 . . O . .  5\n"
+        " 4 X . O . .  4\n"
+        " 3 . . O X .  3\n"
+        " 2 . X X O .  2\n"
+        " 1 . . . . .  1\n"
+        "   a b c d e \n\n";
+    
+    EXPECT_EQ(expected,  b.serialize_board());
+}
+
+TEST(FastBoardTest, CountRealLibertiesOn5x5) {
+    FastBoard b = createSemiFilled5x5();
+    EXPECT_EQ(2, b.count_pliberties(b.get_vertex(0, 0)));
+    EXPECT_EQ(4, b.count_pliberties(b.get_vertex(1, 1)));
+    EXPECT_EQ(4, b.count_pliberties(b.get_vertex(2, 1)));
+    EXPECT_EQ(4, b.count_pliberties(b.get_vertex(3, 1))); // ?
+    EXPECT_EQ(3, b.count_pliberties(b.get_vertex(4, 1))); // ?
+    EXPECT_EQ(4, b.count_pliberties(b.get_vertex(2, 2))); // ? 
+    EXPECT_EQ(4, b.count_pliberties(b.get_vertex(3, 2))); // ?
+    EXPECT_EQ(3, b.count_pliberties(b.get_vertex(0, 3)));
+}
+
+TEST(FastBoardTest, SemiFilled9x9Board) {
+    FastBoard b = createSemiFilled9x9();
+    
+    const char *expected = "\n"
+        "   a b c d e f g h j \n"
+        " 9 . . . . . . . . .  9\n"
+        " 8 . . . . . . . . .  8\n"
+        " 7 . . + . + . O . .  7\n"
+        " 6 . . . . O . . . .  6\n"
+        " 5 . . + . + O + . .  5\n"
+        " 4 . . X . O X O . .  4\n"
+        " 3 . X X . + O + . .  3\n"
+        " 2 . . . . . . . . .  2\n"
+        " 1 X . . . . . . . .  1\n"
+        "   a b c d e f g h j \n\n";
+    
+    EXPECT_EQ(expected,  b.serialize_board());
+}
+
+TEST(FastBoardTest, CountRealLibertiesOn9x9) {
+    FastBoard b = createSemiFilled5x5();
+    
+    EXPECT_EQ(2, b.count_pliberties(b.get_vertex(0, 0)));
+    EXPECT_EQ(4, b.count_pliberties(b.get_vertex(1, 2)));
+    EXPECT_EQ(3, b.count_pliberties(b.get_vertex(4, 3)));
+    EXPECT_EQ(2, b.count_pliberties(b.get_vertex(4, 4))); 
+    EXPECT_EQ(0, b.count_pliberties(b.get_vertex(5, 4)));
+}
+
+TEST(FastBoardTest, IsSuicideWhenNotForBlack) {
+    FastBoard b;
+    b.reset_board(5);  
+    b.set_square(2, 2, FastBoard::WHITE);
+    EXPECT_EQ(false, b.is_suicide(b.get_vertex(1, 1), FastBoard::BLACK));
+    EXPECT_EQ(false, b.is_suicide(b.get_vertex(2, 1), FastBoard::BLACK));
+}
+
+TEST(FastBoardTest, IsSuicideWhenForBlackInAllWhiteField) {
+    FastBoard b = create5x5AllWhiteField();
+
+    EXPECT_EQ(false, b.is_suicide(b.get_vertex(1, 1), FastBoard::BLACK));
+    EXPECT_EQ(false, b.is_suicide(b.get_vertex(3, 3), FastBoard::BLACK));
+    EXPECT_EQ(false, b.is_suicide(b.get_vertex(4, 4), FastBoard::BLACK));
+    EXPECT_EQ(false, b.is_suicide(b.get_vertex(4, 2), FastBoard::BLACK));
+    EXPECT_EQ(false, b.is_suicide(b.get_vertex(4, 4), FastBoard::BLACK));
 }

--- a/src/tests/FastBoard_unittest.cpp
+++ b/src/tests/FastBoard_unittest.cpp
@@ -137,28 +137,19 @@ TEST(FastBoardTest, MakeBlackMoveOn19x19) {
     EXPECT_EQ(expected, b.serialize_board());
 }
 
-TEST(FastBoardTest, GetVertexOn19x19) {
-    FastBoard b;
-    b.reset_board(19);
-    EXPECT_EQ(22, b.get_vertex(0, 0));
-    EXPECT_EQ(43, b.get_vertex(0, 1));
-    EXPECT_EQ(44, b.get_vertex(1, 1));
-    EXPECT_EQ(87, b.get_vertex(2, 3));
-    EXPECT_EQ(418, b.get_vertex(18, 18));
-}
 
-TEST(FastBoardTest, GetXYFromVertex) {
+TEST(FastBoardTest, GetXYFromGetVertexOn19x19) {
     FastBoard b;
     b.reset_board(19);
-    EXPECT_EQ(std::make_pair(0, 0), b.get_xy(22));
-    EXPECT_EQ(std::make_pair(0, 1), b.get_xy(43));
-    EXPECT_EQ(std::make_pair(1, 1), b.get_xy(44));
-    EXPECT_EQ(std::make_pair(2, 1), b.get_xy(45));
-    EXPECT_EQ(std::make_pair(2, 3), b.get_xy(87));
-    EXPECT_EQ(std::make_pair(18, 18), b.get_xy(418));
+    EXPECT_EQ(std::make_pair(0, 0), b.get_xy(b.get_vertex(0, 0)));
+    EXPECT_EQ(std::make_pair(0, 1), b.get_xy(b.get_vertex(0, 1)));
+    EXPECT_EQ(std::make_pair(1, 1), b.get_xy(b.get_vertex(1, 1)));
+    EXPECT_EQ(std::make_pair(2, 1), b.get_xy(b.get_vertex(2, 1)));
+    EXPECT_EQ(std::make_pair(2, 3), b.get_xy(b.get_vertex(2, 3)));
+    EXPECT_EQ(std::make_pair(18, 18), b.get_xy(b.get_vertex(18, 18)));
     
     // Negative test to check assertion
-    // Commenting out until assertions are enable in CI build.
+    // Commenting out until assertions are enabled in CI build.
     //ASSERT_DEATH({ b.get_xy(7);}, ".*FastBoard.cpp.* Assertion `y >= 0 && y < m_boardsize' failed.");
 }
 
@@ -188,7 +179,7 @@ TEST(FastBoardTest, SemiFilled5x5Board) {
     EXPECT_EQ(expected,  b.serialize_board());
 }
 
-// Results will make more sense in FullBuard test
+// Results will make more sense in FullBoard test
 TEST(FastBoardTest, CountRealLibertiesOn5x5) {
     FastBoard b = create_filled_5x5();
     EXPECT_EQ(2, b.count_pliberties(b.get_vertex(0, 0)));
@@ -220,7 +211,7 @@ TEST(FastBoardTest, SemiFilled9x9Board) {
     EXPECT_EQ(expected,  b.serialize_board());
 }
 
-// Results will make more sense in FullBuard test
+// Results will make more sense in FullBoard test
 TEST(FastBoardTest, CountRealLibertiesOn9x9) {
     FastBoard b = create_filled_9x9();
     
@@ -231,7 +222,7 @@ TEST(FastBoardTest, CountRealLibertiesOn9x9) {
     EXPECT_EQ(4, b.count_pliberties(b.get_vertex(5, 4)));
 }
 
-// Results will make more sense in FullBuard test
+// Results will make more sense in FullBoard test
 TEST(FastBoardTest, IsSuicideWhenNotForBlack) {
     FastBoard b;
     b.reset_board(5);  
@@ -240,7 +231,7 @@ TEST(FastBoardTest, IsSuicideWhenNotForBlack) {
     EXPECT_EQ(false, b.is_suicide(b.get_vertex(2, 1), FastBoard::BLACK));
 }
 
-// Results will make more sense in FullBuard test
+// Results will make more sense in FullBoard test
 TEST(FastBoardTest, IsSuicideWhenForBlackInAllWhiteField) {
     FastBoard b = create_5x5_all_white_field();
 
@@ -295,7 +286,6 @@ TEST(FastBoardTest, MoveToTextSgf) {
     EXPECT_EQ("ab", b.move_to_text_sgf(b.get_vertex(0, 1)));
     EXPECT_EQ("ca", b.move_to_text_sgf(b.get_vertex(2, 2)));
     EXPECT_EQ("tt", b.move_to_text_sgf(FastBoard::PASS));
-    EXPECT_EQ("tt", b.move_to_text_sgf(FastBoard::RESIGN));
 }
 
 TEST(FastBoardTest, GetStoneList) {

--- a/src/tests/FastBoard_unittest.cpp
+++ b/src/tests/FastBoard_unittest.cpp
@@ -1,0 +1,54 @@
+/*
+    This file is part of Leela Zero.
+    Copyright (C) 2018 Gian-Carlo Pascutto
+
+    Leela Zero is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Leela Zero is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Leela Zero.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <cstddef>
+#include <gtest/gtest.h>
+#include <limits>
+#include <vector>
+
+#include "Utils.h"
+#include "FastBoard.h"
+
+
+using namespace Utils;
+
+TEST(FastBoardTest, FBCeilMultiple) {
+    // Equal to a multiple
+    EXPECT_EQ(ceilMultiple(0, 1), (size_t)0);
+    EXPECT_EQ(ceilMultiple(0, 3), (size_t)0);
+
+    EXPECT_EQ(ceilMultiple(6,  1), (size_t)6);
+    EXPECT_EQ(ceilMultiple(23, 1), (size_t)23);
+
+    EXPECT_EQ(ceilMultiple(2, 2), (size_t)2);
+    EXPECT_EQ(ceilMultiple(4, 2), (size_t)4);
+    EXPECT_EQ(ceilMultiple(6, 2), (size_t)6);
+    EXPECT_EQ(ceilMultiple(0, 3), (size_t)0);
+    EXPECT_EQ(ceilMultiple(3, 3), (size_t)3);
+    EXPECT_EQ(ceilMultiple(9, 3), (size_t)9);
+
+}
+
+TEST(FastBoardTest, Board3x3) {
+    FastBoard b;
+    b.reset_board(3);
+    EXPECT_EQ(
+        "\n   a b c \n 3 . . .  3\n 2 . . .  2\n 1 . . .  1\n   a b c \n\n",  
+        b.serialize_board()
+    );
+}

--- a/src/tests/FastBoard_unittest.cpp
+++ b/src/tests/FastBoard_unittest.cpp
@@ -157,9 +157,8 @@ TEST(FastBoardTest, GetXYFromVertex) {
     EXPECT_EQ(std::make_pair(2, 3), b.get_xy(87));
     EXPECT_EQ(std::make_pair(18, 18), b.get_xy(418));
     
-    //assert(3 > 5); this fails
-    EXPECT_EQ(std::make_pair(6, -1), b.get_xy(7)); // should fail
-    //ASSERT_DEATH({ b.get_xy(7);}, "failed assertion");
+    // Negative test to check assertion
+    ASSERT_DEATH({ b.get_xy(7);}, ".*FastBoard.cpp.* Assertion `y >= 0 && y < m_boardsize' failed.");
 }
 
 TEST(FastBoardTest, GetSquare) {
@@ -220,14 +219,15 @@ TEST(FastBoardTest, SemiFilled9x9Board) {
     EXPECT_EQ(expected,  b.serialize_board());
 }
 
+// Results will make more sense in FullBuard test
 TEST(FastBoardTest, CountRealLibertiesOn9x9) {
-    FastBoard b = create_filled_5x5();
+    FastBoard b = create_filled_9x9();
     
     EXPECT_EQ(2, b.count_pliberties(b.get_vertex(0, 0)));
     EXPECT_EQ(4, b.count_pliberties(b.get_vertex(1, 2)));
-    EXPECT_EQ(3, b.count_pliberties(b.get_vertex(4, 3)));
-    EXPECT_EQ(2, b.count_pliberties(b.get_vertex(4, 4))); 
-    EXPECT_EQ(0, b.count_pliberties(b.get_vertex(5, 4)));
+    EXPECT_EQ(4, b.count_pliberties(b.get_vertex(4, 3)));
+    EXPECT_EQ(4, b.count_pliberties(b.get_vertex(4, 4))); 
+    EXPECT_EQ(4, b.count_pliberties(b.get_vertex(5, 4)));
 }
 
 // Results will make more sense in FullBuard test

--- a/src/tests/FastBoard_unittest.cpp
+++ b/src/tests/FastBoard_unittest.cpp
@@ -24,25 +24,7 @@
 #include "Utils.h"
 #include "FastBoard.h"
 
-
 using namespace Utils;
-
-TEST(FastBoardTest, FBCeilMultiple) {
-    // Equal to a multiple
-    EXPECT_EQ(ceilMultiple(0, 1), (size_t)0);
-    EXPECT_EQ(ceilMultiple(0, 3), (size_t)0);
-
-    EXPECT_EQ(ceilMultiple(6,  1), (size_t)6);
-    EXPECT_EQ(ceilMultiple(23, 1), (size_t)23);
-
-    EXPECT_EQ(ceilMultiple(2, 2), (size_t)2);
-    EXPECT_EQ(ceilMultiple(4, 2), (size_t)4);
-    EXPECT_EQ(ceilMultiple(6, 2), (size_t)6);
-    EXPECT_EQ(ceilMultiple(0, 3), (size_t)0);
-    EXPECT_EQ(ceilMultiple(3, 3), (size_t)3);
-    EXPECT_EQ(ceilMultiple(9, 3), (size_t)9);
-
-}
 
 TEST(FastBoardTest, Board3x3) {
     FastBoard b;

--- a/src/tests/gtests.cpp
+++ b/src/tests/gtests.cpp
@@ -81,7 +81,7 @@ public:
 
 class LeelaTest: public ::testing::Test {
 public:
-    LeelaTest( ) {
+    LeelaTest() {
         // Reset engine parameters
         GTP::setup_default_parameters();
         cfg_max_playouts = 1;

--- a/src/tests/utils_unittest.cpp
+++ b/src/tests/utils_unittest.cpp
@@ -48,6 +48,7 @@ TEST(UtilsTest, CeilMultiple) {
     EXPECT_EQ(ceilMultiple(0, 3), (size_t)0);
     EXPECT_EQ(ceilMultiple(3, 3), (size_t)3);
     EXPECT_EQ(ceilMultiple(9, 3), (size_t)9);
+    EXPECT_EQ(ceilMultiple(5, 5), (size_t)5);
     
     // Requires rounding up
     EXPECT_EQ(ceilMultiple(3, 5), (size_t)5);

--- a/src/tests/utils_unittest.cpp
+++ b/src/tests/utils_unittest.cpp
@@ -28,8 +28,8 @@
 
 // Test should fail about this often from distribution not looking uniform.
 // Increasing this allows better detection of bad RNG but increase the chance
-// of test failure with acceptable RNG implemantation. On my system RNG seems
-// to be a tiny bit not random and test fail about twice as often as predicted.
+// of test failure with acceptable RNG implementation. On my system RNG seems
+// to be a tiny bit non-random and test fails about twice as often as predicted.
 constexpr auto ALPHA = 0.0001;
 
 using namespace Utils;

--- a/src/tests/utils_unittest.cpp
+++ b/src/tests/utils_unittest.cpp
@@ -48,13 +48,16 @@ TEST(UtilsTest, CeilMultiple) {
     EXPECT_EQ(ceilMultiple(0, 3), (size_t)0);
     EXPECT_EQ(ceilMultiple(3, 3), (size_t)3);
     EXPECT_EQ(ceilMultiple(9, 3), (size_t)9);
-
+    
     // Requires rounding up
     EXPECT_EQ(ceilMultiple(3, 5), (size_t)5);
     EXPECT_EQ(ceilMultiple(6, 5), (size_t)10);
     EXPECT_EQ(ceilMultiple(9, 5), (size_t)10);
+    EXPECT_EQ(ceilMultiple(12, 5), (size_t)15);
+    EXPECT_EQ(ceilMultiple(13, 5), (size_t)15);
     EXPECT_EQ(ceilMultiple(23, 5), (size_t)25);
     EXPECT_EQ(ceilMultiple(99, 100), (size_t)100);
+    EXPECT_EQ(ceilMultiple(149, 10), (size_t)150);
 }
 
 double randomlyDistributedProbability(std::vector<short> values, double expected) {


### PR DESCRIPTION
I was able to run the existing google unit tests in my Ubuntu VM, and have started to add tests for FastBoard. To make testing of FastBoard easier, I split display_board into 2 methods. As serialize_board method which creates a string (for use with unit tests) and the same display_board method which now calls serialize_board to get the string to print. 

If it looks like I am on the right track, let me know, and I will continue adding more FastBoard tests to test all of the methods in that class. 