### PR TITLE
autogtp: clean up networks when they are not needed any more

### DIFF
--- a/autogtp/Job.cpp
+++ b/autogtp/Job.cpp
@@ -67,7 +67,7 @@ Job(gpu, parent)
 
 Result ProductionJob::execute(){
     Result res(Result::Error);
-    Game game(m_network, m_option);
+    Game game("networks/" + m_network, m_option);
     if (!game.gameStart(m_leelazMinVersion)) {
         return res;
     }
@@ -131,7 +131,7 @@ void ProductionJob::init(const Order &o) {
 
 Result ValidationJob::execute(){
     Result res(Result::Error);
-    Game first(m_firstNet,  m_option);
+    Game first("networks/" + m_firstNet,  m_option);
     if (!first.gameStart(m_leelazMinVersion)) {
         return res;
     }
@@ -140,7 +140,7 @@ Result ValidationJob::execute(){
         first.setMovesCount(m_moves);
         QFile::remove(m_sgfFirst + ".sgf");
     }
-    Game second(m_secondNet, m_option);
+    Game second("networks/" + m_secondNet, m_option);
     if (!second.gameStart(m_leelazMinVersion)) {
         return res;
     }

--- a/autogtp/Management.cpp
+++ b/autogtp/Management.cpp
@@ -41,6 +41,7 @@ Management::Management(const int gpus,
                        const QStringList& gpuslist,
                        const int ver,
                        const int maxGames,
+                       const bool delNetworks,
                        const QString& keep,
                        const QString& debug)
 
@@ -56,8 +57,10 @@ Management::Management(const int gpus,
     m_debugPath(debug),
     m_version(ver),
     m_fallBack(Order::Error),
+    m_lastMatch(Order::Error),
     m_gamesLeft(maxGames),
     m_threadsLeft(gpus * games),
+    m_delNetworks(delNetworks),
     m_lockFile(nullptr) {
 }
 
@@ -91,7 +94,7 @@ void Management::giveAssignments() {
     QTextStream(stdout) << "Starting tuning process, please wait..." << endl;
 
     Order tuneOrder = getWork(true);
-    QString tuneCmdLine("./leelaz --tune-only -w ");
+    QString tuneCmdLine("./leelaz --tune-only -w networks/");
     tuneCmdLine.append(tuneOrder.parameters()["network"]);
     if (m_gpusList.isEmpty()) {
         runTuningProcess(tuneCmdLine);
@@ -383,6 +386,11 @@ Order Management::getWorkInternal(bool tuning) {
         o.type(Order::Production);
         parameters["network"] = net;
         o.parameters(parameters);
+        if (m_delNetworks &&
+            m_fallBack.parameters()["network"] != net) {
+            QTextStream(stdout) << "Deleting network " << "networks/" + m_fallBack.parameters()["network"] << endl;
+            QFile::remove("networks/" + m_fallBack.parameters()["network"]);
+        }
         m_fallBack = o;
         QTextStream(stdout) << "net: " << net << "." << endl;
     }
@@ -395,6 +403,19 @@ Order Management::getWorkInternal(bool tuning) {
         parameters["firstNet"] = net1;
         parameters["secondNet"] = net2;
         o.parameters(parameters);
+        if (m_delNetworks) {
+            if (m_lastMatch.parameters()["firstNet"] != net1 &&
+                m_lastMatch.parameters()["firstNet"] != net2) {
+                QTextStream(stdout) << "Deleting network " << "networks/" + m_lastMatch.parameters()["firstNet"] << endl;
+                QFile::remove("networks/" + m_lastMatch.parameters()["firstNet"]);
+            }
+            if (m_lastMatch.parameters()["secondNet"] != net1 &&
+                m_lastMatch.parameters()["secondNet"] != net2) {
+                QTextStream(stdout) << "Deleting network " << "networks/" + m_lastMatch.parameters()["secondNet"] << endl;
+                QFile::remove("networks/" + m_lastMatch.parameters()["secondNet"]);
+            }
+        }
+        m_lastMatch = o;
         QTextStream(stdout) << "first network: " << net1 << "." << endl;
         QTextStream(stdout) << "second network " << net2 << "." << endl;
     }
@@ -444,6 +465,8 @@ Order Management::getWork(bool tuning) {
 
 
 bool Management::networkExists(const QString &name) {
+    QString realHash = name;
+    realHash.remove(0,9);
     if (QFileInfo::exists(name)) {
         QFile f(name);
         if (f.open(QFile::ReadOnly)) {
@@ -452,7 +475,7 @@ bool Management::networkExists(const QString &name) {
                 throw NetworkException("Reading network file failed.");
             }
             QString result = hash.result().toHex();
-            if (result == name) {
+            if (result == realHash) {
                 return true;
             }
         } else {
@@ -470,7 +493,8 @@ bool Management::networkExists(const QString &name) {
     return false;
 }
 
-void Management::fetchNetwork(const QString &name) {
+void Management::fetchNetwork(const QString &net) {
+    QString name = "networks/" + net;
     if (networkExists(name)) {
         return;
     }
@@ -487,9 +511,9 @@ void Management::fetchNetwork(const QString &name) {
 #endif
     // Be quiet, but output the real file name we saved.
     // Use the filename from the server.
-    prog_cmdline.append(" -s -O -J");
+    prog_cmdline.append(" -s -J -o " + name + ".gz ");
     prog_cmdline.append(" -w %{filename_effective}");
-    prog_cmdline.append(" http://zero.sjeng.org/networks/" + name + ".gz");
+    prog_cmdline.append(" http://zero.sjeng.org/" + name + ".gz");
 
     QProcess curl;
     curl.start(prog_cmdline);

--- a/autogtp/Management.h
+++ b/autogtp/Management.h
@@ -39,6 +39,7 @@ public:
                const QStringList& gpuslist,
                const int ver,
                const int maxGame,
+               const bool delNetworks,
                const QString& keep,
                const QString& debug);
     ~Management() = default;
@@ -75,8 +76,10 @@ private:
     int m_storeGames;
     QList<QFileInfo> m_storedFiles;
     Order m_fallBack;
+    Order m_lastMatch;
     int m_gamesLeft;
     int m_threadsLeft;
+    bool m_delNetworks;
     QLockFile *m_lockFile;
 
     Order getWorkInternal(bool tuning);
@@ -89,7 +92,7 @@ private:
     void checkStoredGames();
     QFileInfo getNextStored();
     bool networkExists(const QString &name);
-    void fetchNetwork(const QString &name);
+    void fetchNetwork(const QString &net);
     void printTimingInfo(float duration);
     void runTuningProcess(const QString &tuneCmdLine);
     void gzipFile(const QString &fileName);

--- a/autogtp/main.cpp
+++ b/autogtp/main.cpp
@@ -74,6 +74,10 @@ int main(int argc, char *argv[]) {
         { "m", "maxgames" }, "Exit after the given number of games is completed.",
                           "max number of games");
 
+    QCommandLineOption eraseOption(
+        { "e", "erase" }, "Erase old networks when new ones are available.",
+                          "");
+
     parser.addOption(gamesNumOption);
     parser.addOption(gpusOption);
     parser.addOption(keepSgfOption);
@@ -81,6 +85,7 @@ int main(int argc, char *argv[]) {
     parser.addOption(timeoutOption);
     parser.addOption(singleOption);
     parser.addOption(maxOption);
+    parser.addOption(eraseOption);
 
     // Process the actual command line arguments given by the user
     parser.process(app);
@@ -130,8 +135,14 @@ int main(int argc, char *argv[]) {
         }
     }
     Console *cons = nullptr;
+    if (!QDir().mkpath("networks")) {
+        cerr << "Couldn't create the directory for the networks files!"
+             << endl;
+        return EXIT_FAILURE;
+    }
     Management *boss = new Management(gpusNum, gamesNum, gpusList, AUTOGTP_VERSION, maxNum,
-                                      parser.value(keepSgfOption), parser.value(keepDebugOption));
+                                      parser.isSet(eraseOption), parser.value(keepSgfOption),
+                                      parser.value(keepDebugOption));
     QObject::connect(&app, &QCoreApplication::aboutToQuit, boss, &Management::storeGames);
     QTimer *timer = new QTimer();
     boss->giveAssignments();


### PR DESCRIPTION
`autogtp` now saves all networks in a subdirectory `networks`. If the option `--erase` (`-e`) is active then the old best network and the old networks used for matches are deleted so that in that directory there are at most 3 networks.
If you use the stop-resume option (`q+Enter`) to update to this version you have to manually copy the network used by the saved games. To do this look into the files `storefile*` and check the lines starting with 
`network` `firstNet` `secondNet` and copy them in the new directory networks.
If you are under Linux you can use the following command to find the networks you need:
`grep -e network -e firstNet -e secondNet storefile*  | awk '{print $2}' | sort | uniq`