### PR TITLE
Trim the search tree during the search.

### DIFF
--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -70,6 +70,7 @@ public:
     void virtual_loss(void);
     void virtual_loss_undo(void);
     void update(float eval);
+    void trim_tree(int threshold, std::atomic<int>& nodecount);
 
     // Defined in UCTNodeRoot.cpp, only to be called on m_root in UCTSearch
     void kill_superkos(const KoState& state);
@@ -96,7 +97,7 @@ private:
     // Move
     std::int16_t m_move;
     // UCT
-    std::atomic<std::int16_t> m_virtual_loss{0};
+    std::atomic<std::int16_t> m_active_cpus{0};
     std::atomic<int> m_visits{0};
     // UCT eval
     float m_score;


### PR DESCRIPTION
In the master, do a check whether we are 3/4ths through our memory
budget. If so, attempt to do a depth first pruning of the search tree.

We try to get a lock on a node and check if there are any other CPUs
searching inside it. If so, we give up. If not, we prune every child
that has less than a given number of visits. These can be re-expanded by
the search later on. We find the right threshold by just doubling it
until the number of nodes in the tree drops below half our memory budget.

With a lot of threads active, we might not necessarily be able to prune
enough, especially with low maximum tree sizes, so we will still abort
if we reach the full memory budget.

This reworks the virtual loss code to accurately reflect the number of
active CPUs in a subtree.