### PR TITLE
Disable FPU reductions at a noised root.

### DIFF
--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -49,7 +49,7 @@ public:
     const std::vector<node_ptr_t>& get_children() const;
     void sort_children(int color);
     UCTNode& get_best_root_child(int color);
-    UCTNode* uct_select_child(int color);
+    UCTNode* uct_select_child(int color, bool is_root);
 
     size_t count_nodes() const;
     SMP::Mutex& get_mutex();
@@ -65,8 +65,6 @@ public:
     void set_score(float score);
     float get_eval(int tomove) const;
     float get_net_eval(int tomove) const;
-    double get_blackevals() const;
-    void accumulate_eval(float eval);
     void virtual_loss(void);
     void virtual_loss_undo(void);
     void update(float eval);
@@ -88,6 +86,8 @@ private:
     };
     void link_nodelist(std::atomic<int>& nodecount,
                        std::vector<Network::scored_node>& nodelist);
+    double get_blackevals() const;
+    void accumulate_eval(float eval);
 
     // Note : This class is very size-sensitive as we are going to create
     // tens of millions of instances of these.  Please put extra caution

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -142,7 +142,7 @@ SearchResult UCTSearch::play_simulation(GameState & currstate,
     }
 
     if (node->has_children() && !result.valid()) {
-        auto next = node->uct_select_child(color);
+        auto next = node->uct_select_child(color, node == m_root.get());
 
         if (next != nullptr) {
             auto move = next->get_move();


### PR DESCRIPTION
The Dirichlet noise that is added to self-play games was originally
tuned for a regular UCT search in the AGZ paper. With FPU reduction,
the possibility to discover a noised move is greatly reduced. So
we should not use FPU reduction at the place where we add noise, i.e. at
the root.