### PR TITLE
Clean up the SWA code somewhat.

### DIFF
--- a/training/tf/net_to_model.py
+++ b/training/tf/net_to_model.py
@@ -2,17 +2,26 @@
 import tensorflow as tf
 import os
 import sys
-from tfprocess import TFProcess, read_weights
+from tfprocess import TFProcess
 
+with open(sys.argv[1], 'r') as f:
+    weights = []
+    for e, line in enumerate(f):
+        if e == 0:
+            #Version
+            print("Version", line.strip())
+            if line != '1\n':
+                raise ValueError("Unknown version {}".format(line.strip()))
+        else:
+            weights.append(list(map(float, line.split(' '))))
+        if e == 2:
+            channels = len(line.split(' '))
+            print("Channels", channels)
 
-if __name__ == "__main__":
-    version, blocks, channels, weights = read_weights(sys.argv[1])
-
-    if version == None:
-        raise ValueError("Unable to read version number")
-
-    print("Version", version)
-    print("Channels", channels)
+    blocks = e - (4 + 14)
+    if blocks % 8 != 0:
+        raise ValueError("Inconsistent number of weights in the file")
+    blocks //= 8
     print("Blocks", blocks)
 
     x = [

--- a/training/tf/tfprocess.py
+++ b/training/tf/tfprocess.py
@@ -84,7 +84,8 @@ class TFProcess:
         # Net sampling rate (e.g 2 == every 2nd network).
         self.swa_c = 1
         # Take an exponentially weighted moving average over this
-        # many networks.
+        # many networks. Under the SWA assumptions, this will reduce
+        # the distance to the optimal value by a factor of 1/sqrt(n)
         self.swa_max_n = 16
         # Recalculate SWA weight batchnorm means and variances
         self.swa_recalc_bn = True
@@ -483,9 +484,8 @@ class TFProcess:
         # Copy the swa weights into the current network.
         self.session.run(self.swa_load_op)
         if self.swa_recalc_bn:
-            print("Recalculating SWA batch normalization")
-            self.update_ops = tf.get_collection(tf.GraphKeys.UPDATE_OPS)
-            for _ in range(400):
+            print("Refining SWA batch normalization")
+            for _ in range(200):
                 self.session.run(
                     [self.loss, self.update_ops, self.next_batch],
                     feed_dict={self.training: True, self.handle: self.train_handle})


### PR DESCRIPTION
1. Bugfix: Batch norms weren't being updated.
2. Bugfix: Use 400 batches when recomputing batch norms to reduce error is ~2% (from 13%).
3. Remove the need for external files: SWA is now accumulated in RAM.
4. Change TF restore to be optimistic. This allows restoring from snapshots
that don't have the SWA variable (and vice versa).

NB: I've verified by hand that the batch norms vars are being updated. If I get a little spare time later I'll try and add some unit tests for that.