### PR TITLE
UCTNode memory optimization

### DIFF
--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -96,11 +96,15 @@ public:
     UCTNode* get_nopass_child(FastState& state) const;
     node_ptr_t find_child(const int move);
 
+    bool is_expanding() const;
+    void set_expanding();
 private:
     enum Status : char {
         INVALID, // superko
         PRUNED,
-        ACTIVE
+        ACTIVE,
+        PRUNED_EXPANDING,
+        ACTIVE_EXPANDING
     };
     void link_nodelist(std::atomic<int>& nodecount,
                        std::vector<Network::scored_node>& nodelist,
@@ -114,23 +118,25 @@ private:
 
     // Move
     std::int16_t m_move;
+
     // UCT
     std::atomic<std::int16_t> m_virtual_loss{0};
     std::atomic<int> m_visits{0};
+
     // UCT eval
     float m_score;
+
     // Original net eval for this node (not children).
     float m_net_eval{0.0f};
     std::atomic<double> m_blackevals{0.0};
-    std::atomic<Status> m_status{ACTIVE};
-    // Is someone adding scores to this node?
-    // We don't need to unset this.
-    bool m_is_expanding{false};
-    SMP::Mutex m_nodemutex;
 
     // Tree data
-    std::atomic<uint32_t> m_children_size{0};
     std::unique_ptr<node_ptr_t[]> m_children;
+    std::atomic<uint16_t> m_children_size{0};
+
+    // Other flags
+    SMP::Mutex m_nodemutex;
+    std::atomic<Status> m_status{ACTIVE};
 };
 
 #endif

--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -47,7 +47,24 @@ public:
                          GameState& state, float& eval,
                          float mem_full = 0.0f);
 
-    const std::vector<node_ptr_t>& get_children() const;
+    class children_wrapper {
+    private:
+        uint32_t m_size;
+        node_ptr_t* m_ptr;
+    public:
+        children_wrapper(uint32_t size_, node_ptr_t * ptr_) : m_size(size_), m_ptr(ptr_) {}
+        node_ptr_t * begin() {
+            return m_ptr;
+        }
+        node_ptr_t * end() {
+            return m_ptr + m_size;
+        }
+        uint32_t size() {
+            return m_size;
+        }
+    };
+
+    children_wrapper get_children() const;
     void sort_children(int color);
     UCTNode& get_best_root_child(int color);
     UCTNode* uct_select_child(int color, bool is_root);
@@ -112,8 +129,8 @@ private:
     SMP::Mutex m_nodemutex;
 
     // Tree data
-    std::atomic<bool> m_has_children{false};
-    std::vector<node_ptr_t> m_children;
+    std::atomic<uint32_t> m_children_size{0};
+    std::unique_ptr<node_ptr_t[]> m_children;
 };
 
 #endif

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -78,7 +78,7 @@ public:
         on 64-bits.
     */
     static constexpr auto MAX_TREE_SIZE =
-        (sizeof(void*) == 4 ? 25'000'000 : 100'000'000);
+        (sizeof(void*) == 4 ? 25'000'000 : 10'000'000);
 
     UCTSearch(GameState& g);
     int think(int color, passflag_t passflag = NORMAL);


### PR DESCRIPTION
Since the last attempt was closed without merging, this time I am proposing a less intrusive (but possibly a bit controversial, IMHO) approach.  What I did was replaced the std::vector inside the UCTNode with a plain-old array of pointer.  This saves about 16 bytes from sizeof(UCTNode) which can mean a quite a bit of memory footprint.  This makes future code maintenance a bit more confusing at the cost of lower memory footprint.

Memory footprint while generating first move with 1 million playouts:
- 12 threads, 2 GPUs
- long enough time limit, large enough playout limit to hit 1M playout per move

Before change : saturate at 8.95GB
After change : saturate at 7.49GB