### PR TITLE
UCTNode lazy initialization for memory footprint reduction (attempt 3 of "Reduce the memory consumption of nodes")

### DIFF
--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -280,7 +280,7 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
     }
 
     assert(best != nullptr);
-    best->expand();
+    best->inflate();
     return best->get();
 }
 
@@ -318,7 +318,7 @@ UCTNode& UCTNode::get_best_root_child(int color) {
 
     auto ret = std::max_element(begin(m_children), end(m_children),
                                 NodeComp(color));
-    ret->expand();
+    ret->inflate();
     return *(ret->get());
 }
 

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -145,16 +145,14 @@ void UCTNode::link_nodelist(std::atomic<int>& nodecount,
     m_children.reserve(nodelist.size());
     for (const auto& node : nodelist) {
         if (node.first < min_psa) continue;
-        m_children.emplace_back(
-            std::make_unique<UCTNode>(node.second, node.first)
-        );
+        m_children.emplace_back(node.second, node.first);
     }
 
     nodecount += m_children.size();
     m_has_children = true;
 }
 
-const std::vector<UCTNode::node_ptr_t>& UCTNode::get_children() const {
+const std::vector<UCTNodePointer>& UCTNode::get_children() const {
     return m_children;
 }
 
@@ -226,7 +224,7 @@ void UCTNode::accumulate_eval(float eval) {
 }
 
 UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
-    UCTNode* best = nullptr;
+    UCTNodePointer * best = nullptr;
     auto best_value = std::numeric_limits<double>::lowest();
 
     LOCK(get_mutex(), lock);
@@ -235,10 +233,10 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
     auto total_visited_policy = 0.0f;
     auto parentvisits = size_t{0};
     for (const auto& child : m_children) {
-        if (child->valid()) {
-            parentvisits += child->get_visits();
-            if (child->get_visits() > 0) {
-                total_visited_policy += child->get_score();
+        if (child.valid()) {
+            parentvisits += child.get_visits();
+            if (child.get_visits() > 0) {
+                total_visited_policy += child.get_score();
             }
         }
     }
@@ -254,49 +252,50 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
     // Estimated eval for unknown nodes = original parent NN eval - reduction
     auto fpu_eval = get_net_eval(color) - fpu_reduction;
 
-    for (const auto& child : m_children) {
-        if (!child->active()) {
+    for (auto& child : m_children) {
+        if (!child.active()) {
             continue;
         }
 
         float winrate = fpu_eval;
-        if (child->get_visits() > 0) {
-            winrate = child->get_eval(color);
+        if (child.get_visits() > 0) {
+            winrate = child.get_eval(color);
         }
-        auto psa = child->get_score();
-        auto denom = 1.0 + child->get_visits();
+        auto psa = child.get_score();
+        auto denom = 1.0 + child.get_visits();
         auto puct = cfg_puct * psa * (numerator / denom);
         auto value = winrate + puct;
         assert(value > std::numeric_limits<double>::lowest());
 
         if (value > best_value) {
             best_value = value;
-            best = child.get();
+            best = &child;
         }
     }
 
     assert(best != nullptr);
-    return best;
+    best->expand();
+    return best->get();
 }
 
-class NodeComp : public std::binary_function<UCTNode::node_ptr_t&,
-                                             UCTNode::node_ptr_t&, bool> {
+class NodeComp : public std::binary_function<UCTNodePointer&,
+                                             UCTNodePointer&, bool> {
 public:
     NodeComp(int color) : m_color(color) {};
-    bool operator()(const UCTNode::node_ptr_t& a,
-                    const UCTNode::node_ptr_t& b) {
+    bool operator()(const UCTNodePointer& a,
+                    const UCTNodePointer& b) {
         // if visits are not same, sort on visits
-        if (a->get_visits() != b->get_visits()) {
-            return a->get_visits() < b->get_visits();
+        if (a.get_visits() != b.get_visits()) {
+            return a.get_visits() < b.get_visits();
         }
 
         // neither has visits, sort on prior score
-        if (a->get_visits() == 0) {
-            return a->get_score() < b->get_score();
+        if (a.get_visits() == 0) {
+            return a.get_score() < b.get_score();
         }
 
         // both have same non-zero number of visits
-        return a->get_eval(m_color) < b->get_eval(m_color);
+        return a.get_eval(m_color) < b.get_eval(m_color);
     }
 private:
     int m_color;
@@ -311,8 +310,10 @@ UCTNode& UCTNode::get_best_root_child(int color) {
     LOCK(get_mutex(), lock);
     assert(!m_children.empty());
 
-    return *(std::max_element(begin(m_children), end(m_children),
-                              NodeComp(color))->get());
+    auto ret = std::max_element(begin(m_children), end(m_children),
+                              NodeComp(color));
+    ret->expand();
+    return *(ret->get());
 }
 
 size_t UCTNode::count_nodes() const {
@@ -320,7 +321,9 @@ size_t UCTNode::count_nodes() const {
     if (m_has_children) {
         nodecount += m_children.size();
         for (auto& child : m_children) {
-            nodecount += child->count_nodes();
+            if(child.get_visits() > 0) {
+                nodecount += child->count_nodes();
+            }
         }
     }
     return nodecount;

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -311,7 +311,7 @@ UCTNode& UCTNode::get_best_root_child(int color) {
     assert(!m_children.empty());
 
     auto ret = std::max_element(begin(m_children), end(m_children),
-                              NodeComp(color));
+                                NodeComp(color));
     ret->expand();
     return *(ret->get());
 }
@@ -321,7 +321,7 @@ size_t UCTNode::count_nodes() const {
     if (m_has_children) {
         nodecount += m_children.size();
         for (auto& child : m_children) {
-            if(child.get_visits() > 0) {
+            if (child.get_visits() > 0) {
                 nodecount += child->count_nodes();
             }
         }

--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -217,7 +217,7 @@ inline UCTNodePointer::UCTNodePointer(std::int16_t vertex, float score) {
 }
 
 inline UCTNodePointer& UCTNodePointer::operator=(UCTNodePointer&& n) {
-    if( _expanded() ) {
+    if ( _expanded() ) {
         delete _readptr();
     }
     m_data = n.m_data;
@@ -227,7 +227,7 @@ inline UCTNodePointer& UCTNodePointer::operator=(UCTNodePointer&& n) {
 }
 
 inline void UCTNodePointer::expand() const {
-    if(_expanded()) return;
+    if (_expanded()) return;
 
     m_data = reinterpret_cast<std::uint64_t>(new UCTNode(_vertex(), _score()));
 }
@@ -255,6 +255,6 @@ inline float UCTNodePointer::get_eval(int tomove) const {
 }
 inline int UCTNodePointer::get_move() const {
     if (_expanded()) return _readptr()->get_move();
-    return _vertex();
+    else return _vertex();
 }
 #endif

--- a/src/UCTNodeRoot.cpp
+++ b/src/UCTNodeRoot.cpp
@@ -146,7 +146,8 @@ UCTNode* UCTNode::get_nopass_child(FastState& state) const {
 UCTNode* UCTNode::find_child(const int move) {
     if (m_has_children) {
         for (auto& child : m_children) {
-            if (child->get_move() == move) {
+            if (child.get_move() == move) {
+                child.expand(); // no guarantee that this is a non-expanded node
                 return child.release();
             }
         }

--- a/src/UCTNodeRoot.cpp
+++ b/src/UCTNodeRoot.cpp
@@ -141,12 +141,13 @@ UCTNode* UCTNode::get_nopass_child(FastState& state) const {
     return nullptr;
 }
 
-// Used to find new root in UCTSearch
-UCTNode::node_ptr_t UCTNode::find_child(const int move) {
+// Used to find new root in UCTSearch.
+// BEWARE : caller is now responsible of freeing the return value
+UCTNode* UCTNode::find_child(const int move) {
     if (m_has_children) {
         for (auto& child : m_children) {
             if (child->get_move() == move) {
-                return std::move(child);
+                return child.release();
             }
         }
     }

--- a/src/UCTNodeRoot.cpp
+++ b/src/UCTNodeRoot.cpp
@@ -143,12 +143,12 @@ UCTNode* UCTNode::get_nopass_child(FastState& state) const {
 
 // Used to find new root in UCTSearch.
 // BEWARE : caller is now responsible of freeing the return value
-UCTNode* UCTNode::find_child(const int move) {
+std::unique_ptr<UCTNode> UCTNode::find_child(const int move) {
     if (m_has_children) {
         for (auto& child : m_children) {
             if (child.get_move() == move) {
-                child.expand(); // no guarantee that this is a non-expanded node
-                return child.release();
+                child.inflate(); // no guarantee that this is a non-inflated node
+                return std::unique_ptr<UCTNode>(child.release());
             }
         }
     }
@@ -156,3 +156,10 @@ UCTNode* UCTNode::find_child(const int move) {
     // Can happen if we resigned or children are not expanded
     return nullptr;
 }
+
+void UCTNode::inflate_all_children() {
+    for (const auto& node : get_children()) {
+        node.inflate();
+    }
+}
+

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -77,7 +77,7 @@ bool UCTSearch::advance_to_new_rootstate() {
     for (auto i = 0; i < depth; i++) {
         test->forward_move();
         const auto move = test->get_last_move();
-        m_root.reset(m_root->find_child(move));
+        m_root = m_root->find_child(move);
         if (!m_root) {
             // Tree hasn't been expanded this far
             return false;
@@ -549,11 +549,9 @@ int UCTSearch::think(int color, passflag_t passflag) {
     }
 
     // Now that the new root is installed...
-    // There are a lot of special cases where root nodes assumes all childs are expanded.
-    // it won't be a waste of memory by so much so go ahead and expand it.
-    for (const auto& node : m_root->get_children()) {
-        node.expand();
-    }
+    // There are a lot of special cases where root nodes assumes all childs are inflated.
+    // it won't be a waste of memory by so much so go ahead and inflate it.
+    m_root->inflate_all_children();
 
     m_root->kill_superkos(m_rootstate);
     if (cfg_noise) {
@@ -637,11 +635,9 @@ void UCTSearch::ponder() {
     m_run = true;
     int cpus = cfg_num_threads;
 
-    // There are a lot of special cases where root nodes assumes all childs are expanded.
-    // it won't be a waste of memory by so much so go ahead and expand it.
-    for (const auto& node : m_root->get_children()) {
-        node.expand();
-    }
+    // There are a lot of special cases where root nodes assumes all childs are .
+    // it won't be a waste of memory by so much so go ahead and inflate it.
+    m_root->inflate_all_children();
 
     ThreadGroup tg(thread_pool);
     for (int i = 1; i < cpus; i++) {

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -214,12 +214,12 @@ void tree_stats_helper(const UCTNode& node, size_t depth,
         if (child.get_visits() > 0) {
             children_count += 1;
             tree_stats_helper(*(child.get()), depth+1,
-                          nodes, non_leaf_nodes, depth_sum,
-                          max_depth, children_count);
+                              nodes, non_leaf_nodes, depth_sum,
+                              max_depth, children_count);
         } else {
             nodes += 1;
             depth_sum += depth+1;
-            if(depth+1 > max_depth) max_depth = depth+1;
+            if (depth+1 > max_depth) max_depth = depth+1;
         }
     }
 }

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -636,6 +636,13 @@ void UCTSearch::ponder() {
 
     m_run = true;
     int cpus = cfg_num_threads;
+
+    // There are a lot of special cases where root nodes assumes all childs are expanded.
+    // it won't be a waste of memory by so much so go ahead and expand it.
+    for (const auto& node : m_root->get_children()) {
+        node.expand();
+    }
+
     ThreadGroup tg(thread_pool);
     for (int i = 1; i < cpus; i++) {
         tg.add_task(UCTWorker(m_rootstate, this, m_root.get()));


### PR DESCRIPTION
- When we expand children nodes, we don't actually create the UCTNode but only keep a proxy of it.
- The actual child node is created (called 'expanded' here) only if it is selected from uct_select_child
  - (One more case - for ease of implementation, the root's children are always expanded)
- As of this commit, we saturate around 3.45GB memory footprint when we hit MAX_TREE_SIZE (down from 8.9GB)