### PR TITLE
Batch norm beta support

### DIFF
--- a/training/tf/tfprocess.py
+++ b/training/tf/tfprocess.py
@@ -38,12 +38,6 @@ def bias_variable(shape):
     initial = tf.constant(0.0, shape=shape)
     return tf.Variable(initial)
 
-# No point in learning bias weights as they are cancelled
-# out by the BatchNorm layers's mean adjustment.
-def bn_bias_variable(shape):
-    initial = tf.constant(0.0, shape=shape)
-    return tf.Variable(initial, trainable=False)
-
 def conv2d(x, W):
     return tf.nn.conv2d(x, W, data_format='NCHW',
                         strides=[1, 1, 1, 1], padding='SAME')
@@ -202,10 +196,30 @@ class TFProcess:
                 shape = [s[i] for i in [1, 0]]
                 new_weight = tf.constant(new_weights[e], shape=shape)
                 self.session.run(weights.assign(tf.transpose(new_weight, [1, 0])))
+            elif 'beta_bias' in weights.name:
+                # Calculated after the other weights have been assigned
+                continue
             else:
                 # Biases, batchnorm etc
                 new_weight = tf.constant(new_weights[e], shape=weights.shape)
                 self.session.run(weights.assign(new_weight))
+
+        # Batch norm bias to beta
+        for e, weights in enumerate(self.weights):
+            if hasattr(weights, 'name') and 'beta_bias' in weights.name:
+                key = weights.name.split('_')[0]
+                beta_key = key + "/batch_normalization/beta:0"
+                var_key  = key + "/batch_normalization/moving_variance:0"
+
+                var = tf.get_default_graph().get_tensor_by_name(var_key)
+                beta = tf.get_default_graph().get_tensor_by_name(beta_key)
+
+                beta_bias = tf.constant(new_weights[e])
+
+                new_beta = tf.divide(beta_bias, tf.sqrt(var + tf.constant(1e-5)))
+
+                self.session.run(tf.assign(beta, new_beta))
+
         #This should result in identical file to the starting one
         #self.save_leelaz_weights('restored.txt')
 
@@ -334,52 +348,53 @@ class TFProcess:
     def conv_block(self, inputs, filter_size, input_channels, output_channels):
         W_conv = weight_variable([filter_size, filter_size,
                                   input_channels, output_channels])
-        b_conv = bn_bias_variable([output_channels])
-        self.weights.append(W_conv)
-        self.weights.append(b_conv)
         # The weights are internal to the batchnorm layer, so apply
         # a unique scope that we can store, and use to look them back up
         # later on.
         weight_key = self.get_batchnorm_key()
-        self.weights.append(weight_key + "/batch_normalization/moving_mean:0")
-        self.weights.append(weight_key + "/batch_normalization/moving_variance:0")
 
         with tf.variable_scope(weight_key):
             h_bn = \
                 tf.layers.batch_normalization(
                     conv2d(inputs, W_conv),
                     epsilon=1e-5, axis=1, fused=True,
-                    center=False, scale=False,
+                    center=True, scale=False,
                     training=self.training)
         h_conv = tf.nn.relu(h_bn)
+
+        beta_key = weight_key + "/batch_normalization/beta:0"
+        mean_key = weight_key + "/batch_normalization/moving_mean:0"
+        var_key = weight_key + "/batch_normalization/moving_variance:0"
+        beta = tf.get_default_graph().get_tensor_by_name(beta_key)
+        var = tf.get_default_graph().get_tensor_by_name(var_key)
+
+        # Move beta before the batch norm for backwards compatibility in leelaz
+        with tf.variable_scope(weight_key):
+            beta_bias = tf.multiply(beta, tf.sqrt(var + tf.constant(1e-5)), name="beta_bias")
+
+        self.weights.append(W_conv)
+        self.weights.append(beta_bias)
+        self.weights.append(mean_key)
+        self.weights.append(var_key)
+
         return h_conv
 
     def residual_block(self, inputs, channels):
         # First convnet
         orig = tf.identity(inputs)
         W_conv_1 = weight_variable([3, 3, channels, channels])
-        b_conv_1 = bn_bias_variable([channels])
-        self.weights.append(W_conv_1)
-        self.weights.append(b_conv_1)
         weight_key_1 = self.get_batchnorm_key()
-        self.weights.append(weight_key_1 + "/batch_normalization/moving_mean:0")
-        self.weights.append(weight_key_1 + "/batch_normalization/moving_variance:0")
 
         # Second convnet
         W_conv_2 = weight_variable([3, 3, channels, channels])
-        b_conv_2 = bn_bias_variable([channels])
-        self.weights.append(W_conv_2)
-        self.weights.append(b_conv_2)
         weight_key_2 = self.get_batchnorm_key()
-        self.weights.append(weight_key_2 + "/batch_normalization/moving_mean:0")
-        self.weights.append(weight_key_2 + "/batch_normalization/moving_variance:0")
 
         with tf.variable_scope(weight_key_1):
             h_bn1 = \
                 tf.layers.batch_normalization(
                     conv2d(inputs, W_conv_1),
                     epsilon=1e-5, axis=1, fused=True,
-                    center=False, scale=False,
+                    center=True, scale=False,
                     training=self.training)
         h_out_1 = tf.nn.relu(h_bn1)
         with tf.variable_scope(weight_key_2):
@@ -387,9 +402,39 @@ class TFProcess:
                 tf.layers.batch_normalization(
                     conv2d(h_out_1, W_conv_2),
                     epsilon=1e-5, axis=1, fused=True,
-                    center=False, scale=False,
+                    center=True, scale=False,
                     training=self.training)
         h_out_2 = tf.nn.relu(tf.add(h_bn2, orig))
+
+        beta_key_1 = weight_key_1 + "/batch_normalization/beta:0"
+        mean_key_1 = weight_key_1 + "/batch_normalization/moving_mean:0"
+        var_key_1 = weight_key_1 + "/batch_normalization/moving_variance:0"
+        beta_1 = tf.get_default_graph().get_tensor_by_name(beta_key_1)
+        var_1 = tf.get_default_graph().get_tensor_by_name(var_key_1)
+
+        beta_key_2 = weight_key_2 + "/batch_normalization/beta:0"
+        mean_key_2 = weight_key_2 + "/batch_normalization/moving_mean:0"
+        var_key_2 = weight_key_2 + "/batch_normalization/moving_variance:0"
+        beta_2 = tf.get_default_graph().get_tensor_by_name(beta_key_2)
+        var_2 = tf.get_default_graph().get_tensor_by_name(var_key_2)
+
+        # Move beta before the batch norm for backwards compatibility in leelaz
+        with tf.variable_scope(weight_key_1):
+            beta_bias_1 = tf.multiply(beta_1, tf.sqrt(var_1 + tf.constant(1e-5)), name="beta_bias")
+
+        with tf.variable_scope(weight_key_2):
+            beta_bias_2 = tf.multiply(beta_2, tf.sqrt(var_2 + tf.constant(1e-5)), name="beta_bias")
+
+        self.weights.append(W_conv_1)
+        self.weights.append(beta_bias_1)
+        self.weights.append(mean_key_1)
+        self.weights.append(var_key_1)
+
+        self.weights.append(W_conv_2)
+        self.weights.append(beta_bias_2)
+        self.weights.append(mean_key_2)
+        self.weights.append(var_key_2)
+
         return h_out_2
 
     def construct_net(self, planes):


### PR DESCRIPTION
Backwards compatible batch norm beta support. Replaces zero biases in network file with `beta*sqrt(var + e)` so that the output is correct in leelaz which adds biases before the batch norm.

In my previous test (https://github.com/gcp/leela-zero/issues/785#issuecomment-362274170) it seemed like adding beta gave a very small decrease in loss. Maybe the effect would be bigger when starting from scratch or with bigger learning rate? Even if the strength increase is minor it should be worth it since this doesn't require any additional work in leelaz.

Tested that restoring and saving gives back the input weights. Training gave reasonable loss and output weights and the network works in leelaz. However I don't have resources to do a bigger training run to check how this affects strength.