### PR TITLE
Minimize old-style casts and null pointer constants.

### DIFF
--- a/autogtp/Management.cpp
+++ b/autogtp/Management.cpp
@@ -219,7 +219,7 @@ void  Management::printTimingInfo(float duration) {
         << total_time_min.count() << " minutes = "
         << total_time_s.count() / m_gamesPlayed << " seconds/game, "
         << total_time_millis.count() / m_movesMade.load()  << " ms/move"
-        << ", last game took " << (int) duration << " seconds." << endl;
+        << ", last game took " << int(duration) << " seconds." << endl;
 }
 
 QString Management::getOption(const QJsonObject &ob, const QString &key, const QString &opt, const QString &defValue) {

--- a/src/FullBoard.cpp
+++ b/src/FullBoard.cpp
@@ -115,7 +115,7 @@ int FullBoard::update_board(const int color, const int i) {
     m_hash ^= Zobrist::zobrist[m_square[i]][i];
     m_ko_hash ^= Zobrist::zobrist[m_square[i]][i];
 
-    m_square[i] = (square_t)color;
+    m_square[i] = square_t(color);
     m_next[i] = i;
     m_parent[i] = i;
     m_libs[i] = count_pliberties(i);

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -429,7 +429,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
         float ftmp = game.final_score();
         /* white wins */
         if (ftmp < -0.1) {
-            gtp_printf(id, "W+%3.1f", (float)fabs(ftmp));
+            gtp_printf(id, "W+%3.1f", float(fabs(ftmp)));
         } else if (ftmp > 0.1) {
             gtp_printf(id, "B+%3.1f", ftmp);
         } else {

--- a/src/Im2Col.h
+++ b/src/Im2Col.h
@@ -42,10 +42,10 @@ void im2col(const int channels,
             for (unsigned int kernel_col = 0; kernel_col < filter_size; kernel_col++) {
                 int input_row = -pad + kernel_row;
                 for (int output_rows = output_h; output_rows; output_rows--) {
-                    if ((unsigned)input_row < height) {
+                    if (unsigned(input_row) < height) {
                         int input_col = -pad + kernel_col;
                         for (int output_col = output_w; output_col; output_col--) {
-                            if ((unsigned)input_col < width) {
+                            if (unsigned(input_col) < width) {
                                 *(data_col++) =
                                     data_im[input_row * width + input_col];
                             } else {

--- a/src/OpenCL.cpp
+++ b/src/OpenCL.cpp
@@ -680,7 +680,7 @@ void OpenCL_Network::convolve3(int channels, int outputs,
 
         cl::NDRange size_sgemm = {(m_ceil * mdimc) / mwg,
                                   (n_ceil * ndimc) / nwg,
-                                  (cl::size_type)WINOGRAD_TILE};
+                                  cl::size_type(WINOGRAD_TILE)};
 
         queue.enqueueNDRangeKernel(sgemm_kernel, cl::NullRange,
                                    size_sgemm, local_sgemm);

--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -36,7 +36,7 @@ Random::Random(std::uint64_t seed) {
     if (seed == 0) {
         size_t thread_id =
             std::hash<std::thread::id>()(std::this_thread::get_id());
-        seedrandom(cfg_rng_seed ^ (std::uint64_t)thread_id);
+        seedrandom(cfg_rng_seed ^ std::uint64_t(thread_id));
     } else {
         seedrandom(seed);
     }

--- a/src/SGFTree.cpp
+++ b/src/SGFTree.cpp
@@ -174,7 +174,7 @@ void SGFTree::populate_states(void) {
         float handicap;
         strm >> handicap;
         has_handicap = (handicap > 0.0f);
-        m_state.set_handicap((int)handicap);
+        m_state.set_handicap(int(handicap));
     }
 
     // result

--- a/src/Training.cpp
+++ b/src/Training.cpp
@@ -356,7 +356,7 @@ void Training::dump_supervised(const std::string& sgf_name,
             Time elapsed;
             auto elapsed_s = Time::timediff_seconds(start, elapsed);
             Utils::myprintf("Game %5d, %5d positions in %5.2f seconds -> %d pos/s\n",
-                gamecount, train_pos, elapsed_s, (int)(train_pos / elapsed_s));
+                gamecount, train_pos, elapsed_s, int(train_pos / elapsed_s));
         }
 
         auto tree_moves = sgftree->get_mainline();

--- a/src/Tuner.cpp
+++ b/src/Tuner.cpp
@@ -152,7 +152,7 @@ std::string Tuner::parameters_to_string(const Parameters& p) {
 }
 
 static size_t next_power_of_two(const size_t x) {
-    return 2 << (size_t)(std::ceil(std::log2(x)) - 1);
+    return 2 << size_t(std::ceil(std::log2(x)) - 1);
 }
 
 static void sgemm_generate_data(std::vector<float> &x,
@@ -322,9 +322,9 @@ std::string Tuner::tune_sgemm(const int m, const int n, const int k,
 
         auto sgemm_kernel = cl::Kernel(program, "XgemmBatched");
 
-        auto m_ceil = (int)ceilMultiple(ceilMultiple(m, p["MWG"]), p["VWM"]);
-        auto n_ceil = (int)ceilMultiple(ceilMultiple(n, p["NWG"]), p["VWN"]);
-        auto k_ceil = (int)ceilMultiple(ceilMultiple(k, p["KWG"]), p["VWM"]);
+        auto m_ceil = int(ceilMultiple(ceilMultiple(m, p["MWG"]), p["VWM"]));
+        auto n_ceil = int(ceilMultiple(ceilMultiple(n, p["NWG"]), p["VWN"]));
+        auto k_ceil = int(ceilMultiple(ceilMultiple(k, p["KWG"]), p["VWM"]));
 
         if (m_ceil != m_ceil_prev
             || n_ceil != n_ceil_prev
@@ -355,7 +355,7 @@ std::string Tuner::tune_sgemm(const int m, const int n, const int k,
 
         cl::NDRange size_sgemm = {(m_ceil * p["MDIMC"]) / p["MWG"],
                                   (n_ceil * p["NDIMC"]) / p["NWG"],
-                                  (size_t)batch_size};
+                                  size_t(batch_size)};
 
         auto sum = 0.0f;
         auto max_error = 0.0f;

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -209,7 +209,7 @@ float UCTNode::get_eval(int tomove) const {
     if (tomove == FastBoard::WHITE) {
         blackeval += static_cast<double>(virtual_loss);
     }
-    auto score = static_cast<float>(blackeval / (double)visits);
+    auto score = static_cast<float>(blackeval / double(visits));
     if (tomove == FastBoard::WHITE) {
         score = 1.0f - score;
     }
@@ -228,7 +228,7 @@ double UCTNode::get_blackevals() const {
 }
 
 void UCTNode::accumulate_eval(float eval) {
-    atomic_add(m_blackevals, (double)eval);
+    atomic_add(m_blackevals, double(eval));
 }
 
 UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
@@ -249,7 +249,7 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
         }
     }
 
-    auto numerator = std::sqrt((double)parentvisits);
+    auto numerator = std::sqrt(double(parentvisits));
     auto fpu_reduction = 0.0f;
     // Lower the expected eval for moves that are likely not the best.
     // Do not do this if we have introduced noise at this node exactly

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -57,7 +57,7 @@ bool UCTSearch::advance_to_new_rootstate() {
     }
 
     auto depth =
-        (int) (m_rootstate.get_movenum() - m_last_rootstate->get_movenum());
+        int(m_rootstate.get_movenum() - m_last_rootstate->get_movenum());
 
     if (depth < 0) {
         return false;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -39,7 +39,7 @@ bool Utils::input_pending(void) {
     FD_ZERO(&read_fds);
     FD_SET(0,&read_fds);
     struct timeval timeout{0,0};
-    select(1,&read_fds,NULL,NULL,&timeout);
+    select(1,&read_fds,nullptr,nullptr,&timeout);
     return FD_ISSET(0, &read_fds);
 #else
     static int init = 0, pipe;
@@ -57,7 +57,7 @@ bool Utils::input_pending(void) {
     }
 
     if (pipe) {
-        if (!PeekNamedPipe(inh, NULL, 0, NULL, &dw, NULL)) {
+        if (!PeekNamedPipe(inh, nullptr, 0, nullptr, &dw, nullptr)) {
             myprintf("Nothing at other end - exiting\n");
             exit(EXIT_FAILURE);
         }


### PR DESCRIPTION
This eliminates all the warnings GCC gives with `-Wold-style-cast` and `-Wzero-as-null-pointer-constant` except where it concerns **cl2.hpp**.