### PR TITLE
Tidy Network gathering of features into input vector 

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -515,14 +515,14 @@ bool GTP::execute(GameState & game, std::string xinput) {
     } else if (command.find("heatmap") == 0) {
         std::istringstream cmdstream(command);
         std::string tmp;
-        int rotation;
+        int symmetry;
 
         cmdstream >> tmp;   // eat heatmap
-        cmdstream >> rotation;
+        cmdstream >> symmetry;
 
         if (!cmdstream.fail()) {
             auto vec = Network::get_scored_moves(
-                &game, Network::Ensemble::DIRECT, rotation, true);
+                &game, Network::Ensemble::DIRECT, symmetry, true);
             Network::show_heatmap(&game, vec, false);
         } else {
             auto vec = Network::get_scored_moves(

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -347,7 +347,7 @@ int main (int argc, char *argv[]) {
     auto komi = 7.5f;
     maingame->init_game(BOARD_SIZE, komi);
 
-    Network::init_rotation_table(*maingame);
+    Network::init_symmetry_table(*maingame);
 
     if (cfg_benchmark) {
         cfg_quiet = false;

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -347,6 +347,8 @@ int main (int argc, char *argv[]) {
     auto komi = 7.5f;
     maingame->init_game(BOARD_SIZE, komi);
 
+    Network::init_rotation_table(*maingame);
+
     if (cfg_benchmark) {
         cfg_quiet = false;
         benchmark(*maingame);

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -431,11 +431,14 @@ void Network::initialize() {
 }
 
 void Network::init_symmetry_table(const GameState& state) {
-    for (auto r = 0; r < 8; r++) {
+    for (auto s = 0; s < 8; s++) {
         for (auto y = 0; y < BOARD_SIZE; y++) {
             for (auto x = 0; x < BOARD_SIZE; x++) {
-                symmetry_nn_idx_vtx_table[r][y * BOARD_SIZE + x] =
-                    get_board_vertex(state, x, y, r);
+                int x_sym, y_sym;
+                get_xy_symmetry(x, y, s, &x_sym, &y_sym);
+
+                symmetry_nn_idx_vtx_table[s][y * BOARD_SIZE + x] = 
+                    state.board.get_vertex(x_sym, y_sym);
             }
         }
     }
@@ -1044,8 +1047,8 @@ void Network::gather_features_vector(const GameState* const state,
     input_data.insert(input_data.cend(), BOARD_SQUARES, net_t(!blacks_move));
 }
 
-int Network::get_board_vertex(const GameState& state, 
-                              const int x, const int y, int symmetry) {
+void Network::get_xy_symmetry(const int x, const int y, int symmetry,
+                              int* const x_out, int* const y_out) {
     assert(x >= 0 && x < BOARD_SIZE);
     assert(y >= 0 && y < BOARD_SIZE);
     assert(symmetry >= 0 && symmetry <= 7);
@@ -1073,8 +1076,7 @@ int Network::get_board_vertex(const GameState& state,
         assert(symmetry == 0);
         break;
     }
-
-    const auto newvtx = state.board.get_vertex(newx, newy);
-    return newvtx;
+    
+    *x_out = newx;
+    *y_out = newy;
 }
-

--- a/src/Network.h
+++ b/src/Network.h
@@ -91,12 +91,9 @@ private:
     static void winograd_sgemm(const std::vector<float>& U,
                                const std::vector<float>& V,
                                std::vector<float>& M, const int C, const int K);
-    static int rotate_nn_idx(const int vertex, int symmetry);
 
     static int get_board_vertex(const GameState& state,
                                 const int x, const int y, int rotation);
-    static void fill_input_plane_pair(
-        const FullBoard& board, BoardPlane& black, BoardPlane& white);
     static void get_input_moves(const GameState* const state,
                                 std::vector<net_t>& input_data,
                                 const int rotation, 

--- a/src/Network.h
+++ b/src/Network.h
@@ -92,9 +92,16 @@ private:
                                std::vector<float>& M, const int C, const int K);
     static int rotate_nn_idx(const int vertex, int symmetry);
     static void fill_input_plane_pair(
-      const FullBoard& board, BoardPlane& black, BoardPlane& white);
-    static Netresult get_scored_moves_internal(
-      const GameState* const state, const NNPlanes & planes, const int rotation);
+        const FullBoard& board, BoardPlane& black, BoardPlane& white);
+    static void get_player_input_moves(const GameState* const state,
+                                       std::vector<net_t>& input_data,
+                                       const int rotation, 
+                                       const int color);
+    static void gather_features_vector(const GameState* const state,
+                                       std::vector<net_t>& input_data, 
+                                       const int rotation);
+    static Netresult get_scored_moves_internal(const GameState* const state, 
+                                               const int rotation);
 #if defined(USE_BLAS)
     static void forward_cpu(const std::vector<float>& input,
                             std::vector<float>& output_pol,

--- a/src/Network.h
+++ b/src/Network.h
@@ -35,7 +35,7 @@
 class Network {
 public:
     enum Ensemble {
-        DIRECT, RANDOM_ROTATION
+        DIRECT, RANDOM_SYMMETRY
     };
     using BoardPlane = std::bitset<BOARD_SQUARES>;
     using NNPlanes = std::vector<BoardPlane>;
@@ -44,7 +44,7 @@ public:
 
     static Netresult get_scored_moves(const GameState* const state,
                                       const Ensemble ensemble,
-                                      const int rotation = -1,
+                                      const int symmetry = -1,
                                       const bool skip_cache = false);
     // File format version
     static constexpr auto FORMAT_VERSION = 1;
@@ -58,7 +58,7 @@ public:
     static constexpr auto WINOGRAD_TILE = WINOGRAD_ALPHA * WINOGRAD_ALPHA;
 
     static void initialize();
-    static void init_rotation_table(const GameState& state);
+    static void init_symmetry_table(const GameState& state);
     static void benchmark(const GameState * const state,
                           const int iterations = 1600);
     static void show_heatmap(const FastState * const state,
@@ -93,16 +93,16 @@ private:
                                std::vector<float>& M, const int C, const int K);
 
     static int get_board_vertex(const GameState& state,
-                                const int x, const int y, int rotation);
+                                const int x, const int y, int symmetry);
     static void get_input_moves(const GameState* const state,
                                 std::vector<net_t>& input_data,
-                                const int rotation, 
+                                const int symmetry,
                                 const int color);
     static void gather_features_vector(const GameState* const state,
                                        std::vector<net_t>& input_data, 
-                                       const int rotation);
+                                       const int symmetry);
     static Netresult get_scored_moves_internal(const GameState* const state, 
-                                               const int rotation);
+                                               const int symmetry);
 #if defined(USE_BLAS)
     static void forward_cpu(const std::vector<float>& input,
                             std::vector<float>& output_pol,

--- a/src/Network.h
+++ b/src/Network.h
@@ -58,6 +58,7 @@ public:
     static constexpr auto WINOGRAD_TILE = WINOGRAD_ALPHA * WINOGRAD_ALPHA;
 
     static void initialize();
+    static void init_rotation_table(const GameState& state);
     static void benchmark(const GameState * const state,
                           const int iterations = 1600);
     static void show_heatmap(const FastState * const state,
@@ -91,12 +92,15 @@ private:
                                const std::vector<float>& V,
                                std::vector<float>& M, const int C, const int K);
     static int rotate_nn_idx(const int vertex, int symmetry);
+
+    static int get_board_vertex(const GameState& state,
+                                const int x, const int y, int rotation);
     static void fill_input_plane_pair(
         const FullBoard& board, BoardPlane& black, BoardPlane& white);
-    static void get_player_input_moves(const GameState* const state,
-                                       std::vector<net_t>& input_data,
-                                       const int rotation, 
-                                       const int color);
+    static void get_input_moves(const GameState* const state,
+                                std::vector<net_t>& input_data,
+                                const int rotation, 
+                                const int color);
     static void gather_features_vector(const GameState* const state,
                                        std::vector<net_t>& input_data, 
                                        const int rotation);

--- a/src/Network.h
+++ b/src/Network.h
@@ -92,8 +92,8 @@ private:
                                const std::vector<float>& V,
                                std::vector<float>& M, const int C, const int K);
 
-    static int get_board_vertex(const GameState& state,
-                                const int x, const int y, int symmetry);
+    static void get_xy_symmetry(const int x, const int y, int symmetry,
+                                int* const x_out, int* const y_out);
     static void get_input_moves(const GameState* const state,
                                 std::vector<net_t>& input_data,
                                 const int symmetry,

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -78,7 +78,7 @@ bool UCTNode::create_children(std::atomic<int>& nodecount,
     lock.unlock();
 
     const auto raw_netlist = Network::get_scored_moves(
-        &state, Network::Ensemble::RANDOM_ROTATION);
+        &state, Network::Ensemble::RANDOM_SYMMETRY);
 
     // DCNN returns winrate as side to move
     m_net_eval = raw_netlist.second;


### PR DESCRIPTION
Changed to produce a vector of feature directly rather than going via the NNPlanes representation. Simplified application of rotations by storing board vertices instead of NN plane vertices.

Also makes it easier for a future change to produce rotations of training data, if ever desired.