### PR TITLE
Reduce time uncertainty

### DIFF
--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -19,10 +19,12 @@
 #ifndef UCTSEARCH_H_INCLUDED
 #define UCTSEARCH_H_INCLUDED
 
+#include <list>
 #include <atomic>
 #include <memory>
 #include <string>
 #include <tuple>
+#include <future>
 
 #include "FastBoard.h"
 #include "FastState.h"
@@ -111,6 +113,8 @@ private:
     std::atomic<bool> m_run{false};
     int m_maxplayouts;
     int m_maxvisits;
+
+    std::list<std::future<void>> m_delete_futures;
 };
 
 class UCTWorker {

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -26,6 +26,7 @@
 #include <tuple>
 #include <future>
 
+#include "ThreadPool.h"
 #include "FastBoard.h"
 #include "FastState.h"
 #include "GameState.h"
@@ -114,7 +115,7 @@ private:
     int m_maxplayouts;
     int m_maxvisits;
 
-    std::list<std::future<void>> m_delete_futures;
+    std::list<Utils::ThreadGroup> m_delete_futures;
 };
 
 class UCTWorker {


### PR DESCRIPTION
There are complaints that leelaz does not honor the configured time on some corner cases.  This tries to address the problem by:
1) measure time including the 'select new root' code for each move
2) move the tree destructur to the side thread