### PR TITLE
Ponder now keeps tree for tree re-use

### DIFF
--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -666,6 +666,9 @@ void UCTSearch::ponder() {
     dump_stats(m_rootstate, *m_root);
 
     myprintf("\n%d visits, %d nodes\n\n", m_root->get_visits(), m_nodes.load());
+
+	// Copy the root state. Use to check for tree re-use in future calls.
+	m_last_rootstate = std::make_unique<GameState>(m_rootstate);
 }
 
 void UCTSearch::set_playout_limit(int playouts) {


### PR DESCRIPTION
Fixes bug where ponder would lose tree and it would have to be built from NNCache.