### PR TITLE
Thread-safe UCTNodePointer

### DIFF
--- a/src/UCTNodePointer.cpp
+++ b/src/UCTNodePointer.cpp
@@ -26,17 +26,18 @@
 #include "UCTNode.h"
 
 UCTNodePointer::~UCTNodePointer() {
-    if (is_inflated()) {
-        delete read_ptr();
+    auto v = std::atomic_exchange(&m_data, std::uint64_t{2});
+    if (is_inflated(v)) {
+        delete read_ptr(v);
     }
 }
 
 UCTNodePointer::UCTNodePointer(UCTNodePointer&& n) {
-    if (is_inflated()) {
-        delete read_ptr();
+    auto nv = std::atomic_exchange(&n.m_data, std::uint64_t{2});
+    auto v = std::atomic_exchange(&m_data, nv);
+    if (is_inflated(v)) {
+        delete read_ptr(v);
     }
-    m_data = n.m_data;
-    n.m_data = 1; // non-inflated garbage
 }
 
 UCTNodePointer::UCTNodePointer(std::int16_t vertex, float score) {
@@ -45,52 +46,71 @@ UCTNodePointer::UCTNodePointer(std::int16_t vertex, float score) {
     std::memcpy(&i_score, &score, sizeof(i_score));
 
     m_data =  (static_cast<std::uint64_t>(i_score)  << 32)
-            | (static_cast<std::uint64_t>(i_vertex) << 16) | 1ULL;
+            | (static_cast<std::uint64_t>(i_vertex) << 16);
 }
 
 UCTNodePointer& UCTNodePointer::operator=(UCTNodePointer&& n) {
-    if (is_inflated()) {
-        delete read_ptr();
-    }
-    m_data = n.m_data;
-    n.m_data = 1;
+    auto nv = std::atomic_exchange(&n.m_data, std::uint64_t{2});
+    auto v = std::atomic_exchange(&m_data, nv);
 
+    if (is_inflated(v)) {
+        delete read_ptr(v);
+    }
     return *this;
 }
 
 void UCTNodePointer::inflate() const {
-    if (is_inflated()) return;
-    m_data = reinterpret_cast<std::uint64_t>(
-        new UCTNode(read_vertex(), read_score()));
+    while(1) {
+        auto v = m_data.load();
+        if (is_inflated(v)) return;
+
+        auto v2 = reinterpret_cast<std::uint64_t>(
+            new UCTNode(read_vertex(v), read_score(v))
+        ) + 1;
+        bool success = m_data.compare_exchange_strong(v, v2);
+        if (success) {
+            return;
+        } else {
+            // this means that somebody else also modified this instance.
+            // Try again next time
+            delete read_ptr(v2);
+        }
+    }
 }
 
 bool UCTNodePointer::valid() const {
-    if (is_inflated()) return read_ptr()->valid();
+    auto v = m_data.load();
+    if (is_inflated(v)) return read_ptr(v)->valid();
     return true;
 }
 
 int UCTNodePointer::get_visits() const {
-    if (is_inflated()) return read_ptr()->get_visits();
+    auto v = m_data.load();
+    if (is_inflated(v)) return read_ptr(v)->get_visits();
     return 0;
 }
 
 float UCTNodePointer::get_score() const {
-    if (is_inflated()) return read_ptr()->get_score();
-    return read_score();
+    auto v = m_data.load();
+    if (is_inflated(v)) return read_ptr(v)->get_score();
+    return read_score(v);
 }
 
 bool UCTNodePointer::active() const {
-    if (is_inflated()) return read_ptr()->active();
+    auto v = m_data.load();
+    if (is_inflated(v)) return read_ptr(v)->active();
     return true;
 }
 
 float UCTNodePointer::get_eval(int tomove) const {
     // this can only be called if it is an inflated pointer
-    assert(is_inflated());
-    return read_ptr()->get_eval(tomove);
+    auto v = m_data.load();
+    assert(is_inflated(v));
+    return read_ptr(v)->get_eval(tomove);
 }
 
 int UCTNodePointer::get_move() const {
-    if (is_inflated()) return read_ptr()->get_move();
-    return read_vertex();
+    auto v = m_data.load();
+    if (is_inflated(v)) return read_ptr(v)->get_move();
+    return read_vertex(v);
 }

--- a/src/UCTNodePointer.h
+++ b/src/UCTNodePointer.h
@@ -39,36 +39,41 @@ class UCTNode;
 //  - std::unique_ptr<UCTNode> pointer;
 //  - std::pair<float, std::int16_t> args;
 
-// WARNING : inflate() is not thread-safe and hence has to be protected
-// by an external lock.
+// All methods should be thread-safe except destructor and when
+// the instanced is 'moved from'.
 
 class UCTNodePointer {
 private:
     // the raw storage used here.
-    // if bit 0 is 0, m_data is the actual pointer.
-    // if bit 0 is 1, bit [31:16] is the vertex value, bit [63:32] is the score.
+    // if bit [1:0] is 1, m_data is the actual pointer.
+    // if bit [1:0] is 0, bit [31:16] is the vertex value, bit [63:32] is the score.
+    // if bit [1:0] is other values, it should assert-fail
     // (C-style bit fields and unions are not portable)
-    mutable uint64_t m_data = 1;
+    mutable std::atomic<std::uint64_t> m_data{2};
 
-    UCTNode * read_ptr() const {
-        assert(is_inflated());
-        return reinterpret_cast<UCTNode*>(m_data);
+    UCTNode * read_ptr(uint64_t v) const {
+        assert((v & 3ULL) == 1);
+        return reinterpret_cast<UCTNode*>(v-1);
     }
 
-    std::int16_t read_vertex() const {
-        assert(!is_inflated());
-        return static_cast<std::int16_t>(m_data >> 16);
+    std::int16_t read_vertex(uint64_t v) const {
+        assert((v & 3ULL) == 0);
+        return static_cast<std::int16_t>(v >> 16);
     }
 
-    float read_score() const {
+    float read_score(uint64_t v) const {
         static_assert(sizeof(float) == 4,
             "This code assumes floats are 32-bit");
-        assert(!is_inflated());
+        assert((v & 3ULL) == 0);
 
-        auto x = static_cast<std::uint32_t>(m_data >> 32);
+        auto x = static_cast<std::uint32_t>(v >> 32);
         float ret;
         std::memcpy(&ret, &x, sizeof(ret));
         return ret;
+    }
+
+    bool is_inflated(uint64_t v) const {
+        return (v & 3ULL) == 1;
     }
 
 public:
@@ -77,25 +82,21 @@ public:
     UCTNodePointer(std::int16_t vertex, float score);
     UCTNodePointer(const UCTNodePointer&) = delete;
 
-    bool is_inflated() const {
-        return (m_data & 1ULL) == 0;
-    }
 
     // methods from std::unique_ptr<UCTNode>
     typename std::add_lvalue_reference<UCTNode>::type operator*() const{
-        return *read_ptr();
+        return *read_ptr(m_data.load());
     }
     UCTNode* operator->() const {
-        return read_ptr();
+        return read_ptr(m_data.load());
     }
     UCTNode* get() const {
-        return read_ptr();
+        return read_ptr(m_data.load());
     }
     UCTNodePointer& operator=(UCTNodePointer&& n);
     UCTNode * release() {
-        auto ret = read_ptr();
-        m_data = 1;
-        return ret;
+        auto v = std::atomic_exchange(&m_data, std::uint64_t{2}); 
+        return read_ptr(v);
     }
 
     // construct UCTNode instance from the vertex/score pair

--- a/src/UCTNodePointer.h
+++ b/src/UCTNodePointer.h
@@ -44,27 +44,30 @@ class UCTNode;
 
 class UCTNodePointer {
 private:
+    static constexpr std::uint64_t INVALID = 2;
+    static constexpr std::uint64_t POINTER = 1;
+    static constexpr std::uint64_t UNINFLATED = 0;
     // the raw storage used here.
     // if bit [1:0] is 1, m_data is the actual pointer.
     // if bit [1:0] is 0, bit [31:16] is the vertex value, bit [63:32] is the score.
     // if bit [1:0] is other values, it should assert-fail
     // (C-style bit fields and unions are not portable)
-    mutable std::atomic<std::uint64_t> m_data{2};
+    mutable std::atomic<std::uint64_t> m_data{INVALID};
 
     UCTNode * read_ptr(uint64_t v) const {
-        assert((v & 3ULL) == 1);
-        return reinterpret_cast<UCTNode*>(v-1);
+        assert((v & 3ULL) == POINTER);
+        return reinterpret_cast<UCTNode*>(v & ~(0x3ULL));
     }
 
     std::int16_t read_vertex(uint64_t v) const {
-        assert((v & 3ULL) == 0);
+        assert((v & 3ULL) == UNINFLATED);
         return static_cast<std::int16_t>(v >> 16);
     }
 
     float read_score(uint64_t v) const {
         static_assert(sizeof(float) == 4,
             "This code assumes floats are 32-bit");
-        assert((v & 3ULL) == 0);
+        assert((v & 3ULL) == UNINFLATED);
 
         auto x = static_cast<std::uint32_t>(v >> 32);
         float ret;
@@ -73,7 +76,7 @@ private:
     }
 
     bool is_inflated(uint64_t v) const {
-        return (v & 3ULL) == 1;
+        return (v & 3ULL) == POINTER;
     }
 
 public:
@@ -95,7 +98,7 @@ public:
     }
     UCTNodePointer& operator=(UCTNodePointer&& n);
     UCTNode * release() {
-        auto v = std::atomic_exchange(&m_data, std::uint64_t{2}); 
+        auto v = std::atomic_exchange(&m_data, INVALID); 
         return read_ptr(v);
     }
 


### PR DESCRIPTION
This makes almost all UCTNodePointer operations thread-safe.
The only exceptions are destructors and when it is 'moved out'
Should even handle concurrent inflate() calls properly.