### PR TITLE
SMP : Lock destructor should not unlock mutex if lock is not owned

### DIFF
--- a/src/SMP.h
+++ b/src/SMP.h
@@ -43,6 +43,8 @@ namespace SMP {
         void unlock();
     private:
         Mutex * m_mutex;
+        // true if this Lock holds the mutex
+        bool m_selflock;
     };
 }
 


### PR DESCRIPTION
If a thread explicitly calls unlock() then the destructor may try to unlock it again.
Check if this Lock instance owns the lock, and attempt unlocking only if it owns it.