### PR TITLE
Encode Netresult value to be 16-bit unsigned integer

### DIFF
--- a/msvc/VS2015/leela-zero.vcxproj
+++ b/msvc/VS2015/leela-zero.vcxproj
@@ -108,6 +108,7 @@
     <ClInclude Include="..\..\src\Im2Col.h" />
     <ClInclude Include="..\..\src\KoState.h" />
     <ClInclude Include="..\..\src\Network.h" />
+    <ClInclude Include="..\..\src\Netresult.h" />
     <ClInclude Include="..\..\src\NNCache.h" />
     <ClInclude Include="..\..\src\OpenCL.h" />
     <ClInclude Include="..\..\src\OpenCLScheduler.h" />

--- a/msvc/VS2015/leela-zero.vcxproj.filters
+++ b/msvc/VS2015/leela-zero.vcxproj.filters
@@ -42,6 +42,9 @@
     <ClInclude Include="..\..\src\Network.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\Netresult.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\OpenCL.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/msvc/VS2017/leela-zero.vcxproj
+++ b/msvc/VS2017/leela-zero.vcxproj
@@ -29,6 +29,7 @@
     <ClInclude Include="..\..\src\Im2Col.h" />
     <ClInclude Include="..\..\src\KoState.h" />
     <ClInclude Include="..\..\src\Network.h" />
+    <ClInclude Include="..\..\src\Netresult.h" />
     <ClInclude Include="..\..\src\NNCache.h" />
     <ClInclude Include="..\..\src\OpenCL.h" />
     <ClInclude Include="..\..\src\OpenCLScheduler.h" />

--- a/msvc/VS2017/leela-zero.vcxproj.filters
+++ b/msvc/VS2017/leela-zero.vcxproj.filters
@@ -42,6 +42,9 @@
     <ClInclude Include="..\..\src\Network.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\Netresult.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\OpenCL.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/src/NNCache.cpp
+++ b/src/NNCache.cpp
@@ -29,7 +29,7 @@ NNCache& NNCache::get_NNCache(void) {
     return cache;
 }
 
-bool NNCache::lookup(std::uint64_t hash, Network::Netresult & result) {
+bool NNCache::lookup(std::uint64_t hash, Netresult & result) {
     std::lock_guard<std::mutex> lock(m_mutex);
     ++m_lookups;
 
@@ -47,7 +47,7 @@ bool NNCache::lookup(std::uint64_t hash, Network::Netresult & result) {
 }
 
 void NNCache::insert(std::uint64_t hash,
-                     const Network::Netresult& result) {
+                     const Netresult& result) {
     std::lock_guard<std::mutex> lock(m_mutex);
 
     if (m_cache.find(hash) != m_cache.end()) {
@@ -76,8 +76,8 @@ void NNCache::resize(int size) {
 void NNCache::set_size_from_playouts(int max_playouts) {
     // cache hits are generally from last several moves so setting cache
     // size based on playouts increases the hit rate while balancing memory
-    // usage for low playout instances. 150'000 cache entries is ~225 MB
-    auto max_size = std::min(150'000, std::max(6'000, 3 * max_playouts));
+    // usage for low playout instances. 300'000 cache entries is ~225 MB
+    auto max_size = std::min(300'000, std::max(6'000, 3 * max_playouts));
     NNCache::get_NNCache().resize(max_size);
 }
 

--- a/src/NNCache.h
+++ b/src/NNCache.h
@@ -39,11 +39,11 @@ public:
     void resize(int size);
 
     // Try and find an existing entry.
-    bool lookup(std::uint64_t hash, Network::Netresult & result);
+    bool lookup(std::uint64_t hash, Netresult & result);
 
     // Insert a new entry.
     void insert(std::uint64_t hash,
-                const Network::Netresult& result);
+                const Netresult& result);
 
     // Return the hit rate ratio.
     std::pair<int, int> hit_rate() const {
@@ -53,7 +53,7 @@ public:
     void dump_stats();
 
 private:
-    NNCache(int size = 150000);  // ~ 225MB
+    NNCache(int size = 300000);  // ~ 225MB
 
     std::mutex m_mutex;
 
@@ -65,9 +65,9 @@ private:
     int m_inserts{0};
 
     struct Entry {
-        Entry( const Network::Netresult& r)
+        Entry( const Netresult& r)
             : result(r) {}
-        Network::Netresult result;  // ~ 1.5KB
+        Netresult result;  // ~ 0.75kB 
     };
 
     // Map from hash to {features, result}

--- a/src/Netresult.h
+++ b/src/Netresult.h
@@ -1,0 +1,69 @@
+/*
+    This file is part of Leela Zero.
+    Copyright (C) 2017-2018 Gian-Carlo Pascutto and contributors
+
+    Leela Zero is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Leela Zero is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Leela Zero.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef NETRESULT_H_INCLUDED
+#define NETRESULT_H_INCLUDED
+
+#include <limits>
+#include <cmath>
+
+#include "FastState.h"
+class Netresult {
+    uint16_t encode(float v) const {
+        std::uint16_t MAX = std::numeric_limits<std::uint16_t>::max();
+        v = std::round(v * MAX);
+        if(v > MAX) v = static_cast<float>(MAX);
+        if(v < 0) v = 0.0;
+        
+        return static_cast<uint16_t>(v);
+    }
+    float to_float(uint16_t v) const {
+        std::uint16_t MAX = std::numeric_limits<std::uint16_t>::max();
+        return static_cast<float>(v) / MAX;
+    }
+
+    // 19x19 board positions, 0.0 ~ 1.0 encoded as 0~65535
+    std::vector<std::uint16_t> m_policy;
+
+    // pass, 0.0 ~ 1.0 encoded as 0~65535
+    std::uint16_t m_policy_pass;
+
+    // winrate, 0.0 ~ 1.0 encoded as 0~65535
+    std::uint16_t m_winrate;
+
+public:
+    Netresult() : m_policy(BOARD_SQUARES), m_policy_pass(0), m_winrate(0) {}
+    float read_policy(int index) const {
+        return to_float(m_policy[index]);
+    }
+    float read_pass() const {
+        return to_float(m_policy_pass);
+    } 
+    float read_winrate() const {
+        return to_float(m_winrate);
+    }
+    void write_policy(int index, float value) {
+        m_policy[index] = encode(value);
+    }
+    void write_pass_winrate(float pass, float winrate) {
+        m_policy_pass = encode(pass);
+        m_winrate = encode(winrate);
+    }
+};
+
+#endif

--- a/src/Network.h
+++ b/src/Network.h
@@ -31,6 +31,8 @@
 
 #include "FastState.h"
 #include "GameState.h"
+#include "Netresult.h"
+
 
 class Network {
 public:
@@ -41,18 +43,6 @@ public:
     using NNPlanes = std::vector<BoardPlane>;
     using ScoreVertexPair = std::pair<float,int>;
 
-    struct Netresult {
-        // 19x19 board positions
-        std::vector<float> policy;
-
-        // pass
-        float policy_pass;
-
-        // winrate
-        float winrate;
-
-        Netresult() : policy(BOARD_SQUARES), policy_pass(0.0f), winrate(0.0f) {}
-    };
 
     static Netresult get_scored_moves(const GameState* const state,
                                       const Ensemble ensemble,

--- a/src/Training.cpp
+++ b/src/Training.cpp
@@ -147,7 +147,7 @@ void Training::record(GameState& state, UCTNode& root) {
 
     auto result =
         Network::get_scored_moves(&state, Network::Ensemble::DIRECT, 0);
-    step.net_winrate = result.winrate;
+    step.net_winrate = result.read_winrate();
 
     const auto& best_node = root.get_best_root_child(step.to_move);
     step.root_uct_winrate = root.get_eval(step.to_move);

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -81,7 +81,7 @@ bool UCTNode::create_children(std::atomic<int>& nodecount,
         &state, Network::Ensemble::RANDOM_ROTATION);
 
     // DCNN returns winrate as side to move
-    m_net_eval = raw_netlist.winrate;
+    m_net_eval = raw_netlist.read_winrate();
     const auto to_move = state.board.get_to_move();
     // our search functions evaluate from black's point of view
     if (state.board.white_to_move()) {
@@ -97,12 +97,12 @@ bool UCTNode::create_children(std::atomic<int>& nodecount,
         const auto y = i / BOARD_SIZE;
         const auto vertex = state.board.get_vertex(x, y);
         if (state.is_move_legal(to_move, vertex)) {
-            nodelist.emplace_back(raw_netlist.policy[i], vertex);
-            legal_sum += raw_netlist.policy[i];
+            nodelist.emplace_back(raw_netlist.read_policy(i), vertex);
+            legal_sum += raw_netlist.read_policy(i);
         }
     }
-    nodelist.emplace_back(raw_netlist.policy_pass, FastBoard::PASS);
-    legal_sum += raw_netlist.policy_pass;
+    nodelist.emplace_back(raw_netlist.read_pass(), FastBoard::PASS);
+    legal_sum += raw_netlist.read_pass();
 
     if (legal_sum > std::numeric_limits<float>::min()) {
         // re-normalize after removing illegal moves.


### PR DESCRIPTION
Since all values of the NN outputs are from 0\~1, encode them to be 0\~65535,
and keep them as a 16-bit integer to save space on NNCache.
Bump up the max cache size to be 300k entries