### PR TITLE
fp16 datatypes for OpenCL evaluation

### DIFF
--- a/src/Im2Col.h
+++ b/src/Im2Col.h
@@ -25,7 +25,7 @@
 
 template <unsigned long filter_size>
 void im2col(const int channels,
-            const std::vector<net_t>& input,
+            const std::vector<float>& input,
             std::vector<float>& output) {
     constexpr unsigned int height = BOARD_SIZE;
     constexpr unsigned int width = BOARD_SIZE;
@@ -34,7 +34,7 @@ void im2col(const int channels,
     constexpr unsigned int output_h = height + 2 * pad - filter_size  + 1;
     constexpr unsigned int output_w = width + 2 * pad - filter_size + 1;
 
-    const net_t* data_im = input.data();
+    const float* data_im = input.data();
     float* data_col = output.data();
 
     for (int channel = channels; channel--; data_im += BOARD_SQUARES) {
@@ -67,7 +67,7 @@ void im2col(const int channels,
 
 template <>
 void im2col<1>(const int channels,
-               const std::vector<net_t>& input,
+               const std::vector<float>& input,
                std::vector<float>& output) {
     auto outSize = size_t{channels * static_cast<size_t>(BOARD_SQUARES)};
     assert(output.size() == outSize);

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -626,7 +626,7 @@ void Network::winograd_convolve3(const int outputs,
 
 template<unsigned int filter_size>
 void convolve(const size_t outputs,
-              const std::vector<net_t>& input,
+              const std::vector<float>& input,
               const std::vector<float>& weights,
               const std::vector<float>& biases,
               std::vector<float>& output) {
@@ -884,6 +884,10 @@ Network::Netresult Network::get_scored_moves_internal(
     std::vector<net_t> input_data;
     std::vector<float> policy_data(OUTPUTS_POLICY * width * height);
     std::vector<float> value_data(OUTPUTS_VALUE * width * height);
+#ifdef USE_HALF
+    std::vector<net_t> policy_data_n(OUTPUTS_POLICY * width * height);
+    std::vector<net_t> value_data_n(OUTPUTS_VALUE * width * height);
+#endif
     // Data layout is input_data[(c * height + h) * width + w]
     input_data.reserve(INPUT_CHANNELS * width * height);
     for (auto c = 0; c < INPUT_CHANNELS; ++c) {
@@ -895,7 +899,13 @@ Network::Netresult Network::get_scored_moves_internal(
         }
     }
 #ifdef USE_OPENCL
+#ifdef USE_HALF
+    opencl.forward(input_data, policy_data_n, value_data_n);
+    std::copy(begin(policy_data_n), end(policy_data_n), begin(policy_data));
+    std::copy(begin(value_data_n), end(value_data_n), begin(value_data));
+#else
     opencl.forward(input_data, policy_data, value_data);
+#endif
 #elif defined(USE_BLAS) && !defined(USE_OPENCL)
     forward_cpu(input_data, policy_data, value_data);
 #endif

--- a/src/Tuner.cpp
+++ b/src/Tuner.cpp
@@ -45,16 +45,31 @@
 #include <cblas.h>
 #endif
 
+#ifdef USE_HALF
+const auto TUNER_FILE_LOCAL = std::string("leelaz_opencl_tuning_half");
+constexpr auto MAX_ERROR = 1e-2f;
+#else
 const auto TUNER_FILE_LOCAL = std::string("leelaz_opencl_tuning");
 constexpr auto MAX_ERROR = 1e-4f;
+#endif
 
 using namespace Utils;
 
-static void sgemmBatched_ref(const std::vector<float>& a,
-                             const std::vector<float>& b,
-                             std::vector<float>& c,
+static void sgemmBatched_ref(const std::vector<net_t>& a,
+                             const std::vector<net_t>& b,
+                             std::vector<net_t>& c,
                              const int m, const int n, const int k,
                              const int batch_size) {
+    std::vector<float> ar(a.size());
+    std::vector<float> br(b.size());
+    std::vector<float> cr(c.size());
+
+    for(auto i=size_t{0}; i<a.size(); i++) {
+        ar[i] = a[i];
+    }
+    for(auto i=size_t{0}; i<b.size(); i++) {
+        br[i] = b[i];
+    }
     for (auto batch = 0; batch < batch_size; batch++) {
         auto offset_u = batch * m * k;
         auto offset_v = batch * n * k;
@@ -63,10 +78,13 @@ static void sgemmBatched_ref(const std::vector<float>& a,
         cblas_sgemm(CblasRowMajor, CblasTrans, CblasNoTrans,
                     m, n, k,
                     1.0f,
-                    &a[offset_u], m,
-                    &b[offset_v], n,
+                    &ar[offset_u], m,
+                    &br[offset_v], n,
                     0.0f,
-                    &c[offset_m], n);
+                    &cr[offset_m], n);
+    }
+    for(auto i=size_t{0}; i<c.size(); i++) {
+        c[i] = cr[i];
     }
 }
 
@@ -155,7 +173,7 @@ static size_t next_power_of_two(const size_t x) {
     return 2 << size_t(std::ceil(std::log2(x)) - 1);
 }
 
-static void sgemm_generate_data(std::vector<float> &x,
+static void sgemm_generate_data(std::vector<net_t> &x,
                                 const int m, const int n,
                                 const int batch_size,
                                 const int m_ceil, const int n_ceil) {
@@ -178,7 +196,7 @@ static void sgemm_generate_data(std::vector<float> &x,
     }
 }
 
-static float compare_ref(std::vector<float> &x, std::vector<float> &ref,
+static float compare_ref(std::vector<net_t> &x, std::vector<net_t> &ref,
                          const int m, const int n, const int batch_size,
                          const int m_ceil, const int n_ceil) {
     auto sum = 0.0f;
@@ -248,10 +266,10 @@ std::string Tuner::tune_sgemm(const int m, const int n, const int k,
 
     auto total_flops = batch_size * 2.0 * m * n * k;
 
-    auto at = std::vector<float>(at_size);
-    auto b = std::vector<float>(b_size);
-    auto c = std::vector<float>(c_size);
-    auto c_ref = std::vector<float>(c_size);
+    auto at = std::vector<net_t>(at_size);
+    auto b = std::vector<net_t>(b_size);
+    auto c = std::vector<net_t>(c_size);
+    auto c_ref = std::vector<net_t>(c_size);
 
     sgemm_generate_data(at, k, m, batch_size, k, m);
     sgemm_generate_data(b, n, k, batch_size, n, k);
@@ -260,13 +278,13 @@ std::string Tuner::tune_sgemm(const int m, const int n, const int k,
 
     auto aBuffer = cl::Buffer(
         m_context,
-        CL_MEM_READ_WRITE, sizeof(float) * at_size, nullptr, nullptr);
+        CL_MEM_READ_WRITE, sizeof(net_t) * at_size, nullptr, nullptr);
     auto bBuffer = cl::Buffer(
         m_context,
-        CL_MEM_READ_WRITE, sizeof(float) * b_size, nullptr, nullptr);
+        CL_MEM_READ_WRITE, sizeof(net_t) * b_size, nullptr, nullptr);
     auto cBuffer = cl::Buffer(
         m_context,
-        CL_MEM_READ_WRITE, sizeof(float) * c_size, nullptr, nullptr);
+        CL_MEM_READ_WRITE, sizeof(net_t) * c_size, nullptr, nullptr);
 
     myprintf("\nStarted OpenCL SGEMM tuner.\n");
 
@@ -337,9 +355,9 @@ std::string Tuner::tune_sgemm(const int m, const int n, const int k,
             sgemm_generate_data(b, n, k, batch_size, n_ceil, k_ceil);
 
             queue.enqueueWriteBuffer(aBuffer, CL_FALSE, 0,
-                                     at_size * sizeof(float), at.data());
+                                     at_size * sizeof(net_t), at.data());
             queue.enqueueWriteBuffer(bBuffer, CL_FALSE, 0,
-                                     b_size * sizeof(float), b.data());
+                                     b_size * sizeof(net_t), b.data());
             queue.finish();
         }
 
@@ -368,7 +386,7 @@ std::string Tuner::tune_sgemm(const int m, const int n, const int k,
                 event.wait();
 
                 queue.enqueueReadBuffer(cBuffer, CL_FALSE, 0,
-                                        c_size * sizeof(float), c.data());
+                                        c_size * sizeof(net_t), c.data());
                 queue.finish();
 
                 auto this_error = compare_ref(c, c_ref, n, m, batch_size,

--- a/src/clblast_level3_half/common.opencl
+++ b/src/clblast_level3_half/common.opencl
@@ -1,0 +1,170 @@
+
+// =================================================================================================
+// This file is part of the CLBlast project. The project is licensed under Apache Version 2.0. This
+// project loosely follows the Google C++ styleguide and uses a tab-size of two spaces and a max-
+// width of 100 characters per line.
+//
+// Author(s):
+//   Cedric Nugteren <www.cedricnugteren.nl>
+//
+// This file contains the common defines and type-defs for the CLBlast OpenCL kernels.
+//
+// =================================================================================================
+
+// Enables loading of this file using the C++ pre-processor's #include (C++11 standard raw string
+// literal). Comment-out this line for syntax-highlighting when developing.
+R"(
+// =================================================================================================
+
+#define ROUTINE_GEMMBATCHED
+
+// Parameters set by the tuner or by the database. Here they are given a basic default value in case
+// this file is used outside of the CLBlast library.
+#ifndef PRECISION
+  #define PRECISION 32      // Data-types: half, single or double precision, complex or regular
+#endif
+
+// =================================================================================================
+#ifndef CUDA
+  // Enable support for double-precision
+  #if PRECISION == 16
+    #pragma OPENCL EXTENSION cl_khr_fp16: enable
+  #endif
+#endif
+
+// Half-precision
+#if PRECISION == 16
+  typedef half real;
+  typedef half2 real2;
+  typedef half4 real4;
+  typedef half8 real8;
+  typedef half16 real16;
+  #define ZERO 0
+  #define ONE 1
+  #define SMALLEST -1.0e14
+
+// Single-precision
+#elif PRECISION == 32
+  typedef float real;
+  typedef float2 real2;
+  typedef float4 real4;
+  typedef float8 real8;
+  typedef float16 real16;
+  #define ZERO 0.0f
+  #define ONE 1.0f
+  #define SMALLEST -1.0e37f
+#endif
+
+// Single-element version of a complex number
+  typedef real singlereal;
+
+// Converts a 'real argument' value to a 'real' value as passed to the kernel. Normally there is no
+// conversion, but half-precision is not supported as kernel argument so it is converted from float.
+#if PRECISION == 16
+  typedef float real_arg;
+  #define GetRealArg(x) (half)x
+#else
+  typedef real real_arg;
+  #define GetRealArg(x) x
+#endif
+
+// Pointers to local memory objects (using a define because CUDA doesn't need them)
+#ifndef LOCAL_PTR
+  #define LOCAL_PTR __local
+#endif
+
+// =================================================================================================
+
+// Don't use the non-IEEE754 compliant OpenCL built-in mad() instruction per default. For specific
+// devices, this is enabled (see src/routine.cpp).
+#ifndef USE_CL_MAD
+  #define USE_CL_MAD 0
+#endif
+
+// Sets a variable to zero
+#define SetToZero(a) a = ZERO
+
+// Sets a variable to zero (only the imaginary part)
+#define ImagToZero(a)
+
+// Sets a variable to one
+#define SetToOne(a) a = ONE
+
+// Determines whether a variable is zero
+#define IsZero(a) (a == ZERO)
+
+// The absolute value (component-wise)
+#define AbsoluteValue(value) value = fabs(value)
+
+// Negation (component-wise)
+#define Negate(value) value = -(value)
+
+// Adds two complex variables
+#define Add(c,a,b) c = a + b
+
+// Subtracts two complex variables
+#define Subtract(c,a,b) c = a - b
+
+// The scalar multiply function
+#define Multiply(c,a,b) c = a * b
+
+// The scalar multiply-add function
+#if USE_CL_MAD == 1
+  #define MultiplyAdd(c,a,b) c = mad(a, b, c)
+#else
+  #define MultiplyAdd(c,a,b) c += a * b
+#endif
+
+// The scalar multiply-subtract function
+#define MultiplySubtract(c,a,b) c -= a * b
+
+// The scalar division function: full division
+#define DivideFull(c,a,b) c = a / b
+
+// The scalar AXPBY function
+#define AXPBY(e,a,b,c,d) e = a*b + c*d
+
+// The complex conjugate operation for complex transforms
+#define COMPLEX_CONJUGATE(value)
+
+// =================================================================================================
+
+// Force inlining functions or not: some compilers don't support the inline keyword
+#ifdef USE_INLINE_KEYWORD
+  #define INLINE_FUNC inline
+#else
+  #define INLINE_FUNC
+#endif
+
+// =================================================================================================
+
+// Shuffled workgroup indices to avoid partition camping, see below. For specific devices, this is
+// enabled (see src/routine.cc).
+#ifndef USE_STAGGERED_INDICES
+  #define USE_STAGGERED_INDICES 0
+#endif
+
+// Staggered/shuffled group indices to avoid partition camping (AMD GPUs). Formula's are taken from:
+// http://docs.nvidia.com/cuda/samples/6_Advanced/transpose/doc/MatrixTranspose.pdf
+// More details: https://github.com/CNugteren/CLBlast/issues/53
+#if USE_STAGGERED_INDICES == 1
+  INLINE_FUNC int GetGroupIDFlat() {
+    return get_group_id(0) + get_num_groups(0) * get_group_id(1);
+  }
+  INLINE_FUNC int GetGroupID1() {
+    return (GetGroupIDFlat()) % get_num_groups(1);
+  }
+  INLINE_FUNC int GetGroupID0() {
+    return ((GetGroupIDFlat() / get_num_groups(1)) + GetGroupID1()) % get_num_groups(0);
+  }
+#else
+  INLINE_FUNC int GetGroupID1() { return get_group_id(1); }
+  INLINE_FUNC int GetGroupID0() { return get_group_id(0); }
+#endif
+
+// =================================================================================================
+
+// End of the C++11 raw string literal
+)"
+
+// =================================================================================================

--- a/src/clblast_level3_half/xgemm_batched.opencl
+++ b/src/clblast_level3_half/xgemm_batched.opencl
@@ -1,0 +1,62 @@
+
+// =================================================================================================
+// This file is part of the CLBlast project. The project is licensed under Apache Version 2.0. This
+// project loosely follows the Google C++ styleguide and uses a tab-size of two spaces and a max-
+// width of 100 characters per line.
+//
+// Author(s):
+//   Cedric Nugteren <www.cedricnugteren.nl>
+//
+// This file contains the batched version of the non-direct GEMM kernel. See part 1 for information
+// about the non-batched version of the kernel.
+//
+// =================================================================================================
+
+// Enables loading of this file using the C++ pre-processor's #include (C++11 standard raw string
+// literal). Comment-out this line for syntax-highlighting when developing.
+R"(
+
+// =================================================================================================
+
+// Main entry point of the kernel. This is the regular full version.
+__kernel __attribute__((reqd_work_group_size(MDIMC, NDIMC, 1)))
+void XgemmBatched(const int kSizeM, const int kSizeN, const int kSizeK,
+                  const __global memM* restrict agm,
+                  const __global memN* restrict bgm,
+                  __global memM* restrict cgm) {
+  const int batch = get_group_id(2);
+
+  // Sets the offsets
+  const int a_offset = kSizeM*kSizeK*batch;
+  const int b_offset = kSizeK*kSizeN*batch;
+  const int c_offset = kSizeM*kSizeN*batch;
+  const __global memM* restrict agm_ = &agm[a_offset / VWM];
+  const __global memN* restrict bgm_ = &bgm[b_offset / VWN];
+  __global memM* restrict cgm_ = &cgm[c_offset / VWM];
+
+  // Allocates workgroup-private memory (local memory)
+  #if SA == 1
+    __local memM alm[KWG * MWG/VWM];
+  #endif
+  #if SB == 1
+    __local memN blm[KWG * NWG/VWN];
+  #endif
+
+  // Computes the matrix-multiplication and stores the result in global memory
+  #if SA == 1 && SB == 1
+    XgemmBody(kSizeM, kSizeN, kSizeK, agm_, bgm_, cgm_, alm, blm);
+  #elif SA == 1
+    XgemmBody(kSizeM, kSizeN, kSizeK, agm_, bgm_, cgm_, alm);
+  #elif SB == 1
+    XgemmBody(kSizeM, kSizeN, kSizeK, agm_, bgm_, cgm_, blm);
+  #else
+    XgemmBody(kSizeM, kSizeN, kSizeK, agm_, bgm_, cgm_);
+  #endif
+}
+
+// =================================================================================================
+
+// End of the C++11 raw string literal
+)"
+
+// =================================================================================================

--- a/src/clblast_level3_half/xgemm_part1.opencl
+++ b/src/clblast_level3_half/xgemm_part1.opencl
@@ -1,0 +1,367 @@
+
+// =================================================================================================
+// This file is part of the CLBlast project. The project is licensed under Apache Version 2.0. This
+// project loosely follows the Google C++ styleguide and uses a tab-size of two spaces and a max-
+// width of 100 characters per line.
+//
+// Author(s):
+//   Cedric Nugteren <www.cedricnugteren.nl>
+//
+// This file contains an optimized matrix-multiplication kernel inspired by the paper by Matsumoto
+// et al. and the tutorial on http://www.cedricnugteren.nl/tutorial.php. It is fully configurable
+// (and tunable!) using more or less the same parameters/naming conventions as in the paper. It
+// supports different data-types (SGEMM/DGEMM/CGEMM/ZGEMM/HGEMM) through a pre-processor define.
+//
+// Matrices are accessed as follows:
+// A: [k*M + m], with 'k' ranging from 0:K and 'm' from 0:M (m,k,m)
+// B: [k*N + n], with 'k' ranging from 0:K and 'n' from 0:N (n,k,n)
+// C: [n*M + m], with 'n' ranging from 0:N and 'm' from 0:M (m,n,m)
+//
+// Or as an image (assuming column-major)
+//       K                      
+//    o-------o                 
+//    |       |                 
+//  N | [B^T] |                 
+//    |       |                 
+//    o-------o                 
+//        K               N     
+//    o-------o        o-----o  
+//  M |  [A]  |      M | [C] |  
+//    |       |        |     |  
+//    o-------o        o-----o  
+//                              
+//
+// This kernel is separated into three files. This is part 1 out of 4.
+//
+// =================================================================================================
+
+// Enables loading of this file using the C++ pre-processor's #include (C++11 standard raw string
+// literal). Comment-out this line for syntax-highlighting when developing.
+R"(
+
+// =================================================================================================
+
+// Parameters set by the tuner or by the database. Here they are given a basic default value in case
+// this kernel file is used outside of the CLBlast library.
+#ifndef MWG
+  #define MWG 8      // Tile-size in dimension M (e.g. 64, 128)
+#endif
+#ifndef NWG
+  #define NWG 8      // Tile-size in dimension N (e.g. 64, 128)
+#endif
+#ifndef KWG
+  #define KWG 8      // Tile-size in dimension K (e.g. 8, 16)
+#endif
+#ifndef MDIMC
+  #define MDIMC 8    // Threads per workgroup in M-dimension (e.g. 8, 16, 32)
+#endif
+#ifndef NDIMC
+  #define NDIMC 8    // Threads per workgroup in N-dimension (e.g. 8, 16, 32)
+#endif
+#ifndef MDIMA
+  #define MDIMA 8    // Re-shaped tile dimension of matrix A: KDIMA * MDIMA
+#endif
+#ifndef NDIMB
+  #define NDIMB 8    // Re-shaped tile dimension of matrix B: KDIMB * NDIMB
+#endif
+#ifndef KWI
+  #define KWI 1      // Unroll factor of the KWG loop (smaller or equal than KWG)
+#endif
+#ifndef VWM
+  #define VWM 1      // Vector width of matrices A and C
+#endif
+#ifndef VWN
+  #define VWN 1      // Vector width of matrix B
+#endif
+#ifndef STRM
+  #define STRM 0     // Use strided access within a thread in the M-dimension (1) or not (0)
+#endif
+#ifndef STRN
+  #define STRN 0     // Use strided access within a thread in the N-dimension (1) or not (0)
+#endif
+#ifndef SA
+  #define SA 0       // Use local/shared memory to cache matrix A (1) or not (0)
+#endif
+#ifndef SB
+  #define SB 0       // Use local/shared memory to cache matrix B (1) or not (0)
+#endif
+
+// Helper parameters based on the above tuning parameters
+#define MWI (MWG/MDIMC)               // Work per work-item (M-dimension)
+#define NWI (NWG/NDIMC)               // Work per work-item (N-dimension)
+#define KDIMA ((MDIMC*NDIMC)/(MDIMA)) // Re-shaped tile dimension of matrix A: KDIMA * MDIMA
+#define KDIMB ((MDIMC*NDIMC)/(NDIMB)) // Re-shaped tile dimension of matrix B: KDIMB * NDIMB
+#define MWA (MWG/MDIMA)               // Amount of loads-per-thread for matrix A (M-dimension)
+#define KWA (KWG/KDIMA)               // Amount of loads-per-thread for matrix A (K-dimension)
+#define KWB (KWG/KDIMB)               // Amount of loads-per-thread for matrix B (K-dimension)
+#define NWB (NWG/NDIMB)               // Amount of loads-per-thread for matrix B (N-dimension)
+
+// Settings
+#ifndef USE_VECTOR_MAD
+  #define USE_VECTOR_MAD 0      // Unroll (0) or don't (1) unroll the vector MAD manually
+#endif
+#ifndef GLOBAL_MEM_FENCE
+  #define GLOBAL_MEM_FENCE 0    // Global synchronisation barrier for potential better performance
+#endif
+
+// =================================================================================================
+
+// Data-widths in dimension M
+#if VWM == 1
+    typedef real realM;
+    typedef short memM;
+#elif VWM == 2
+    typedef real2 realM;
+    typedef short2 memM;
+#elif VWM == 4
+    typedef real4 realM;
+    typedef short4 memM;
+#elif VWM == 8
+    typedef real8 realM;
+    typedef short8 memM;
+#elif VWM == 16
+    typedef real16 realM;
+    typedef short16 memM;
+#endif
+
+// Data-widths in dimension N
+#if VWN == 1
+    typedef real realN;
+    typedef short memN;
+#elif VWN == 2
+    typedef real2 realN;
+    typedef short2 memN;
+#elif VWN == 4
+    typedef real4 realN;
+    typedef short4 memN;
+#elif VWN == 8
+    typedef real8 realN;
+    typedef short8 memN;
+#elif VWN == 16
+    typedef real16 realN;
+    typedef short16 memN;
+#endif
+
+// =================================================================================================
+
+// Initializes the accumulation registers to zero
+INLINE_FUNC realM InitAccRegisters() {
+  realM result;
+  #if VWM == 1
+    SetToZero(result);
+  #elif VWM == 2
+    SetToZero(result.x);
+    SetToZero(result.y);
+  #elif VWM == 4
+    SetToZero(result.x);
+    SetToZero(result.y);
+    SetToZero(result.z);
+    SetToZero(result.w);
+  #elif VWM == 8
+    SetToZero(result.s0);
+    SetToZero(result.s1);
+    SetToZero(result.s2);
+    SetToZero(result.s3);
+    SetToZero(result.s4);
+    SetToZero(result.s5);
+    SetToZero(result.s6);
+    SetToZero(result.s7);
+  #elif VWM == 16
+    SetToZero(result.s0);
+    SetToZero(result.s1);
+    SetToZero(result.s2);
+    SetToZero(result.s3);
+    SetToZero(result.s4);
+    SetToZero(result.s5);
+    SetToZero(result.s6);
+    SetToZero(result.s7);
+    SetToZero(result.s8);
+    SetToZero(result.s9);
+    SetToZero(result.sA);
+    SetToZero(result.sB);
+    SetToZero(result.sC);
+    SetToZero(result.sD);
+    SetToZero(result.sE);
+    SetToZero(result.sF);
+  #endif
+  return result;
+}
+
+// =================================================================================================
+
+// Caches global off-chip memory into local (shared) memory on-chip. This function is specific for
+// caching the A input matrix.
+#if SA == 1
+INLINE_FUNC void GlobalToLocalA(const __global memM* restrict agm, LOCAL_PTR memM* alm,
+                                const int kSizeM, const int tid, const int kwg) {
+  const int la0 = tid % MDIMA;
+  const int la1 = tid / MDIMA;
+  #pragma unroll
+  for (int _mia = 0; _mia < MWA/VWM; _mia += 1) {
+    #pragma unroll
+    for (int _kia = 0; _kia < KWA; _kia += 1) {
+
+      // Computes the indices based on strided/non-strided access
+      #if STRM == 0
+        int mg = _mia + la0*(MWA/VWM);
+      #elif STRM == 1
+        int mg = la0 + _mia*MDIMA;
+      #endif
+
+      // Computes the indices for the global memory
+      int kg = _kia + la1*KWA;
+      int idm = mg + GetGroupID0() * (MWG/VWM);
+      int idk = kg + kwg;
+
+      // Loads the data from global memory (not transposed) into the local memory
+      alm[kg*(MWG/VWM) + mg] = agm[idk*(kSizeM/VWM) + idm];
+    }
+  }
+}
+#endif
+
+// Same as above, but now for the B input matrix
+#if SB == 1
+INLINE_FUNC void GlobalToLocalB(const __global memN* restrict bgm, LOCAL_PTR memN* blm,
+                                const int kSizeN, const int tid, const int kwg) {
+  const int lb0 = tid % NDIMB;
+  const int lb1 = tid / NDIMB;
+  #pragma unroll
+  for (int _kib = 0; _kib < KWB; _kib += 1) {
+    #pragma unroll
+    for (int _nib = 0; _nib < NWB/VWN; _nib += 1) {
+
+      // Computes the indices based on strided/non-strided access
+      #if STRN == 0
+        int ng = _nib + lb0*(NWB/VWN);
+      #elif STRN == 1
+        int ng = lb0 + _nib*NDIMB;
+      #endif
+
+      // Computes the indices for the global memory
+      int kg = _kib + lb1*KWB;
+      int idn = ng + GetGroupID1() * (NWG/VWN);
+      int idk = kg + kwg;
+
+      // Loads the data from global memory (transposed) into the local memory
+      blm[kg*(NWG/VWN) + ng] = bgm[idk*(kSizeN/VWN) + idn];
+    }
+  }
+}
+#endif
+
+// =================================================================================================
+
+// Caches global off-chip memory directly into per-thread private memory (registers). This function
+// is specific for caching the A input matrix.
+#if SA == 0
+INLINE_FUNC realM GlobalToPrivateA(const __global memM* restrict agm, const int _mi,
+                                   const int kSizeM, const int idk, const int kwg) {
+  // Computes the indices based on strided/non-strided access
+  #if STRM == 0
+    int mg = _mi + get_local_id(0)*(MWI/VWM);
+  #elif STRM == 1
+    int mg = get_local_id(0) + _mi*MDIMC;
+  #endif
+
+  // Computes the indices for the global memory
+  int idm = mg + GetGroupID0() * (MWG/VWM);
+
+  // Loads the data from global memory (not transposed) and stores into registers
+#if VWM == 1
+  return vloada_half(idk*(kSizeM/VWM) + idm, (const __global half*)agm);
+#elif VWM == 2
+  return vloada_half2(idk*(kSizeM/VWM) + idm, (const __global half*)agm);
+#elif VWM == 4
+  return vloada_half4(idk*(kSizeM/VWM) + idm, (const __global half*)agm);
+#elif VWM == 8
+  return vloada_half8(idk*(kSizeM/VWM) + idm, (const __global half*)agm);
+#elif VWM == 16
+  return vloada_half16(idk*(kSizeM/VWM) + idm, (const __global half*)agm);
+#endif
+}
+#endif
+
+// Same as above, but now for the B input matrix
+#if SB == 0
+INLINE_FUNC realN GlobalToPrivateB(const __global memN* restrict bgm, const int _ni,
+                                   const int kSizeN, const int idk) {
+  // Computes the indices based on strided/non-strided access
+  #if STRN == 0
+    int ng = _ni + get_local_id(1)*(NWI/VWN);
+  #elif STRN == 1
+    int ng = get_local_id(1) + _ni*NDIMC;
+  #endif
+
+  // Computes the indices for the global memory
+  int idn = ng + GetGroupID1() * (NWG/VWN);
+
+  // Loads the data from global memory (transposed) and stores into registers
+#if VWN == 1
+  return vloada_half(idk*(kSizeN/VWN) + idn, (const __global half*)bgm);
+#elif VWN == 2
+  return vloada_half2(idk*(kSizeN/VWN) + idn, (const __global half*)bgm);
+#elif VWN == 4
+  return vloada_half4(idk*(kSizeN/VWN) + idn, (const __global half*)bgm);
+#elif VWN == 8
+  return vloada_half8(idk*(kSizeN/VWN) + idn, (const __global half*)bgm);
+#elif VWN == 16
+  return vloada_half16(idk*(kSizeN/VWN) + idn, (const __global half*)bgm);
+#endif
+}
+#endif
+
+// =================================================================================================
+
+// Caches on-chip local memory into per-thread private memory (registers). This function is specific
+// for caching the A input matrix.
+#if SA == 1
+INLINE_FUNC realM LocalToPrivateA(LOCAL_PTR memM* alm, const int _mi, const int kg) {
+  #if STRM == 0
+    int mg = _mi + get_local_id(0)*(MWI/VWM);
+  #elif STRM == 1
+    int mg = get_local_id(0) + _mi*MDIMC;
+  #endif
+  #if VWM == 1
+    return vloada_half(kg*(MWG/VWM) + mg, (LOCAL_PTR half*)alm);
+  #elif VWM == 2
+    return vloada_half2(kg*(MWG/VWM) + mg, (LOCAL_PTR half*)alm);
+  #elif VWM == 4
+    return vloada_half4(kg*(MWG/VWM) + mg, (LOCAL_PTR half*)alm);
+  #elif VWM == 8
+    return vloada_half8(kg*(MWG/VWM) + mg, (LOCAL_PTR half*)alm);
+  #elif VWM == 16
+    return vloada_half16(kg*(MWG/VWM) + mg, (LOCAL_PTR half*)alm);
+  #endif
+}
+#endif
+
+// Same as above, but now for the B input matrix
+#if SB == 1
+INLINE_FUNC realN LocalToPrivateB(LOCAL_PTR memN* blm, const int _ni, const int kg) {
+  #if STRN == 0
+    int ng = _ni + get_local_id(1)*(NWI/VWN);
+  #elif STRN == 1
+    int ng = get_local_id(1) + _ni*NDIMC;
+  #endif
+
+  #if VWN == 1
+    return vloada_half(kg*(NWG/VWN) + ng, (LOCAL_PTR half*)blm);
+  #elif VWN == 2
+    return vloada_half2(kg*(NWG/VWN) + ng, (LOCAL_PTR half*)blm);
+  #elif VWN == 4
+    return vloada_half4(kg*(NWG/VWN) + ng, (LOCAL_PTR half*)blm);
+  #elif VWN == 8
+    return vloada_half8(kg*(NWG/VWN) + ng, (LOCAL_PTR half*)blm);
+  #elif VWN == 16
+    return vloada_half16(kg*(NWG/VWN) + ng, (LOCAL_PTR half*)blm);
+  #endif
+}
+#endif
+
+// =================================================================================================
+
+// End of the C++11 raw string literal
+)"
+
+// =================================================================================================

--- a/src/clblast_level3_half/xgemm_part2.opencl
+++ b/src/clblast_level3_half/xgemm_part2.opencl
@@ -1,0 +1,109 @@
+
+// =================================================================================================
+// This file is part of the CLBlast project. The project is licensed under Apache Version 2.0. This
+// project loosely follows the Google C++ styleguide and uses a tab-size of two spaces and a max-
+// width of 100 characters per line.
+//
+// Author(s):
+//   Cedric Nugteren <www.cedricnugteren.nl>
+//
+// This is part 2 of 4 of the GEMM kernel. See part 1 for more information.
+//
+// =================================================================================================
+
+// Enables loading of this file using the C++ pre-processor's #include (C++11 standard raw string
+// literal). Comment-out this line for syntax-highlighting when developing.
+R"(
+
+// =================================================================================================
+
+// The vectorised multiply-add function
+INLINE_FUNC realM MultiplyAddVector(realM cvec, const realM avec, const real bval) {
+  #if USE_VECTOR_MAD == 1
+    cvec += avec * bval;
+  #else
+    #if VWM == 1
+      MultiplyAdd(cvec,    avec,    bval);
+    #elif VWM == 2
+      MultiplyAdd(cvec.x , avec.x,  bval);
+      MultiplyAdd(cvec.y , avec.y,  bval);
+    #elif VWM == 4
+      MultiplyAdd(cvec.x , avec.x,  bval);
+      MultiplyAdd(cvec.y , avec.y,  bval);
+      MultiplyAdd(cvec.z , avec.z,  bval);
+      MultiplyAdd(cvec.w , avec.w,  bval);
+    #elif VWM == 8
+      MultiplyAdd(cvec.s0, avec.s0, bval);
+      MultiplyAdd(cvec.s1, avec.s1, bval);
+      MultiplyAdd(cvec.s2, avec.s2, bval);
+      MultiplyAdd(cvec.s3, avec.s3, bval);
+      MultiplyAdd(cvec.s4, avec.s4, bval);
+      MultiplyAdd(cvec.s5, avec.s5, bval);
+      MultiplyAdd(cvec.s6, avec.s6, bval);
+      MultiplyAdd(cvec.s7, avec.s7, bval);
+    #elif VWM == 16
+      MultiplyAdd(cvec.s0, avec.s0, bval);
+      MultiplyAdd(cvec.s1, avec.s1, bval);
+      MultiplyAdd(cvec.s2, avec.s2, bval);
+      MultiplyAdd(cvec.s3, avec.s3, bval);
+      MultiplyAdd(cvec.s4, avec.s4, bval);
+      MultiplyAdd(cvec.s5, avec.s5, bval);
+      MultiplyAdd(cvec.s6, avec.s6, bval);
+      MultiplyAdd(cvec.s7, avec.s7, bval);
+      MultiplyAdd(cvec.s8, avec.s8, bval);
+      MultiplyAdd(cvec.s9, avec.s9, bval);
+      MultiplyAdd(cvec.sA, avec.sA, bval);
+      MultiplyAdd(cvec.sB, avec.sB, bval);
+      MultiplyAdd(cvec.sC, avec.sC, bval);
+      MultiplyAdd(cvec.sD, avec.sD, bval);
+      MultiplyAdd(cvec.sE, avec.sE, bval);
+      MultiplyAdd(cvec.sF, avec.sF, bval);
+    #endif
+  #endif
+  return cvec;
+}
+
+// =================================================================================================
+
+// Merges the results in Cpm with the global array in Cgm.
+INLINE_FUNC void StoreResults(__global memM* cgm, realM cpm[NWI*MWI/VWM], const int kSizeM) {
+  #pragma unroll
+  for (int _ni = 0; _ni < NWI; _ni += 1) {
+    #pragma unroll
+    for (int _mi = 0; _mi < MWI/VWM; _mi += 1) {
+      #if STRM == 0
+        int mg = _mi + get_local_id(0)*(MWI/VWM);
+      #elif STRM == 1
+        int mg = get_local_id(0) + _mi*MDIMC;
+      #endif
+      #if STRN == 0
+        int ng = _ni + get_local_id(1)*NWI;
+      #elif STRN == 1
+        int ng = _ni%VWN + get_local_id(1)*VWN + (_ni/VWN)*VWN*NDIMC;
+      #endif
+      int idm = mg + GetGroupID0() * (MWG/VWM);
+      int idn = ng + GetGroupID1() * NWG;
+      int index = idn*(kSizeM/VWM) + idm;
+
+#if VWM == 1
+      vstorea_half(cpm[_ni * (MWI/VWM) + _mi], index, (__global half*)cgm);
+#elif VWM == 2
+      vstorea_half2(cpm[_ni * (MWI/VWM) + _mi], index, (__global half*)cgm);
+#elif VWM == 4
+      vstorea_half4(cpm[_ni * (MWI/VWM) + _mi], index, (__global half*)cgm);
+#elif VWM == 8
+      vstorea_half8(cpm[_ni * (MWI/VWM) + _mi], index, (__global half*)cgm);
+#elif VWM == 16
+      vstorea_half16(cpm[_ni * (MWI/VWM) + _mi], index, (__global half*)cgm);
+#endif
+
+    }
+  }
+}
+
+// =================================================================================================
+
+// End of the C++11 raw string literal
+)"
+
+// =================================================================================================

--- a/src/clblast_level3_half/xgemm_part3.opencl
+++ b/src/clblast_level3_half/xgemm_part3.opencl
@@ -1,0 +1,169 @@
+
+// =================================================================================================
+// This file is part of the CLBlast project. The project is licensed under Apache Version 2.0. This
+// project loosely follows the Google C++ styleguide and uses a tab-size of two spaces and a max-
+// width of 100 characters per line.
+//
+// Author(s):
+//   Cedric Nugteren <www.cedricnugteren.nl>
+//
+// This is part 3 of 4 of the GEMM kernel. See part 1 for more information.
+//
+// =================================================================================================
+
+// Enables loading of this file using the C++ pre-processor's #include (C++11 standard raw string
+// literal). Comment-out this line for syntax-highlighting when developing.
+R"(
+
+// =================================================================================================
+
+// Main body of the matrix-multiplication algorithm. It calls various (inlined) functions.
+INLINE_FUNC void XgemmBody(const int kSizeM, const int kSizeN, const int kSizeK,
+                           const __global memM* restrict agm, const __global memN* restrict bgm,
+                           __global memM* cgm
+                           #if SA == 1 && SB == 1
+                             , LOCAL_PTR memM* alm, LOCAL_PTR memN* blm
+                           #elif SA == 1
+                             , LOCAL_PTR memM* alm
+                           #elif SB == 1
+                             , LOCAL_PTR memN* blm
+                           #endif
+                           ) {
+
+  // Allocates workitem-private memory (registers)
+  #pragma promote_to_registers
+  realM apm[MWI/VWM];
+  #pragma promote_to_registers
+  realN bpm[NWI/VWN];
+  #pragma promote_to_registers
+  realM cpm[NWI*(MWI/VWM)];
+
+  // Combined thread identifier (volatile to disable caching)
+  #if SA == 1 || SB == 1
+    volatile int tid = get_local_id(0) + MDIMC*get_local_id(1);
+  #endif
+
+  // Initializes the accumulation registers
+  #pragma unroll
+  for (int _mi = 0; _mi < MWI/VWM; _mi += 1) {
+    #pragma unroll
+    for (int _ni = 0; _ni < NWI; _ni += 1) {
+      cpm[_ni * (MWI/VWM) + _mi] = InitAccRegisters();
+    }
+  }
+
+
+  // Loops over all workgroup tiles
+  for (int kwg = 0; kwg < kSizeK; kwg += KWG) {
+
+    // Loads data: off-chip --> local (matrix A)
+    #if SA == 1
+      GlobalToLocalA(agm, alm, kSizeM, tid, kwg);
+    #endif
+    // Loads data: off-chip --> local (matrix B)
+    #if SB == 1
+      GlobalToLocalB(bgm, blm, kSizeN, tid, kwg);
+    #endif
+    #if SA == 1 || SB == 1
+      barrier(CLK_LOCAL_MEM_FENCE);
+    #endif
+
+    // Loops over all workitem tiles, unrolled by a factor KWI
+    for (int pwi = 0; pwi < KWG; pwi += KWI) {
+      #pragma unroll
+      for (int _pit = 0; _pit < KWI; _pit += 1) {
+        #if SA == 0 || SB == 0
+          int idk = kwg + pwi + _pit;
+        #endif
+        #if SA == 1 || SB == 1
+          int kg = pwi + _pit;
+        #endif
+
+        #pragma unroll
+        for (int _mi = 0; _mi < MWI/VWM; _mi += 1) {
+          // Loads data: local --> private (matrix A)
+          #if SA == 1
+            apm[_mi] = LocalToPrivateA(alm, _mi, kg);
+          // Loads data: off-chip --> private (matrix A)
+          #else
+            apm[_mi] = GlobalToPrivateA(agm, _mi, kSizeM, idk, kwg);
+          #endif
+        }
+
+        // Loads data: local --> private (matrix B)
+        #pragma unroll
+        for (int _ni = 0; _ni < NWI/VWN; _ni += 1) {
+          #if SB == 1
+            bpm[_ni] = LocalToPrivateB(blm, _ni, kg);
+          // Loads data: off-chip --> private (matrix B)
+          #else
+            bpm[_ni] = GlobalToPrivateB(bgm, _ni, kSizeN, idk);
+          #endif
+        }
+
+        // Performs the accumulation (Cpm += Apm * Bpm)
+        #pragma unroll
+        for (int _ni = 0; _ni < NWI/VWN; _ni += 1) {
+          #pragma unroll
+          for (int _mi = 0; _mi < MWI/VWM; _mi += 1) {
+            const realM aval = apm[_mi];
+            #if VWN == 1
+              cpm[(_ni*VWN + 0)*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 0)*(MWI/VWM) + _mi], aval, bpm[_ni]);
+            #elif VWN == 2
+              cpm[(_ni*VWN + 0)*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 0)*(MWI/VWM) + _mi], aval, bpm[_ni].x);
+              cpm[(_ni*VWN + 1)*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 1)*(MWI/VWM) + _mi], aval, bpm[_ni].y);
+            #elif VWN == 4
+              cpm[(_ni*VWN + 0)*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 0)*(MWI/VWM) + _mi], aval, bpm[_ni].x);
+              cpm[(_ni*VWN + 1)*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 1)*(MWI/VWM) + _mi], aval, bpm[_ni].y);
+              cpm[(_ni*VWN + 2)*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 2)*(MWI/VWM) + _mi], aval, bpm[_ni].z);
+              cpm[(_ni*VWN + 3)*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 3)*(MWI/VWM) + _mi], aval, bpm[_ni].w);
+            #elif VWN == 8
+              cpm[(_ni*VWN + 0)*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 0)*(MWI/VWM) + _mi], aval, bpm[_ni].s0);
+              cpm[(_ni*VWN + 1)*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 1)*(MWI/VWM) + _mi], aval, bpm[_ni].s1);
+              cpm[(_ni*VWN + 2)*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 2)*(MWI/VWM) + _mi], aval, bpm[_ni].s2);
+              cpm[(_ni*VWN + 3)*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 3)*(MWI/VWM) + _mi], aval, bpm[_ni].s3);
+              cpm[(_ni*VWN + 4)*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 4)*(MWI/VWM) + _mi], aval, bpm[_ni].s4);
+              cpm[(_ni*VWN + 5)*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 5)*(MWI/VWM) + _mi], aval, bpm[_ni].s5);
+              cpm[(_ni*VWN + 6)*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 6)*(MWI/VWM) + _mi], aval, bpm[_ni].s6);
+              cpm[(_ni*VWN + 7)*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 7)*(MWI/VWM) + _mi], aval, bpm[_ni].s7);
+            #elif VWN == 16
+              cpm[(_ni*VWN + 0 )*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 0 )*(MWI/VWM) + _mi], aval, bpm[_ni].s0);
+              cpm[(_ni*VWN + 1 )*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 1 )*(MWI/VWM) + _mi], aval, bpm[_ni].s1);
+              cpm[(_ni*VWN + 2 )*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 2 )*(MWI/VWM) + _mi], aval, bpm[_ni].s2);
+              cpm[(_ni*VWN + 3 )*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 3 )*(MWI/VWM) + _mi], aval, bpm[_ni].s3);
+              cpm[(_ni*VWN + 4 )*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 4 )*(MWI/VWM) + _mi], aval, bpm[_ni].s4);
+              cpm[(_ni*VWN + 5 )*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 5 )*(MWI/VWM) + _mi], aval, bpm[_ni].s5);
+              cpm[(_ni*VWN + 6 )*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 6 )*(MWI/VWM) + _mi], aval, bpm[_ni].s6);
+              cpm[(_ni*VWN + 7 )*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 7 )*(MWI/VWM) + _mi], aval, bpm[_ni].s7);
+              cpm[(_ni*VWN + 8 )*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 8 )*(MWI/VWM) + _mi], aval, bpm[_ni].s8);
+              cpm[(_ni*VWN + 9 )*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 9 )*(MWI/VWM) + _mi], aval, bpm[_ni].s9);
+              cpm[(_ni*VWN + 10)*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 10)*(MWI/VWM) + _mi], aval, bpm[_ni].sA);
+              cpm[(_ni*VWN + 11)*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 11)*(MWI/VWM) + _mi], aval, bpm[_ni].sB);
+              cpm[(_ni*VWN + 12)*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 12)*(MWI/VWM) + _mi], aval, bpm[_ni].sC);
+              cpm[(_ni*VWN + 13)*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 13)*(MWI/VWM) + _mi], aval, bpm[_ni].sD);
+              cpm[(_ni*VWN + 14)*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 14)*(MWI/VWM) + _mi], aval, bpm[_ni].sE);
+              cpm[(_ni*VWN + 15)*(MWI/VWM) + _mi] = MultiplyAddVector(cpm[(_ni*VWN + 15)*(MWI/VWM) + _mi], aval, bpm[_ni].sF);
+            #endif
+          }
+        }
+
+      }
+    }
+    #if SA == 1 || SB == 1
+      barrier(CLK_LOCAL_MEM_FENCE);
+    #endif
+  }
+  #if GLOBAL_MEM_FENCE == 1
+    barrier(CLK_GLOBAL_MEM_FENCE);
+  #endif
+
+  // Stores an MWG * NWG tile of results
+  StoreResults(cgm, cpm, kSizeM);
+}
+
+// =================================================================================================
+
+// End of the C++11 raw string literal
+)"
+
+// =================================================================================================

--- a/src/config.h
+++ b/src/config.h
@@ -91,7 +91,12 @@
 #define MAX_CPUS 128
 #endif
 
+#ifdef USE_HALF
+#include <half/half.hpp>
+using net_t = half_float::half;
+#else
 using net_t = float;
+#endif
 
 #if defined(USE_BLAS) && defined(USE_OPENCL) && !defined(USE_HALF)
 // If both BLAS and OpenCL are fully usable, then check the OpenCL


### PR DESCRIPTION
Revived the USE_HALF.

The datatypes are fp16 in global memory.  The actual computations are still fp32 because many consumer-grade cards are still not so good at fp16 yet.

Constant number of playouts (4000)
```
50/50 games played

               A     B
A leelaz-base       24-26
B leelaz-fp16 26-24

leelaz-base v leelaz-fp16 (50/50 games)
board size: 19   komi: 7.5
              wins              black         white       avg cpu
leelaz-base     24 48.00%       12 48.00%     12 48.00%    505.46
leelaz-fp16     26 52.00%       13 52.00%     13 52.00%    507.16
                                25 50.00%     25 50.00%

player b: Leela Zero:0.13
player w: Leela Zero:0.13
```

Constant time (10 seconds, 2x GTX1080, 12 threads)
```
50/50 games played

               A     B
A leelaz-base       19-31
B leelaz-fp16 31-19

leelaz-base v leelaz-fp16 (50/50 games)
board size: 19   komi: 7.5
              wins              black         white       avg cpu
leelaz-base     19 38.00%       7  28.00%     12 48.00%   1480.88
leelaz-fp16     31 62.00%       13 52.00%     18 72.00%   1496.12
                                20 40.00%     30 60.00%

player b: Leela Zero:0.13
player w: Leela Zero:0.13
```

The last time fp16 was merged it was a compile-time option which was broken multiple times while developing other code.  Hence I am not sure if this should be merge or not...  Any thoughts?