### PR TITLE
Make CMakeLists.txt file consistently formatted 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,27 +12,27 @@
 # You should have received a copy of the GNU General Public License
 # along with Leela Zero.  If not, see <http://www.gnu.org/licenses/>.
 
-CMAKE_MINIMUM_REQUIRED (VERSION 3.1)
+cmake_minimum_required(VERSION 3.1)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
-PROJECT(leelaz)
+project(leelaz)
 add_subdirectory(gtest EXCLUDE_FROM_ALL) # We don't want to install gtest, exclude it from `all`
 
 # Required Packages
-SET(Boost_MIN_VERSION "1.58.0")
+set(Boost_MIN_VERSION "1.58.0")
 set(Boost_USE_MULTITHREADED ON)
-FIND_PACKAGE(Boost 1.58.0 REQUIRED program_options)
-FIND_PACKAGE(Threads REQUIRED)
-FIND_PACKAGE(ZLIB REQUIRED)
-FIND_PACKAGE(OpenCL REQUIRED)
+find_package(Boost 1.58.0 REQUIRED program_options)
+find_package(Threads REQUIRED)
+find_package(ZLIB REQUIRED)
+find_package(OpenCL REQUIRED)
 # We need OpenBLAS for now, because we make some specific
 # calls. Ideally we'd use OpenBLAS is possible and fall back to
 # not doing those calls if it's not present.
 if(NOT APPLE)
   set(BLA_VENDOR OpenBLAS)
 endif()
-FIND_PACKAGE(BLAS REQUIRED)
+find_package(BLAS REQUIRED)
 find_path(BLAS_INCLUDE_DIRS openblas_config.h
   /usr/include
   /usr/local/include
@@ -40,94 +40,94 @@ find_path(BLAS_INCLUDE_DIRS openblas_config.h
   /opt/OpenBLAS/include
   /usr/include/x86_64-linux-gnu
   $ENV{BLAS_HOME}/include)
-FIND_PACKAGE(Qt5Core)
+find_package(Qt5Core)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED on)
 
 # See if we can set optimization flags as expected.
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  SET(GccSpecificFlags 1)
-elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
-  SET(GccSpecificFlags 1)
-elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-  SET(GccSpecificFlags 1)
-elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
-  SET(GccSpecificFlags 0)
-elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  SET(GccSpecificFlags 0)
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  set(GccSpecificFlags 1)
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+  set(GccSpecificFlags 1)
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+  set(GccSpecificFlags 1)
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+  set(GccSpecificFlags 0)
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+  set(GccSpecificFlags 0)
 endif()
 
-IF(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
-  SET(CMAKE_BUILD_TYPE RELEASE)
-ENDIF(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
+if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE RELEASE)
+endif(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 
-if (GccSpecificFlags)
-  SET(GCC_COMPILE_FLAGS "-Wall -Wextra -ffast-math -flto -march=native")
-  SET(GCC_DISABLED_WARNING_COMPILE_FLAGS "-Wno-ignored-attributes -Wno-maybe-uninitialized")
-  SET(GCC_FLAGS "${GCC_COMPILE_FLAGS} ${GCC_DISABLED_WARNING_COMPILE_FLAGS}")
-  SET(CMAKE_CXX_FLAGS_DEBUG "${GCC_FLAGS} -g -Og")
-  SET(CMAKE_CXX_FLAGS_RELEASE "${GCC_FLAGS} -g -O3 -DNDEBUG")
-  SET(CMAKE_EXE_LINKER_FLAGS "-flto -g")
+if(GccSpecificFlags)
+  set(GCC_COMPILE_FLAGS "-Wall -Wextra -ffast-math -flto -march=native")
+  set(GCC_DISABLED_WARNING_COMPILE_FLAGS "-Wno-ignored-attributes -Wno-maybe-uninitialized")
+  set(GCC_FLAGS "${GCC_COMPILE_FLAGS} ${GCC_DISABLED_WARNING_COMPILE_FLAGS}")
+  set(CMAKE_CXX_FLAGS_DEBUG "${GCC_FLAGS} -g -Og")
+  set(CMAKE_CXX_FLAGS_RELEASE "${GCC_FLAGS} -g -O3 -DNDEBUG")
+  set(CMAKE_EXE_LINKER_FLAGS "-flto -g")
 endif(GccSpecificFlags)
 
-if (FEATURE_USE_CPU_ONLY)
-  ADD_DEFINITIONS(-DFEATURE_USE_CPU_ONLY)
+if(FEATURE_USE_CPU_ONLY)
+  add_definitions(-DFEATURE_USE_CPU_ONLY)
 endif()
 
-SET(IncludePath "${CMAKE_CURRENT_SOURCE_DIR}/src")
-SET(SrcPath "${CMAKE_CURRENT_SOURCE_DIR}/src")
+set(IncludePath "${CMAKE_CURRENT_SOURCE_DIR}/src")
+set(SrcPath "${CMAKE_CURRENT_SOURCE_DIR}/src")
 
-INCLUDE_DIRECTORIES(${IncludePath})
-INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIRS})
-INCLUDE_DIRECTORIES(${OpenCL_INCLUDE_DIRS})
-INCLUDE_DIRECTORIES(${ZLIB_INCLUDE_DIRS})
+include_directories(${IncludePath})
+include_directories(${Boost_INCLUDE_DIRS})
+include_directories(${OpenCL_INCLUDE_DIRS})
+include_directories(${ZLIB_INCLUDE_DIRS})
 
 if((UNIX AND NOT APPLE) OR WIN32)
-    INCLUDE_DIRECTORIES(${BLAS_INCLUDE_DIRS})
+    include_directories(${BLAS_INCLUDE_DIRS})
 endif()
 if(APPLE)
-    INCLUDE_DIRECTORIES("/System/Library/Frameworks/Accelerate.framework/Versions/Current/Headers")
+    include_directories("/System/Library/Frameworks/Accelerate.framework/Versions/Current/Headers")
 endif()
 
-SET(leelaz_MAIN "${SrcPath}/Leela.cpp")
-FILE(GLOB leelaz_SRC "${SrcPath}/*.cpp")
-LIST(REMOVE_ITEM leelaz_SRC ${leelaz_MAIN})
+set(leelaz_MAIN "${SrcPath}/Leela.cpp")
+file(GLOB leelaz_SRC "${SrcPath}/*.cpp")
+list(REMOVE_ITEM leelaz_SRC ${leelaz_MAIN})
 
 # Reuse for leelaz and gtest
-ADD_LIBRARY(objs OBJECT ${leelaz_SRC})
+add_library(objs OBJECT ${leelaz_SRC})
 
-ADD_EXECUTABLE(leelaz $<TARGET_OBJECTS:objs> ${leelaz_MAIN})
+add_executable(leelaz $<TARGET_OBJECTS:objs> ${leelaz_MAIN})
 
-TARGET_LINK_LIBRARIES(leelaz ${Boost_LIBRARIES})
-TARGET_LINK_LIBRARIES(leelaz ${BLAS_LIBRARIES})
-TARGET_LINK_LIBRARIES(leelaz ${OpenCL_LIBRARIES})
-TARGET_LINK_LIBRARIES(leelaz ${ZLIB_LIBRARIES})
-TARGET_LINK_LIBRARIES(leelaz ${CMAKE_THREAD_LIBS_INIT})
-INSTALL(TARGETS leelaz DESTINATION bin)
+target_link_libraries(leelaz ${Boost_LIBRARIES})
+target_link_libraries(leelaz ${BLAS_LIBRARIES})
+target_link_libraries(leelaz ${OpenCL_LIBRARIES})
+target_link_libraries(leelaz ${ZLIB_LIBRARIES})
+target_link_libraries(leelaz ${CMAKE_THREAD_LIBS_INIT})
+install(TARGETS leelaz DESTINATION bin)
 
-if (Qt5Core_FOUND)
-    if (NOT Qt5Core_VERSION VERSION_LESS "5.3.0")
-        ADD_SUBDIRECTORY(autogtp)
-        ADD_SUBDIRECTORY(validation)
+if(Qt5Core_FOUND)
+    if(NOT Qt5Core_VERSION VERSION_LESS "5.3.0")
+        add_subdirectory(autogtp)
+        add_subdirectory(validation)
     else()
-        MESSAGE(WARNING "Qt ${Qt5Core_VERSION} is found but does not met required version 5.3.0, \
+        message(WARNING "Qt ${Qt5Core_VERSION} is found but does not met required version 5.3.0, \
         build target for `autogtp` and `validation` is disabled.")
     endif()
 else()
-    MESSAGE(WARNNING "Qt is not found, build for `autogtp` and `validation` is disabled")
+    message(WARNNING "Qt is not found, build for `autogtp` and `validation` is disabled")
 endif()
 
 # Google Test below
-FILE(GLOB tests_SRC "${SrcPath}/tests/*.cpp")
+file(GLOB tests_SRC "${SrcPath}/tests/*.cpp")
 
-ADD_EXECUTABLE(tests ${tests_SRC} $<TARGET_OBJECTS:objs>)
-if (GccSpecificFlags)
+add_executable(tests ${tests_SRC} $<TARGET_OBJECTS:objs>)
+if(GccSpecificFlags)
   target_compile_options(tests PRIVATE "-Wno-unused-variable")
 endif()
 
-TARGET_LINK_LIBRARIES(tests ${Boost_LIBRARIES})
-TARGET_LINK_LIBRARIES(tests ${BLAS_LIBRARIES})
-TARGET_LINK_LIBRARIES(tests ${OpenCL_LIBRARIES})
-TARGET_LINK_LIBRARIES(tests ${ZLIB_LIBRARIES})
-TARGET_LINK_LIBRARIES(tests gtest_main ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(tests ${Boost_LIBRARIES})
+target_link_libraries(tests ${BLAS_LIBRARIES})
+target_link_libraries(tests ${OpenCL_LIBRARIES})
+target_link_libraries(tests ${ZLIB_LIBRARIES})
+target_link_libraries(tests gtest_main ${CMAKE_THREAD_LIBS_INIT})

--- a/autogtp/CMakeLists.txt
+++ b/autogtp/CMakeLists.txt
@@ -1,10 +1,10 @@
 
-CMAKE_MINIMUM_REQUIRED (VERSION 3.1)
+cmake_minimum_required(VERSION 3.1)
 
-ADD_EXECUTABLE(autogtp
+add_executable(autogtp
 	Game.h Order.h Management.h Worker.h Job.h Result.h Console.h
 	Worker.cpp Management.cpp Job.cpp main.cpp Game.cpp Order.cpp)
-SET_TARGET_PROPERTIES(autogtp PROPERTIES AUTOMOC 1)
-TARGET_LINK_LIBRARIES(autogtp Qt5::Core)
+set_target_properties(autogtp PROPERTIES AUTOMOC 1)
+target_link_libraries(autogtp Qt5::Core)
 
-INSTALL(TARGETS autogtp DESTINATION bin)
+install(TARGETS autogtp DESTINATION bin)

--- a/validation/CMakeLists.txt
+++ b/validation/CMakeLists.txt
@@ -1,10 +1,10 @@
 
-CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
+cmake_minimum_required(VERSION 3.1)
 
-ADD_EXECUTABLE(validation
+add_executable(validation
         main.cpp ../autogtp/Game.cpp SPRT.cpp Validation.cpp Results.cpp
         ../autogtp/Game.h SPRT.h Validation.h Results.h ../autogtp/Console.h)
-SET_TARGET_PROPERTIES(validation PROPERTIES AUTOMOC 1)
-TARGET_LINK_LIBRARIES(validation Qt5::Core)
+set_target_properties(validation PROPERTIES AUTOMOC 1)
+target_link_libraries(validation Qt5::Core)
 
-INSTALL(TARGETS validation DESTINATION bin)
+install(TARGETS validation DESTINATION bin)


### PR DESCRIPTION
In large code bases consistency is important. This PR changes all CMake commands to be upper case with the exception of the command `if`.

If these kind of style PRs are welcomed, I would like to submit more to fix the styling of files in `src/`. Eventually I wish to bring in a script like Google's `cpplint.py` as a part of CI to force style checks in all CI runs.