### PR TITLE
Suppress Clang warning in half.cpp.

### DIFF
--- a/src/half/half.hpp
+++ b/src/half/half.hpp
@@ -1078,7 +1078,7 @@ namespace half_float
 		friend struct detail::unary_specialized<half>;
 		friend struct detail::binary_specialized<half,half>;
 		template<typename,typename,std::float_round_style> friend struct detail::half_caster;
-		friend class std::numeric_limits<half>;
+		friend struct std::numeric_limits<half>;
 	#if HALF_ENABLE_CPP11_HASH
 		friend struct std::hash<half>;
 	#endif


### PR DESCRIPTION
When using `-DUSE_HALF`, Clang will otherwise give me the warning "`class 'numeric_limits' was previously declared as a struct [-Wmismatched-tags]`".