### PR TITLE
Look for symmetrical position in cache.

### DIFF
--- a/src/FastBoard.cpp
+++ b/src/FastBoard.cpp
@@ -147,7 +147,7 @@ void FastBoard::reset_board(int size) {
     m_libs[MAXSQ]   = 16384;    /* we will subtract from this */
     m_next[MAXSQ]   = MAXSQ;
 
-    for (auto symmetry = 0; symmetry < 8; ++symmetry) {
+    for (auto symmetry = 0; symmetry < NUM_SYMMETRIES; ++symmetry) {
         m_symmetry_idx[symmetry][0] = 0; // Make sure the special value for the lack of ko stays unchanged.
         for (auto y = 0; y < size; ++y) {
             for (auto x = 0; x < size; ++x) {

--- a/src/FastBoard.cpp
+++ b/src/FastBoard.cpp
@@ -146,6 +146,16 @@ void FastBoard::reset_board(int size) {
     m_parent[MAXSQ] = MAXSQ;
     m_libs[MAXSQ]   = 16384;    /* we will subtract from this */
     m_next[MAXSQ]   = MAXSQ;
+
+    for (auto symmetry = 0; symmetry < 8; ++symmetry) {
+        m_symmetry_idx[symmetry][0] = 0; // Make sure the special value for the lack of ko stays unchanged.
+        for (auto y = 0; y < size; ++y) {
+            for (auto x = 0; x < size; ++x) {
+                const auto newvtx = get_symmetry({x, y}, symmetry, size);
+                m_symmetry_idx[symmetry][get_vertex(x, y)] = get_vertex(newvtx.first, newvtx.second);
+            }
+        }
+    }
 }
 
 bool FastBoard::is_suicide(int i, int color) const {

--- a/src/FastBoard.h
+++ b/src/FastBoard.h
@@ -72,7 +72,7 @@ public:
     int get_boardsize(void) const;
     square_t get_square(int x, int y) const;
     square_t get_square(int vertex) const ;
-    int get_vertex(int i, int j) const;
+    int get_vertex(int x, int y) const;
     void set_square(int x, int y, square_t content);
     void set_square(int vertex, square_t content);
     std::pair<int, int> get_xy(int vertex) const;
@@ -124,6 +124,8 @@ protected:
 
     int m_boardsize;
     int m_squaresize;
+
+    std::array<std::array<unsigned short, MAXSQ>, 8> m_symmetry_idx;
 
     int calc_reach_color(int color) const;
 

--- a/src/FastBoard.h
+++ b/src/FastBoard.h
@@ -27,6 +27,8 @@
 #include <utility>
 #include <vector>
 
+#include "Utils.h"
+
 class FastBoard {
     friend class FastState;
 public:
@@ -125,7 +127,7 @@ protected:
     int m_boardsize;
     int m_squaresize;
 
-    std::array<std::array<unsigned short, MAXSQ>, 8> m_symmetry_idx;
+    std::array<std::array<unsigned short, MAXSQ>, NUM_SYMMETRIES> m_symmetry_idx;
 
     int calc_reach_color(int color) const;
 

--- a/src/FastState.h
+++ b/src/FastState.h
@@ -53,6 +53,10 @@ public:
     void display_state();
     std::string move_to_text(int move);
 
+    std::uint64_t get_hash(const int symmetry) const {
+        return board.calc_hash(m_komove, symmetry);
+    }
+
     FullBoard board;
 
     float m_komi;

--- a/src/FullBoard.cpp
+++ b/src/FullBoard.cpp
@@ -55,7 +55,7 @@ int FullBoard::remove_string(int i) {
     return removed;
 }
 
-std::uint64_t FullBoard::calc_ko_hash(void) {
+std::uint64_t FullBoard::calc_ko_hash() const {
     auto res = Zobrist::zobrist_empty;
 
     for (int i = 0; i < m_maxsq; i++) {
@@ -65,16 +65,15 @@ std::uint64_t FullBoard::calc_ko_hash(void) {
     }
 
     /* Tromp-Taylor has positional superko */
-    m_ko_hash = res;
     return res;
 }
 
-std::uint64_t FullBoard::calc_hash(int komove) {
+std::uint64_t FullBoard::calc_hash(const int komove, const int symmetry) const {
     auto res = Zobrist::zobrist_empty;
 
     for (int i = 0; i < m_maxsq; i++) {
         if (m_square[i] != INVAL) {
-            res ^= Zobrist::zobrist[m_square[i]][i];
+            res ^= Zobrist::zobrist[m_square[i]][m_symmetry_idx[symmetry][i]];
         }
     }
 
@@ -86,18 +85,16 @@ std::uint64_t FullBoard::calc_hash(int komove) {
         res ^= Zobrist::zobrist_blacktomove;
     }
 
-    res ^= Zobrist::zobrist_ko[komove];
-
-    m_hash = res;
+    res ^= Zobrist::zobrist_ko[m_symmetry_idx[symmetry][komove]];
 
     return res;
 }
 
-std::uint64_t FullBoard::get_hash(void) const {
+std::uint64_t FullBoard::get_hash() const {
     return m_hash;
 }
 
-std::uint64_t FullBoard::get_ko_hash(void) const {
+std::uint64_t FullBoard::get_ko_hash() const {
     return m_ko_hash;
 }
 
@@ -191,6 +188,6 @@ void FullBoard::display_board(int lastmove) {
 void FullBoard::reset_board(int size) {
     FastBoard::reset_board(size);
 
-    calc_hash();
-    calc_ko_hash();
+    m_hash = calc_hash();
+    m_ko_hash = calc_ko_hash();
 }

--- a/src/FullBoard.h
+++ b/src/FullBoard.h
@@ -28,10 +28,10 @@ public:
     int remove_string(int i);
     int update_board(const int color, const int i);
 
-    std::uint64_t calc_hash(int komove = 0);
-    std::uint64_t calc_ko_hash(void);
-    std::uint64_t get_hash(void) const;
-    std::uint64_t get_ko_hash(void) const;
+    std::uint64_t calc_hash(const int komove = 0, const int symmetry = 0) const;
+    std::uint64_t calc_ko_hash() const;
+    std::uint64_t get_hash() const;
+    std::uint64_t get_ko_hash() const;
     void set_to_move(int tomove);
 
     void reset_board(int size);

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -530,14 +530,14 @@ bool GTP::execute(GameState & game, std::string xinput) {
             vec = Network::get_scored_moves(
                 &game, Network::Ensemble::DIRECT, 0, true);
         } else if (symmetry == "all") {
-            for (auto r = 0; r < 8; r++) {
+            for (auto s = 0; s < NUM_SYMMETRIES; ++s) {
                 vec = Network::get_scored_moves(
-                    &game, Network::Ensemble::DIRECT, r, true);
+                    &game, Network::Ensemble::DIRECT, s, true);
                 Network::show_heatmap(&game, vec, false);
             }
         } else if (symmetry == "average" || symmetry == "avg") {
             vec = Network::get_scored_moves(
-                &game, Network::Ensemble::AVERAGE, 8, true);
+                &game, Network::Ensemble::AVERAGE, NUM_SYMMETRIES, true);
         } else {
             vec = Network::get_scored_moves(
                 &game, Network::Ensemble::DIRECT, std::stoi(symmetry), true);

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -358,7 +358,9 @@ void init_global_objects() {
 
 void benchmark(GameState& game) {
     game.set_timecontrol(0, 1, 0, 0);  // Set infinite time.
-    game.play_textmove("b", "q16");
+    game.play_textmove("b", "r16");
+    game.play_textmove("w", "d4");
+    game.play_textmove("b", "c3");
     auto search = std::make_unique<UCTSearch>(game);
     game.set_to_move(FastBoard::WHITE);
     search->think(FastBoard::WHITE);

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -91,7 +91,7 @@ static std::array<float, 1> ip2_val_b;
 static bool value_head_not_stm;
 
 // Symmetry helper
-static std::array<std::array<int, BOARD_SQUARES>, 8> symmetry_nn_idx_table;
+static std::array<std::array<int, BOARD_SQUARES>, NUM_SYMMETRIES> symmetry_nn_idx_table;
 
 void Network::benchmark(const GameState* const state, const int iterations) {
     const auto cpus = cfg_num_threads;
@@ -350,8 +350,8 @@ std::pair<int, int> Network::load_network_file(const std::string& filename) {
 
 void Network::initialize() {
     // Prepare symmetry table
-    for (auto s = 0; s < 8; s++) {
-        for (auto v = 0; v < BOARD_SQUARES; v++) {
+    for (auto s = 0; s < NUM_SYMMETRIES; ++s) {
+        for (auto v = 0; v < BOARD_SQUARES; ++v) {
             const auto newvtx = get_symmetry({v % BOARD_SIZE, v / BOARD_SIZE}, s);
             symmetry_nn_idx_table[s][v] = (newvtx.second * BOARD_SIZE) + newvtx.first;
             assert(symmetry_nn_idx_table[s][v] >= 0 && symmetry_nn_idx_table[s][v] < BOARD_SQUARES);
@@ -882,7 +882,7 @@ Network::Netresult Network::get_scored_moves(
 
     if (!skip_cache) {
         // See if we already have this in the cache.
-        for (auto symmetry = 0; symmetry < 8; ++symmetry) {
+        for (auto symmetry = 0; symmetry < NUM_SYMMETRIES; ++symmetry) {
             const auto hash = state->get_hash(symmetry);
             assert(symmetry != 0 || hash == state->board.get_hash());
             if (NNCache::get_NNCache().lookup(hash, result)) {
@@ -899,22 +899,22 @@ Network::Netresult Network::get_scored_moves(
     }
 
     if (ensemble == DIRECT) {
-        assert(symmetry >= 0 && symmetry < 8);
+        assert(symmetry >= 0 && symmetry < NUM_SYMMETRIES);
         result = get_scored_moves_internal(state, symmetry);
     } else if (ensemble == AVERAGE) {
-        for (auto sym = 0; sym < 8; ++sym) {
+        for (auto sym = 0; sym < NUM_SYMMETRIES; ++sym) {
             auto tmpresult = get_scored_moves_internal(state, sym);
-            result.winrate += tmpresult.winrate / 8.0f;
-            result.policy_pass += tmpresult.policy_pass / 8.0f;
+            result.winrate += tmpresult.winrate / static_cast<float>(NUM_SYMMETRIES);
+            result.policy_pass += tmpresult.policy_pass / static_cast<float>(NUM_SYMMETRIES);
 
             for (auto idx = size_t{0}; idx < BOARD_SQUARES; idx++) {
-                result.policy[idx] += tmpresult.policy[idx] / 8.0f;
+                result.policy[idx] += tmpresult.policy[idx] / static_cast<float>(NUM_SYMMETRIES);
             }
         }
     } else {
         assert(ensemble == RANDOM_SYMMETRY);
         assert(symmetry == -1);
-        const auto rand_sym = Random::get_Rng().randfix<8>();
+        const auto rand_sym = Random::get_Rng().randfix<NUM_SYMMETRIES>();
         result = get_scored_moves_internal(state, rand_sym);
     }
 
@@ -933,7 +933,7 @@ Network::Netresult Network::get_scored_moves(
 
 Network::Netresult Network::get_scored_moves_internal(
     const GameState* const state, const int symmetry) {
-    assert(symmetry >= 0 && symmetry < 8);
+    assert(symmetry >= 0 && symmetry < NUM_SYMMETRIES);
     constexpr auto width = BOARD_SIZE;
     constexpr auto height = BOARD_SIZE;
 
@@ -1073,7 +1073,7 @@ void Network::fill_input_plane_pair(const FullBoard& board,
 
 std::vector<net_t> Network::gather_features(const GameState* const state,
                                             const int symmetry) {
-    assert(symmetry >= 0 && symmetry < 8);
+    assert(symmetry >= 0 && symmetry < NUM_SYMMETRIES);
     auto input_data = std::vector<net_t>(INPUT_CHANNELS * BOARD_SQUARES);
 
     const auto to_move = state->get_to_move();

--- a/src/Network.h
+++ b/src/Network.h
@@ -99,7 +99,6 @@ private:
     static void winograd_sgemm(const std::vector<float>& U,
                                const std::vector<float>& V,
                                std::vector<float>& M, const int C, const int K);
-    static int get_nn_idx_symmetry(const int vertex, int symmetry);
     static void fill_input_plane_pair(const FullBoard& board,
                                       std::vector<net_t>::iterator black,
                                       std::vector<net_t>::iterator white,

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -148,7 +148,7 @@ size_t Utils::ceilMultiple(size_t a, size_t b) {
 std::pair<int, int> Utils::get_symmetry(const std::pair<int, int>& vertex, const int symmetry, const int board_size) {
     assert(vertex.first >= 0 && vertex.first < board_size);
     assert(vertex.second >= 0 && vertex.second < board_size);
-    assert(symmetry >= 0 && symmetry < 8);
+    assert(symmetry >= 0 && symmetry < NUM_SYMMETRIES);
     auto x = vertex.first;
     auto y = vertex.second;
 

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -144,3 +144,28 @@ size_t Utils::ceilMultiple(size_t a, size_t b) {
     auto ret = a + (b - a % b);
     return ret;
 }
+
+std::pair<int, int> Utils::get_symmetry(const std::pair<int, int>& vertex, const int symmetry, const int board_size) {
+    assert(vertex.first >= 0 && vertex.first < board_size);
+    assert(vertex.second >= 0 && vertex.second < board_size);
+    assert(symmetry >= 0 && symmetry < 8);
+    auto x = vertex.first;
+    auto y = vertex.second;
+
+    if ((symmetry & 4) != 0) {
+        std::swap(x, y);
+    }
+
+    if ((symmetry & 2) != 0) {
+        x = board_size - x - 1;
+    }
+
+    if ((symmetry & 1) != 0) {
+        y = board_size - y - 1;
+    }
+
+    assert(x >= 0 && x < board_size);
+    assert(y >= 0 && y < board_size);
+    assert(symmetry != 0 || vertex == std::make_pair(x, y));
+    return {x, y};
+}

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -52,6 +52,7 @@ namespace Utils {
     }
 
     size_t ceilMultiple(size_t a, size_t b);
+    std::pair<int, int> get_symmetry(const std::pair<int, int>& vertex, const int symmetry, const int board_size = BOARD_SIZE);
 }
 
 #endif

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -27,6 +27,8 @@
 
 #include "ThreadPool.h"
 
+static constexpr auto NUM_SYMMETRIES = 8;
+
 extern Utils::ThreadPool thread_pool;
 
 namespace Utils {


### PR DESCRIPTION
As suggested in https://github.com/gcp/leela-zero/issues/1084#issuecomment-375668610.

I took the liberty of changing the benchmark position to one in which this doesn't cause a speedup, because it's not typical for the game as a whole.