### PR TITLE
Add definition of UCTSearch::UNLIMITED_PLAYOUTS.

### DIFF
--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -38,6 +38,8 @@
 
 using namespace Utils;
 
+constexpr int UCTSearch::UNLIMITED_PLAYOUTS;
+
 UCTSearch::UCTSearch(GameState& g)
     : m_rootstate(g) {
     set_playout_limit(cfg_max_playouts);


### PR DESCRIPTION
Without this, both the debug and Clang builds will fail with undefined reference linker errors.
Another unfortunate miss from the CI checks.