### PR TITLE
Tidy gathering of input vector

### DIFF
--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -1044,9 +1044,9 @@ void Network::show_heatmap(const FastState* const state,
     }
 }
 
-void Network::get_input_moves(const GameState* const state, 
-                              std::vector<net_t>& input_data, 
-                              const int symmetry, 
+void Network::get_input_moves(const GameState* const state,
+                              std::vector<net_t>& input_data,
+                              const int symmetry,
                               const int color)
 {
     assert(symmetry >= 0 && symmetry <= 7);
@@ -1068,7 +1068,7 @@ void Network::get_input_moves(const GameState* const state,
 }
 
 void Network::gather_features_vector(const GameState* const state,
-                                     std::vector<net_t>& input_data, 
+                                     std::vector<net_t>& input_data,
                                      const int symmetry) {
     const auto to_move = state->get_to_move();
     const auto blacks_move = to_move == FastBoard::BLACK;

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -885,15 +885,12 @@ Network::Netresult Network::get_scored_moves(
         }
     }
 
-    NNPlanes planes;
-    gather_features(state, planes);
-
     if (ensemble == DIRECT) {
         assert(symmetry >= 0 && symmetry <= 7);
-        result = get_scored_moves_internal(planes, symmetry);
+        result = get_scored_moves_internal(state, symmetry);
     } else if (ensemble == AVERAGE) {
-        for (auto r = 0; r < 8; ++r) {
-            auto tmpresult = get_scored_moves_internal(planes, r);
+        for (auto sym = 0; sym < 8; ++sym) {
+            auto tmpresult = get_scored_moves_internal(state, sym);
             result.winrate += tmpresult.winrate / 8.0f;
             result.policy_pass += tmpresult.policy_pass / 8.0f;
 
@@ -905,7 +902,7 @@ Network::Netresult Network::get_scored_moves(
         assert(ensemble == RANDOM_SYMMETRY);
         assert(symmetry == -1);
         const auto rand_sym = Random::get_Rng().randfix<8>();
-        result = get_scored_moves_internal(planes, rand_sym);
+        result = get_scored_moves_internal(state, rand_sym);
     }
 
     // v2 format (ELF Open Go) returns black value, not stm
@@ -922,11 +919,11 @@ Network::Netresult Network::get_scored_moves(
 }
 
 Network::Netresult Network::get_scored_moves_internal(
-    const NNPlanes& planes, const int symmetry) {
+    const GameState* const state, const int symmetry) {
     assert(symmetry >= 0 && symmetry <= 7);
-    assert(INPUT_CHANNELS == planes.size());
     constexpr auto width = BOARD_SIZE;
     constexpr auto height = BOARD_SIZE;
+
     std::vector<net_t> input_data;
     std::vector<float> policy_data(OUTPUTS_POLICY * width * height);
     std::vector<float> value_data(OUTPUTS_VALUE * width * height);
@@ -934,16 +931,9 @@ Network::Netresult Network::get_scored_moves_internal(
     std::vector<net_t> policy_data_n(OUTPUTS_POLICY * width * height);
     std::vector<net_t> value_data_n(OUTPUTS_VALUE * width * height);
 #endif
-    // Data layout is input_data[(c * height + h) * width + w]
-    input_data.reserve(INPUT_CHANNELS * width * height);
-    for (auto c = 0; c < INPUT_CHANNELS; ++c) {
-        for (auto h = 0; h < height; ++h) {
-            for (auto w = 0; w < width; ++w) {
-                const auto sym_idx = symmetry_nn_idx_table[symmetry][h * width + w];
-                input_data.emplace_back(net_t(planes[c][sym_idx]));
-            }
-        }
-    }
+
+    gather_features_vector(state, input_data, symmetry);
+
 #ifdef USE_OPENCL
 #ifdef USE_HALF
     opencl.forward(input_data, policy_data_n, value_data_n);
@@ -1054,50 +1044,43 @@ void Network::show_heatmap(const FastState* const state,
     }
 }
 
-void Network::fill_input_plane_pair(const FullBoard& board,
-                                    BoardPlane& black, BoardPlane& white) {
-    auto idx = 0;
-    for (auto j = 0; j < BOARD_SIZE; j++) {
-        for (auto i = 0; i < BOARD_SIZE; i++) {
-            const auto vtx = board.get_vertex(i, j);
-            const auto color = board.get_square(vtx);
-            if (color != FastBoard::EMPTY) {
-                if (color == FastBoard::BLACK) {
-                    black[idx] = true;
-                } else {
-                    white[idx] = true;
-                }
-            }
-            idx++;
+void Network::get_input_moves(const GameState* const state, 
+                              std::vector<net_t>& input_data, 
+                              const int symmetry, 
+                              const int color)
+{
+    assert(symmetry >= 0 && symmetry <= 7);
+    const auto moves = std::min<size_t>(state->get_movenum() + 1, INPUT_MOVES);
+
+    for (auto c = size_t{0}; c < moves; c++) {
+        auto const board = state->get_past_board(c);
+        for (auto idx = 0; idx < BOARD_SQUARES; idx++) {
+            const auto sym_idx = symmetry_nn_idx_table[symmetry][idx];
+            const auto x = sym_idx % BOARD_SIZE;
+            const auto y = sym_idx / BOARD_SIZE;
+            const auto color_is_at_vtx = (color == board.get_square(x, y));
+            input_data.emplace_back(net_t(color_is_at_vtx));
         }
+    }
+    for (auto c = moves; c < INPUT_MOVES; c++) {
+        input_data.insert(input_data.cend(), BOARD_SQUARES, net_t(false));
     }
 }
 
-void Network::gather_features(const GameState* const state, NNPlanes & planes) {
-    planes.resize(INPUT_CHANNELS);
-    auto& black_to_move = planes[2 * INPUT_MOVES];
-    auto& white_to_move = planes[2 * INPUT_MOVES + 1];
-
+void Network::gather_features_vector(const GameState* const state,
+                                     std::vector<net_t>& input_data, 
+                                     const int symmetry) {
     const auto to_move = state->get_to_move();
     const auto blacks_move = to_move == FastBoard::BLACK;
+    const auto not_to_move = blacks_move ? FastBoard::WHITE : FastBoard::BLACK;
 
-    const auto black_offset = blacks_move ? 0 : INPUT_MOVES;
-    const auto white_offset = blacks_move ? INPUT_MOVES : 0;
+    input_data.reserve(INPUT_CHANNELS * BOARD_SQUARES);
 
-    if (blacks_move) {
-        black_to_move.set();
-    } else {
-        white_to_move.set();
-    }
+    get_input_moves(state, input_data, symmetry, to_move);
+    get_input_moves(state, input_data, symmetry, not_to_move);
 
-    const auto moves = std::min<size_t>(state->get_movenum() + 1, INPUT_MOVES);
-    // Go back in time, fill history boards
-    for (auto h = size_t{0}; h < moves; h++) {
-        // collect white, black occupation planes
-        fill_input_plane_pair(state->get_past_board(h),
-                              planes[black_offset + h],
-                              planes[white_offset + h]);
-    }
+    input_data.insert(input_data.cend(), BOARD_SQUARES, net_t(blacks_move));
+    input_data.insert(input_data.cend(), BOARD_SQUARES, net_t(!blacks_move));
 }
 
 int Network::get_nn_idx_symmetry(const int vertex, int symmetry) {

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -924,16 +924,15 @@ Network::Netresult Network::get_scored_moves_internal(
     constexpr auto width = BOARD_SIZE;
     constexpr auto height = BOARD_SIZE;
 
-    std::vector<net_t> input_data;
+    auto input_data = std::vector<net_t>{};
+    gather_features(state, input_data, symmetry);
+
     std::vector<float> policy_data(OUTPUTS_POLICY * width * height);
     std::vector<float> value_data(OUTPUTS_VALUE * width * height);
 #ifdef USE_HALF
     std::vector<net_t> policy_data_n(OUTPUTS_POLICY * width * height);
     std::vector<net_t> value_data_n(OUTPUTS_VALUE * width * height);
 #endif
-
-    gather_features_vector(state, input_data, symmetry);
-
 #ifdef USE_OPENCL
 #ifdef USE_HALF
     opencl.forward(input_data, policy_data_n, value_data_n);
@@ -1044,43 +1043,48 @@ void Network::show_heatmap(const FastState* const state,
     }
 }
 
-void Network::get_input_moves(const GameState* const state,
+void Network::gather_features(const GameState* const state,
                               std::vector<net_t>& input_data,
-                              const int symmetry,
-                              const int color)
-{
+                              const int symmetry) {
     assert(symmetry >= 0 && symmetry <= 7);
-    const auto moves = std::min<size_t>(state->get_movenum() + 1, INPUT_MOVES);
 
+    const auto color_to_move = state->get_to_move();
+    const auto color_not_to_move = color_to_move == FastBoard::BLACK ?
+                                                    FastBoard::WHITE :
+                                                    FastBoard::BLACK;
+    auto color_not_to_move_data = std::vector<net_t>{};
+
+    input_data.reserve(INPUT_CHANNELS * BOARD_SQUARES);
+    color_not_to_move_data.reserve(INPUT_MOVES * BOARD_SQUARES);
+
+    const auto moves = std::min<size_t>(state->get_movenum() + 1, INPUT_MOVES);
     for (auto c = size_t{0}; c < moves; c++) {
         auto const board = state->get_past_board(c);
         for (auto idx = 0; idx < BOARD_SQUARES; idx++) {
             const auto sym_idx = symmetry_nn_idx_table[symmetry][idx];
             const auto x = sym_idx % BOARD_SIZE;
             const auto y = sym_idx / BOARD_SIZE;
-            const auto color_is_at_vtx = (color == board.get_square(x, y));
-            input_data.emplace_back(net_t(color_is_at_vtx));
+            const auto color = board.get_square(x, y);
+            input_data.emplace_back(
+                net_t(color == color_to_move));
+            color_not_to_move_data.emplace_back(
+                net_t(color == color_not_to_move));
         }
     }
     for (auto c = moves; c < INPUT_MOVES; c++) {
-        input_data.insert(input_data.cend(), BOARD_SQUARES, net_t(false));
+        input_data.insert(cend(input_data), BOARD_SQUARES, net_t(false));
+        color_not_to_move_data.insert(cend(color_not_to_move_data),
+            BOARD_SQUARES, net_t(false));
     }
-}
 
-void Network::gather_features_vector(const GameState* const state,
-                                     std::vector<net_t>& input_data,
-                                     const int symmetry) {
-    const auto to_move = state->get_to_move();
-    const auto blacks_move = to_move == FastBoard::BLACK;
-    const auto not_to_move = blacks_move ? FastBoard::WHITE : FastBoard::BLACK;
+    input_data.insert(cend(input_data),
+        std::make_move_iterator(cbegin(color_not_to_move_data)),
+        std::make_move_iterator(cend(color_not_to_move_data)));
 
-    input_data.reserve(INPUT_CHANNELS * BOARD_SQUARES);
-
-    get_input_moves(state, input_data, symmetry, to_move);
-    get_input_moves(state, input_data, symmetry, not_to_move);
-
-    input_data.insert(input_data.cend(), BOARD_SQUARES, net_t(blacks_move));
-    input_data.insert(input_data.cend(), BOARD_SQUARES, net_t(!blacks_move));
+    input_data.insert(cend(input_data), BOARD_SQUARES,
+                      net_t(color_to_move == FastBoard::BLACK));
+    input_data.insert(cend(input_data), BOARD_SQUARES,
+                      net_t(color_to_move == FastBoard::WHITE));
 }
 
 int Network::get_nn_idx_symmetry(const int vertex, int symmetry) {

--- a/src/Network.h
+++ b/src/Network.h
@@ -55,7 +55,7 @@ public:
                                       const Ensemble ensemble,
                                       const int symmetry = -1,
                                       const bool skip_cache = false);
-    // File format version
+
     static constexpr auto INPUT_MOVES = 8;
     static constexpr auto INPUT_CHANNELS = 2 * INPUT_MOVES + 2;
     static constexpr auto OUTPUTS_POLICY = 2;
@@ -71,9 +71,9 @@ public:
     static void show_heatmap(const FastState * const state,
                              const Netresult & netres, const bool topmoves);
 
-    static void gather_features_vector(const GameState* const state,
-                                       std::vector<net_t>& input_data,
-                                       const int symmetry);
+    static void gather_features(const GameState* const state,
+                                std::vector<net_t>& input_data,
+                                const int symmetry);
 private:
     static std::pair<int, int> load_v1_network(std::istream& wtfile);
     static std::pair<int, int> load_network_file(const std::string& filename);
@@ -101,11 +101,7 @@ private:
                                const std::vector<float>& V,
                                std::vector<float>& M, const int C, const int K);
     static int get_nn_idx_symmetry(const int vertex, int symmetry);
-    static void get_input_moves(const GameState* const state,
-                                std::vector<net_t>& input_data,
-                                const int symmetry,
-                                const int color);
-    static Netresult get_scored_moves_internal(const GameState* const state, 
+    static Netresult get_scored_moves_internal(const GameState* const state,
                                                const int symmetry);
 #if defined(USE_BLAS)
     static void forward_cpu(const std::vector<float>& input,

--- a/src/Network.h
+++ b/src/Network.h
@@ -71,9 +71,8 @@ public:
     static void show_heatmap(const FastState * const state,
                              const Netresult & netres, const bool topmoves);
 
-    static void gather_features(const GameState* const state,
-                                std::vector<net_t>& input_data,
-                                const int symmetry);
+    static std::vector<net_t> gather_features(const GameState* const state,
+                                              const int symmetry);
 private:
     static std::pair<int, int> load_v1_network(std::istream& wtfile);
     static std::pair<int, int> load_network_file(const std::string& filename);
@@ -101,6 +100,10 @@ private:
                                const std::vector<float>& V,
                                std::vector<float>& M, const int C, const int K);
     static int get_nn_idx_symmetry(const int vertex, int symmetry);
+    static void fill_input_plane_pair(const FullBoard& board,
+                                      std::vector<net_t>::iterator black,
+                                      std::vector<net_t>::iterator white,
+                                      const int symmetry);
     static Netresult get_scored_moves_internal(const GameState* const state,
                                                const int symmetry);
 #if defined(USE_BLAS)

--- a/src/Network.h
+++ b/src/Network.h
@@ -22,7 +22,6 @@
 #include "config.h"
 
 #include <array>
-#include <bitset>
 #include <memory>
 #include <string>
 #include <utility>
@@ -37,8 +36,6 @@ public:
     enum Ensemble {
         DIRECT, RANDOM_SYMMETRY, AVERAGE
     };
-    using BoardPlane = std::bitset<BOARD_SQUARES>;
-    using NNPlanes = std::vector<BoardPlane>;
     using ScoreVertexPair = std::pair<float,int>;
 
     struct Netresult {
@@ -74,7 +71,9 @@ public:
     static void show_heatmap(const FastState * const state,
                              const Netresult & netres, const bool topmoves);
 
-    static void gather_features(const GameState* const state, NNPlanes& planes);
+    static void gather_features_vector(const GameState* const state,
+                                       std::vector<net_t>& input_data,
+                                       const int symmetry);
 private:
     static std::pair<int, int> load_v1_network(std::istream& wtfile);
     static std::pair<int, int> load_network_file(const std::string& filename);
@@ -102,10 +101,12 @@ private:
                                const std::vector<float>& V,
                                std::vector<float>& M, const int C, const int K);
     static int get_nn_idx_symmetry(const int vertex, int symmetry);
-    static void fill_input_plane_pair(
-      const FullBoard& board, BoardPlane& black, BoardPlane& white);
-    static Netresult get_scored_moves_internal(
-      const NNPlanes& planes, const int symmetry);
+    static void get_input_moves(const GameState* const state,
+                                std::vector<net_t>& input_data,
+                                const int symmetry,
+                                const int color);
+    static Netresult get_scored_moves_internal(const GameState* const state, 
+                                               const int symmetry);
 #if defined(USE_BLAS)
     static void forward_cpu(const std::vector<float>& input,
                             std::vector<float>& output_pol,

--- a/src/Training.cpp
+++ b/src/Training.cpp
@@ -139,12 +139,12 @@ void Training::clear_training() {
     Training::m_data.clear();
 }
 
-void Training::fill_planes(const GameState* const state, 
+void Training::fill_planes(const GameState* const state,
                            TimeStep::NNPlanes& planes) {
 
     std::vector<net_t>features_vector;
     Network::gather_features_vector(state, features_vector, 0);
-    
+
     planes = TimeStep::NNPlanes{};
     planes.resize(Network::INPUT_CHANNELS);
 

--- a/src/Training.cpp
+++ b/src/Training.cpp
@@ -140,8 +140,7 @@ void Training::clear_training() {
 }
 
 TimeStep::NNPlanes Training::get_planes(const GameState* const state) {
-    auto input_data = std::vector<net_t>{};
-    Network::gather_features(state, input_data, 0);
+    const auto input_data = Network::gather_features(state, 0);
 
     auto planes = TimeStep::NNPlanes{};
     planes.resize(Network::INPUT_CHANNELS);

--- a/src/Training.h
+++ b/src/Training.h
@@ -21,6 +21,7 @@
 
 #include "config.h"
 
+#include <bitset>
 #include <cstddef>
 #include <string>
 #include <utility>
@@ -32,7 +33,9 @@
 
 class TimeStep {
 public:
-    Network::NNPlanes planes;
+    using BoardPlane = std::bitset<BOARD_SQUARES>;
+    using NNPlanes = std::vector<BoardPlane>;
+    NNPlanes planes;
     std::vector<float> probabilities;
     int to_move;
     float net_winrate;
@@ -76,6 +79,8 @@ public:
     static void load_training(const std::string& filename);
 
 private:
+    static void fill_planes(const GameState* const state,
+                            TimeStep::NNPlanes& planes);
     static void process_game(GameState& state, size_t& train_pos, int who_won,
                              const std::vector<int>& tree_moves,
                              OutputChunker& outchunker);

--- a/src/Training.h
+++ b/src/Training.h
@@ -79,8 +79,7 @@ public:
     static void load_training(const std::string& filename);
 
 private:
-    static void fill_planes(const GameState* const state,
-                            TimeStep::NNPlanes& planes);
+    static TimeStep::NNPlanes get_planes(const GameState* const state);
     static void process_game(GameState& state, size_t& train_pos, int who_won,
                              const std::vector<int>& tree_moves,
                              OutputChunker& outchunker);


### PR DESCRIPTION
Network now gathers inputs directly into a vector rather than going via a bitset. The bitset conversion is now only done for the selected move when recording training data. 2nd attempt of #1130 (without other changes).
A couple of questions:
1. My 2nd commit in this avoids `get_scored_moves_internal()` having to be passed the `state` but it looks weird to me that input data has the symmetry applied outside of the function but the outputs are converted back within the function. So:
a. also pull applying symmetry to `result.policy[]` out into `get_scored_moves()`
b. put applying of symmetry to inputs back into `get_scored_moves()`
c. "who cares? you're worrying about nothing"
2. Should `fill_planes()` be a method of `TimeStep` rather than `Training`? I'm not that experienced with OO (I program in C mostly) but what I have done doesn't look too out of place with what is currently in Training.cpp