### PR TITLE
Exclude low visit moves from random selection.

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -56,6 +56,8 @@ int cfg_lagbuffer_cs;
 int cfg_resignpct;
 int cfg_noise;
 int cfg_random_cnt;
+int cfg_random_min_visits;
+float cfg_random_temp;
 std::uint64_t cfg_rng_seed;
 bool cfg_dumbpass;
 #ifdef USE_OPENCL
@@ -99,6 +101,8 @@ void GTP::setup_default_parameters() {
     cfg_resignpct = -1;
     cfg_noise = false;
     cfg_random_cnt = 0;
+    cfg_random_min_visits = 1;
+    cfg_random_temp = 1.0f;
     cfg_dumbpass = false;
     cfg_logfile_handle = nullptr;
     cfg_quiet = false;

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -39,6 +39,8 @@ extern int cfg_lagbuffer_cs;
 extern int cfg_resignpct;
 extern int cfg_noise;
 extern int cfg_random_cnt;
+extern int cfg_random_min_visits;
+extern float cfg_random_temp;
 extern std::uint64_t cfg_rng_seed;
 extern bool cfg_dumbpass;
 #ifdef USE_OPENCL


### PR DESCRIPTION
Right now the randomized move selection will still pick moves that only
got a single visit. That means that no matter how badly they are
evaluated, we still have a fair chance of playing them. This means our
learning cycle can't avoid some really bad blunders.

There's some indication that using FPU=parent causes these blunders to
stay happening when ahead, as opposed to the AGZ method of using
FPU=0.5, which ends up filtering them. Because we really want to keep
FPU=parent, filter moves with only a single visit to get a similar
effect, i.e. to not pick moves with a really bad evalution.

This defaults the minimum visits to 1, and also adds a configurable
temperature to move selection, defaulted at t=1.