### PR TITLE
Extend GTP to add support for displaying real time winrates and variations 

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -373,6 +373,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
                 return 1;
             }
             if (analysis_output) {
+                // Start of multi-line response
                 cfg_analyze_interval_centis = interval;
                 if (id != -1) gtp_printf_raw("=%d\n", id);
                 else gtp_printf_raw("=\n");
@@ -380,6 +381,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
             // start thinking
             {
                 game.set_to_move(who);
+                // Outputs winrate and pvs for lz-genmove_analyze
                 int move = search->think(who);
                 game.play_move(move);
 
@@ -393,10 +395,12 @@ bool GTP::execute(GameState & game, std::string xinput) {
             if (cfg_allow_pondering) {
                 // now start pondering
                 if (!game.has_resigned()) {
+                    // Outputs winrate and pvs through gtp for lz-genmove_analyze
                     search->ponder();
                 }
             }
             if (analysis_output) {
+                // Terminate multi-line response
                 gtp_printf_raw("\n");
             }
         } else {
@@ -417,13 +421,16 @@ bool GTP::execute(GameState & game, std::string xinput) {
             gtp_fail_printf(id, "syntax not understood");
             return true;
         }
+        // Start multi-line response
         if (id != -1) gtp_printf_raw("=%d\n", id);
         else gtp_printf_raw("=\n");
         // now start pondering
         if (!game.has_resigned()) {
+            // Outputs winrate and pvs through gtp
             search->ponder();
         }
         cfg_analyze_interval_centis = 0;
+        // Terminate multi-line response
         gtp_printf_raw("\n");
         return true;
     } else if (command.find("kgs-genmove_cleanup") == 0) {

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -350,8 +350,8 @@ bool GTP::execute(GameState & game, std::string xinput) {
         }
         return true;
     } else if (command.find("genmove") == 0 || command.find("lz-genmove_analyze") == 0 ) {
-        bool analysis_output = command.find("lz-genmove_analyze") == 0;
-        int interval;
+        auto analysis_output = command.find("lz-genmove_analyze") == 0;
+        auto interval = 0;
 
         std::istringstream cmdstream(command);
         std::string tmp;

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -349,7 +349,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
             }
         }
         return true;
-    } else if (command.find("genmove") == 0 || command.find("lz-genmove_analyze") == 0 ) {
+    } else if (command.find("genmove") == 0 || command.find("lz-genmove_analyze") == 0) {
         auto analysis_output = command.find("lz-genmove_analyze") == 0;
         auto interval = 0;
 
@@ -408,7 +408,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
         std::istringstream cmdstream(command);
         std::string tmp;
         int interval;
-        
+
         cmdstream >> tmp; // eat lz-analyze
         cmdstream >> interval;
         if (!cmdstream.fail()) {

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -57,6 +57,7 @@ extern FILE* cfg_logfile_handle;
 extern bool cfg_quiet;
 extern std::string cfg_options_str;
 extern bool cfg_benchmark;
+extern int cfg_analyze_interval_centis;
 
 /*
     A list of all valid GTP2 commands is defined here:

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -241,21 +241,21 @@ void UCTSearch::output_analysis(FastState & state, UCTNode & parent) {
     }
 
     const int color = state.get_to_move();
-    
+
     // sort children, put best move on top
     parent.sort_children(color);
-    
+
     if (parent.get_first_child()->first_visit()) {
         return;
     }
-    
+
     int movecount = 0;
     std::string separator = "info";
     for (const auto& node : parent.get_children()) {
         // Always display at least two moves. In the case there is
         // only one move searched the user could get an idea why.
         if (++movecount > 2 && !node->get_visits()) break;
-        
+
         std::string move = state.move_to_text(node->get_move());
         FastState tmpstate = state;
         tmpstate.play_move(node->get_move());
@@ -265,7 +265,7 @@ void UCTSearch::output_analysis(FastState & state, UCTNode & parent) {
         separator = " info";
     }
     gtp_printf_raw("\n");
-    
+
 }
 
 void tree_stats_helper(const UCTNode& node, size_t depth,
@@ -725,7 +725,7 @@ void UCTSearch::ponder() {
             if (elapsed_centis - last_output > cfg_analyze_interval_centis) {
                 last_output = elapsed_centis;
                 output_analysis(m_rootstate, *m_root);
-            }                                                           
+            }
         }
         keeprunning  = is_running();
         keeprunning &= !stop_thinking(0, 1);

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -242,19 +242,10 @@ void UCTSearch::output_analysis(FastState & state, UCTNode & parent) {
 
     const int color = state.get_to_move();
 
-    // sort children, put best move on top
-    parent.sort_children(color);
-
-    if (parent.get_first_child()->first_visit()) {
-        return;
-    }
-
-    int movecount = 0;
     std::string separator = "info";
     for (const auto& node : parent.get_children()) {
-        // Always display at least two moves. In the case there is
-        // only one move searched the user could get an idea why.
-        if (++movecount > 2 && !node->get_visits()) break;
+        // Only send variations with visits
+        if (!node->get_visits()) continue;
 
         std::string move = state.move_to_text(node->get_move());
         FastState tmpstate = state;

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -250,7 +250,7 @@ void UCTSearch::output_analysis(FastState & state, UCTNode & parent) {
     }
     
     int movecount = 0;
-    std::string separator = "info ";
+    std::string separator = "info";
     for (const auto& node : parent.get_children()) {
         // Always display at least two moves. In the case there is
         // only one move searched the user could get an idea why.
@@ -260,9 +260,9 @@ void UCTSearch::output_analysis(FastState & state, UCTNode & parent) {
         FastState tmpstate = state;
         tmpstate.play_move(node->get_move());
         std::string pv = move + " " + get_pv(tmpstate, *node);
-        gtp_printf_raw("%s%s %d %.2f %s", separator.c_str(), move.c_str(),node->get_visits(),
-                 node->get_visits() ? node->get_eval(color)*100.0f : 0.0f, pv.c_str());
-        separator = " | ";
+        gtp_printf_raw("%s %s %s %s %d %s %d %s %s", separator.c_str(), "move", move.c_str(), "visits", node->get_visits(),
+                 "winrate", node->get_visits() ? (int)(node->get_eval(color)*10000) : 0, "pv", pv.c_str());
+        separator = " info";
     }
     gtp_printf_raw("\n");
     
@@ -633,9 +633,9 @@ int UCTSearch::think(int color, passflag_t passflag) {
         tg.add_task(UCTWorker(m_rootstate, this, m_root.get()));
     }
 
-    bool keeprunning = true;
-    int last_update = 0;
-    int last_output = 0;
+    auto keeprunning = true;
+    auto last_update = 0;
+    auto last_output = 0;
     do {
         auto currstate = std::make_unique<GameState>(m_rootstate);
 
@@ -712,7 +712,7 @@ void UCTSearch::ponder() {
     }
     Time start;
     auto keeprunning = true;
-    int last_output = 0;
+    auto last_output = 0;
     do {
         auto currstate = std::make_unique<GameState>(m_rootstate);
         auto result = play_simulation(*currstate, m_root.get());

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -115,7 +115,7 @@ private:
     void update_root();
     bool advance_to_new_rootstate();
     void output_analysis(FastState & state, UCTNode & parent);
-    
+
     GameState & m_rootstate;
     std::unique_ptr<GameState> m_last_rootstate;
     std::unique_ptr<UCTNode> m_root;

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -114,7 +114,8 @@ private:
     int get_best_move(passflag_t passflag);
     void update_root();
     bool advance_to_new_rootstate();
-
+    void output_analysis(FastState & state, UCTNode & parent);
+    
     GameState & m_rootstate;
     std::unique_ptr<GameState> m_last_rootstate;
     std::unique_ptr<UCTNode> m_root;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -94,25 +94,17 @@ void Utils::myprintf(const char *fmt, ...) {
     }
 }
 
-static void gtp_fprintf(FILE* file, const std::string& prefix,
-                        const char *fmt, va_list ap) {
-    fprintf(file, "%s ", prefix.c_str());
-    vfprintf(file, fmt, ap);
-    fprintf(file, "\n\n");
-}
-
 static void gtp_base_printf(int id, std::string prefix,
                             const char *fmt, va_list ap) {
     if (id != -1) {
         prefix += std::to_string(id);
     }
+    prefix += " ";
 
-    gtp_fprintf(stdout, prefix, fmt, ap);
+    Utils::gtp_printf_raw(prefix.c_str());
+    Utils::gtp_printf_raw(fmt, ap);
+    Utils::gtp_printf_raw("\n\n");
 
-    if (cfg_logfile_handle) {
-        std::lock_guard<std::mutex> lock(IOmutex);
-        gtp_fprintf(cfg_logfile_handle, prefix, fmt, ap);
-    }
 }
 
 void Utils::gtp_printf(int id, const char *fmt, ...) {

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -122,6 +122,17 @@ void Utils::gtp_printf(int id, const char *fmt, ...) {
     va_end(ap);
 }
 
+void Utils::gtp_printf_raw(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(stdout, fmt, ap);
+    if (cfg_logfile_handle) {
+        std::lock_guard<std::mutex> lock(IOmutex);
+        vfprintf(cfg_logfile_handle, fmt, ap);
+    }
+    va_end(ap);
+}
+
 void Utils::gtp_fail_printf(int id, const char *fmt, ...) {
     va_list ap;
     va_start(ap, fmt);

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -32,6 +32,7 @@ extern Utils::ThreadPool thread_pool;
 namespace Utils {
     void myprintf(const char *fmt, ...);
     void gtp_printf(int id, const char *fmt, ...);
+    void gtp_printf_raw(const char *fmt, ...);
     void gtp_fail_printf(int id, const char *fmt, ...);
     void log_input(const std::string& input);
     bool input_pending();


### PR DESCRIPTION
This is an alternative implementation to #1242 and implements the solution discussed in that thread.

I have added two gtp commands:
```
lz-analyze <interval in centis>
lz-genmove-analyze <color> <interval in centis>
```

lz-analyze will return a multi-line response starting with =\n (or =id\n), before outputting one new info line every <interval in centis>. Each info line has the following format:
```
info <variation 1 info> | <variation 2 info> | .. | <variation n info>\n
```
The variation info has the following format
```
<Move> <playouts> <winrate> <list of moves in variation>
```
Example:
```
info D7 2234 99.94 D7 E6 C4 C3 C5 B3 E7 F7 F6 G6 F5 E4 F8 G7 G8 J7 H8 K6 J8 K8 | C5 260 99.88 C5 C4 D7 D5 E7 C7 C8 B7 B8 B5 R14 Q13 | N3 133 99.94 N3 O3 N2 N1 D7 E7 D5 E6 C4 | S3 120 99.91 S3 C5 R14 R17 Q17 Q18 R16 | C4 105 97.04 C4 C5 B5 D5 B3 C3 B4 C7 D3 E3 C2 R12 R14 P12 | N2 92 99.96 N2 O1 D7 E7 D8 C5 E6 D5 F7 | P5 90 99.94 P5 P4 D7 E7 D8 C5 E6 D5 F7 R14 R15 | R14 44 99.91 R14 C5 G3 G2 H3 H2 F4 | S2 21 99.92 S2 C5 R14 R17 R16 Q17 P17 P18 | B5 20 99.91 B5 C5 D7 B6 C7 B4\n
```
Once a (any) command is received from the gui/controller, the response is terminated with a \n on a separate line (as defined in multi-line responses in GTP protocol), and no more info lines are output.

lz-genmove-analyze works the same way, except when it finds a move to play (using the same criteria as a regular genmove), it outputs the following line:
```
play <move>
```
So the output will typically look like this (info lines truncated for simplicity):
```
info D7 2234 .....
info D7 3344 .....
play D7
info D6 1200 ...
info D6 2200 ...
info D6 3400 ...
etc
```

Response is terminated when LZ receives a (any) command the same way as the other command.

This code has been tested against (a modified version of) Lizzie.

Please let me know if you would like any changes to this implementation.