### PR TITLE
Tree reduction

### DIFF
--- a/msvc/VS2015/leela-zero.vcxproj
+++ b/msvc/VS2015/leela-zero.vcxproj
@@ -93,6 +93,7 @@
     <ClCompile Include="..\..\src\Training.cpp" />
     <ClCompile Include="..\..\src\Tuner.cpp" />
     <ClCompile Include="..\..\src\UCTNode.cpp" />
+    <ClCompile Include="..\..\src\UCTNodePointer.cpp" />
     <ClCompile Include="..\..\src\UCTNodeRoot.cpp" />
     <ClCompile Include="..\..\src\UCTSearch.cpp" />
     <ClCompile Include="..\..\src\Utils.cpp" />
@@ -121,6 +122,7 @@
     <ClInclude Include="..\..\src\Training.h" />
     <ClInclude Include="..\..\src\Tuner.h" />
     <ClInclude Include="..\..\src\UCTNode.h" />
+    <ClInclude Include="..\..\src\UCTNodePointer.h" />
     <ClInclude Include="..\..\src\UCTSearch.h" />
     <ClInclude Include="..\..\src\Utils.h" />
     <ClInclude Include="..\..\src\Zobrist.h" />

--- a/msvc/VS2015/leela-zero.vcxproj.filters
+++ b/msvc/VS2015/leela-zero.vcxproj.filters
@@ -90,6 +90,9 @@
     <ClInclude Include="..\..\src\OpenCLScheduler.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\UCTNodePointer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\FastBoard.cpp">
@@ -162,6 +165,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\OpenCLScheduler.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\UCTNodePointer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -151,7 +151,7 @@ void UCTNode::link_nodelist(std::atomic<int>& nodecount,
 	auto iter = 0;
     auto skipped_children = false;
     for (const auto& node : nodelist) {
-		if (++iter > BOARD_SQUARES / 4) break; //limit tree width to BOARD_SQUARES_4 at all times
+        if (++iter > BOARD_SQUARES / 4) break; //limit tree width to BOARD_SQUARES_4 at all times	
         if (node.first < new_min_psa) {
             skipped_children = true;
         } else if (node.first < old_min_psa) {

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -147,7 +147,7 @@ void UCTNode::link_nodelist(std::atomic<int>& nodecount,
     } else {
         m_children.reserve(nodelist.size());
     }
-	auto iter = 0;
+    auto iter = 0;
     auto skipped_children = false;
     for (const auto& node : nodelist) {
         if (++iter > BOARD_SQUARES / 4) break; //limit tree width to BOARD_SQUARES_4 at all times

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -151,7 +151,7 @@ void UCTNode::link_nodelist(std::atomic<int>& nodecount,
 	auto iter = 0;
     auto skipped_children = false;
     for (const auto& node : nodelist) {
-        if (++iter > BOARD_SQUARES / 4) break; //limit tree width to BOARD_SQUARES_4 at all times	
+        if (++iter > BOARD_SQUARES / 4) break; //limit tree width to BOARD_SQUARES_4 at all times
         if (node.first < new_min_psa) {
             skipped_children = true;
         } else if (node.first < old_min_psa) {

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -147,7 +147,6 @@ void UCTNode::link_nodelist(std::atomic<int>& nodecount,
     } else {
         m_children.reserve(nodelist.size());
     }
-
 	auto iter = 0;
     auto skipped_children = false;
     for (const auto& node : nodelist) {

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -148,12 +148,12 @@ void UCTNode::link_nodelist(std::atomic<int>& nodecount,
         m_children.reserve(nodelist.size());
     }
 
-	// ThorAvaTahr: perhaps we should limit the nodelist to BOARD_SQUARES/2 or 
-	//		BOARD_SQUARES/4. this should allow taking up a lot less of our 
-	//		MAX_TREE_SIZE, preventing requiring to re-evaluate nodes (min_psa
-	//		systemic) that we have previously all ready visited. The disadvantage of 
-	//      course is that we might miss the best move, but it should be learnable 
-	//		that the best move is in the first quarter of the vector of moves.
+	// ThorAvaTahr: perhaps we should limit the nodelist to BOARD_SQUARES/2 or
+	//	BOARD_SQUARES/4. this should allow taking up a lot less of our
+	//	MAX_TREE_SIZE, preventing requiring to re-evaluate nodes (min_psa
+	//	systemic) that we have previously all ready visited. The disadvantage of
+	//  course is that we might miss the best move, but it should be learnable
+	//	that the best move is in the first quarter of the vector of moves.
 
 
 	auto iter = 0;

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -148,8 +148,18 @@ void UCTNode::link_nodelist(std::atomic<int>& nodecount,
         m_children.reserve(nodelist.size());
     }
 
+	// ThorAvaTahr: perhaps we should limit the nodelist to BOARD_SQUARES/2 or 
+	//		BOARD_SQUARES/4. this should allow taking up a lot less of our 
+	//		MAX_TREE_SIZE, preventing requiring to re-evaluate nodes (min_psa
+	//		systemic) that we have previously all ready visited. The disadvantage of 
+	//      course is that we might miss the best move, but it should be learnable 
+	//		that the best move is in the first quarter of the vector of moves.
+
+
+	auto iter = 0;
     auto skipped_children = false;
     for (const auto& node : nodelist) {
+		if (++iter > BOARD_SQUARES / 4) break; // ThorAvaTahr tree reduction.
         if (node.first < new_min_psa) {
             skipped_children = true;
         } else if (node.first < old_min_psa) {

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -148,18 +148,10 @@ void UCTNode::link_nodelist(std::atomic<int>& nodecount,
         m_children.reserve(nodelist.size());
     }
 
-	// ThorAvaTahr: perhaps we should limit the nodelist to BOARD_SQUARES/2 or
-	//	BOARD_SQUARES/4. this should allow taking up a lot less of our
-	//	MAX_TREE_SIZE, preventing requiring to re-evaluate nodes (min_psa
-	//	systemic) that we have previously all ready visited. The disadvantage of
-	//  course is that we might miss the best move, but it should be learnable
-	//	that the best move is in the first quarter of the vector of moves.
-
-
 	auto iter = 0;
     auto skipped_children = false;
     for (const auto& node : nodelist) {
-		if (++iter > BOARD_SQUARES / 4) break; // ThorAvaTahr tree reduction.
+		if (++iter > BOARD_SQUARES / 4) break; //limit tree width to BOARD_SQUARES_4 at all times
         if (node.first < new_min_psa) {
             skipped_children = true;
         } else if (node.first < old_min_psa) {


### PR DESCRIPTION

This pull requests proposes an optimization to reduce the size of the tree, reducing the number of reevaluations of previously visited nodes. I argue that gain in performance outweighs the negligible chance we miss the optimal move. This was confirmed in an interrupted experiment at 9 wins vs two losses on our best 5x64 network.

After reviewing the search algorithm I wondered about the cost/benefit of keeping the entire search result in the tree (especially the width of the tree: at each node the entire set of valid moves is expanded).

Off course we start pruning the tree once we approach MAX_TREE_SIZE, skipping children with low probability. However this will have the effect that we re-evaluate previously visited nodes for which we know we have pruned some children. It looked somewhat wasteful to me, so I was thinking of some alternatives. 

Thinking of that in fact made me wonder how valuable it was to keep all 300+ moves in every step of the tree. I would say if we just keep the top 90 (max) moves, we would be not likely miss the best move. (And even if the best move would be below the top 90 moves for our policy, that would probably still mean we would miss it).

So I have run an experiment on our best 5x64 network. Unfortunately the experiment was interrupted due to some company policy forcing a restart for updates. The last observed score was 9 wins vs 2 losses on Tree_reduction vs master branch (options: -g -v 3201 --noponder -t 1 -q -d -r 0 -w).

I reflect that the current pruning mechanism results in loss of performance near the end of the game, where we have to revisit nodes to re-add pruned children. This is enhanced by the fact that it seems to me we keep entire tree throughout the game. Is that true? It is nice for uses, such as lizzie, to move back and not have to rebuild the tree again, however, for important matches we may need an option to delete the old part of the tree (say -5 moves back or so, allowing at least a couple of takebacks).

Anyway in conclusion this simple change appears to benefit the performance.