### PR TITLE
Adds option to remove virtual loss from get_eval

### DIFF
--- a/src/Training.cpp
+++ b/src/Training.cpp
@@ -163,8 +163,8 @@ void Training::record(GameState& state, UCTNode& root) {
     step.net_winrate = result.winrate;
 
     const auto& best_node = root.get_best_root_child(step.to_move);
-    step.root_uct_winrate = root.get_eval(step.to_move);
-    step.child_uct_winrate = best_node.get_eval(step.to_move);
+    step.root_uct_winrate = root.get_eval(step.to_move, false);
+    step.child_uct_winrate = best_node.get_eval(step.to_move, false);
     step.bestmove_visits = best_node.get_visits();
 
     step.probabilities.resize((BOARD_SQUARES) + 1);

--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -65,7 +65,7 @@ public:
     int get_visits() const;
     float get_score() const;
     void set_score(float score);
-    float get_eval(int tomove) const;
+    float get_eval(int tomove, bool no_VL) const;
     float get_net_eval(int tomove) const;
     void virtual_loss(void);
     void virtual_loss_undo(void);

--- a/src/UCTNodePointer.cpp
+++ b/src/UCTNodePointer.cpp
@@ -84,10 +84,10 @@ bool UCTNodePointer::active() const {
     return true;
 }
 
-float UCTNodePointer::get_eval(int tomove) const {
+float UCTNodePointer::get_eval(int tomove, bool no_VL) const {
     // this can only be called if it is an inflated pointer
     assert(is_inflated());
-    return read_ptr()->get_eval(tomove);
+    return read_ptr()->get_eval(tomove, false);
 }
 
 int UCTNodePointer::get_move() const {

--- a/src/UCTNodePointer.h
+++ b/src/UCTNodePointer.h
@@ -109,7 +109,7 @@ public:
     bool active() const;
     int get_move() const;
     // this can only be called if it is an inflated pointer
-    float get_eval(int tomove) const;
+    float get_eval(int tomove, bool no_VL) const;
 };
 
 #endif

--- a/src/UCTNodeRoot.cpp
+++ b/src/UCTNodeRoot.cpp
@@ -186,7 +186,7 @@ void UCTNode::prepare_root_node(int color,
         create_children(nodes, root_state, root_eval);
     }
     if (had_children) {
-        root_eval = get_eval(color);
+        root_eval = get_eval(color, false);
     } else {
         update(root_eval);
         root_eval = (color == FastBoard::BLACK ? root_eval : 1.0f - root_eval);

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -228,7 +228,7 @@ void UCTSearch::dump_stats(FastState & state, UCTNode & parent) {
         myprintf("%4s -> %7d (V: %5.2f%%) (N: %5.2f%%) PV: %s\n",
             move.c_str(),
             node->get_visits(),
-            node->get_visits() ? node->get_eval(color)*100.0f : 0.0f,
+            node->get_visits() ? node->get_eval(color, true)*100.0f : 0.0f,
             node->get_score() * 100.0f,
             pv.c_str());
     }
@@ -343,7 +343,7 @@ int UCTSearch::get_best_move(passflag_t passflag) {
     assert(first_child != nullptr);
 
     auto bestmove = first_child->get_move();
-    auto bestscore = first_child->get_eval(color);
+    auto bestscore = first_child->get_eval(color, false);
 
     // do we want to fiddle with the best move because of the rule set?
     if (passflag & UCTSearch::NOPASS) {
@@ -357,7 +357,7 @@ int UCTSearch::get_best_move(passflag_t passflag) {
                 if (nopass->first_visit()) {
                     bestscore = 1.0f;
                 } else {
-                    bestscore = nopass->get_eval(color);
+                    bestscore = nopass->get_eval(color, false);
                 }
             } else {
                 myprintf("Pass is the only acceptable move.\n");
@@ -397,7 +397,7 @@ int UCTSearch::get_best_move(passflag_t passflag) {
                     if (nopass->first_visit()) {
                         bestscore = 1.0f;
                     } else {
-                        bestscore = nopass->get_eval(color);
+                        bestscore = nopass->get_eval(color, false);
                     }
                 } else {
                     myprintf("No alternative to passing.\n");
@@ -465,7 +465,7 @@ void UCTSearch::dump_analysis(int playouts) {
     int color = tempstate.board.get_to_move();
 
     std::string pvstring = get_pv(tempstate, *m_root);
-    float winrate = 100.0f * m_root->get_eval(color);
+    float winrate = 100.0f * m_root->get_eval(color, true);
     myprintf("Playouts: %d, Win: %5.2f%%, PV: %s\n",
              playouts, winrate, pvstring.c_str());
 }


### PR DESCRIPTION
Adds a boolean option to get_eval to not include virtual losses in the position evaluation, for the purpose of getting correct dump_stats in command line use, and for runtime position evaluation, i.e. Lizzie support.