### PR TITLE
Mutex tts

### DIFF
--- a/src/SMP.cpp
+++ b/src/SMP.cpp
@@ -32,7 +32,10 @@ SMP::Lock::Lock(Mutex & m) {
 
 void SMP::Lock::lock() {
     assert(!m_owns_lock);
-    while (m_mutex->m_lock.exchange(true, std::memory_order_acquire) == true);
+    // Test and Test-and-Set reduces memory contention
+    do {
+      while (m_mutex->m_lock);
+    } while (m_mutex->m_lock.exchange(true, std::memory_order_acquire) == true);
     m_owns_lock = true;
 }
 


### PR DESCRIPTION
This pull request changes the mutex from TS to TTS behavior.  This addresses one of https://github.com/gcp/leela-zero/issues/1431

From the Wikipedia page on Test and Test-and-Set:

> In computer science, the test-and-set CPU instruction is used to implement mutual exclusion in multiprocessor environments. Although a correct lock can be implemented with test-and-set, it can lead to resource contention in a busy lock (caused by bus locking and cache invalidation when test-and-set operation needs to access memory atomically).
> 
> To lower the overhead a more elaborate locking protocol test and test-and-set is used. The main idea is not to spin in test-and-set but increase the likelihood of successful test-and-set by using the following entry protocol to the lock:

```
boolean locked := false // shared lock variable
procedure EnterCritical() {
  do {
    while (locked == true) skip // spin until lock seems free
  } while TestAndSet(locked) // actual atomic locking
}
```

And from the page on test-and-set:

> The four major evaluation metrics for locks in general are uncontended lock-acquisition latency, bus traffic, fairness, and storage.[7]
> 
> Test-and-set scores low on two of them, namely, high bus traffic and unfairness.
> 
> When processor P1 has obtained a lock and processor P2 is also waiting for the lock, P2 will keep incurring bus transactions in attempts to acquire the lock. When a processor has obtained a lock, all other processors which also wish to obtain the same lock keep trying to obtain the lock by initiating bus transactions repeatedly until they get hold of the lock. This increases the bus traffic requirement of test-and-set significantly. This slows down all other traffic from cache and coherence misses. It slows down the overall section, since the traffic is saturated by failed lock acquisition attempts. Test-and-test-and-set is an improvement over TSL since it does not initiate lock acquisition requests continuously.
> 
> When we consider fairness, we consider if a processor gets a fair chance of acquiring the lock when it is set free. In an extreme situation the processor might starve i.e. it might not be able to acquire the lock for an extended period of time even though it has become free during that time.
> 
> Storage overhead for TSL is next to nothing since only one lock is required. Uncontended latency is also low since only one atomic instruction and branch are needed.