### PR TITLE
[Experimental] enhance tree search in low winrate situations

### DIFF
--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -274,7 +274,7 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
     if (!is_root || !cfg_noise) {
         fpu_reduction = cfg_fpu_reduction * std::sqrt(total_visited_policy) * pure_eval / 0.5;
     }
-    // Estimated eval for unknown nodes = original parent NN eval - reduction
+    // Estimated eval for unknown nodes = current parent winrate - reduction
     auto fpu_eval = pure_eval - fpu_reduction;
 
     auto best = static_cast<UCTNodePointer*>(nullptr);

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -75,6 +75,7 @@ bool UCTNode::create_children(std::atomic<int>& nodecount,
     }
     // We'll be the one queueing this node for expansion, stop others
     m_is_expanding = true;
+    lock.unlock();
 
     const auto raw_netlist = Network::get_scored_moves(
         &state, Network::Ensemble::RANDOM_SYMMETRY);
@@ -87,7 +88,6 @@ bool UCTNode::create_children(std::atomic<int>& nodecount,
         m_net_eval = 1.0f - m_net_eval;
     }
     update(m_net_eval);
-    lock.unlock();
     eval = m_net_eval;
 
     std::vector<Network::ScoreVertexPair> nodelist;

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -269,11 +269,13 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
     // Lower the expected eval for moves that are likely not the best.
     // Do not do this if we have introduced noise at this node exactly
     // to explore more.
+    
+    auto pure_eval = get_pure_eval(color); 
     if (!is_root || !cfg_noise) {
-        fpu_reduction = cfg_fpu_reduction * std::sqrt(total_visited_policy);
+        fpu_reduction = cfg_fpu_reduction * std::sqrt(total_visited_policy) * pure_eval / 0.5;
     }
     // Estimated eval for unknown nodes = original parent NN eval - reduction
-    auto fpu_eval = get_net_eval(color) - fpu_reduction;
+    auto fpu_eval = pure_eval - fpu_reduction;
 
     auto best = static_cast<UCTNodePointer*>(nullptr);
     auto best_value = std::numeric_limits<double>::lowest();
@@ -289,7 +291,7 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
         }
         auto psa = child.get_score();
         auto denom = 1.0 + child.get_visits();
-        auto puct = cfg_puct * psa * (numerator / denom);
+        auto puct = cfg_puct * psa * (numerator / denom) * pure_eval / 0.5;
         auto value = winrate + puct;
         assert(value > std::numeric_limits<double>::lowest());
 

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -75,7 +75,6 @@ bool UCTNode::create_children(std::atomic<int>& nodecount,
     }
     // We'll be the one queueing this node for expansion, stop others
     m_is_expanding = true;
-    lock.unlock();
 
     const auto raw_netlist = Network::get_scored_moves(
         &state, Network::Ensemble::RANDOM_SYMMETRY);
@@ -87,6 +86,8 @@ bool UCTNode::create_children(std::atomic<int>& nodecount,
     if (state.board.white_to_move()) {
         m_net_eval = 1.0f - m_net_eval;
     }
+    update(m_net_eval);
+    lock.unlock();
     eval = m_net_eval;
 
     std::vector<Network::ScoreVertexPair> nodelist;

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -168,6 +168,7 @@ SearchResult UCTSearch::play_simulation(GameState & currstate,
         if (currstate.get_passes() >= 2) {
             auto score = currstate.final_score();
             result = SearchResult::from_score(score);
+            node->update(result.eval());
         } else if (m_nodes < MAX_TREE_SIZE) {
             float eval;
             const auto had_children = node->has_children();
@@ -189,12 +190,13 @@ SearchResult UCTSearch::play_simulation(GameState & currstate,
             next->invalidate();
         } else {
             result = play_simulation(currstate, next);
+            if (result.valid()) {
+                node->update(result.eval());
+            }
         }
     }
 
-    if (result.valid()) {
-        node->update(result.eval());
-    }
+
     node->virtual_loss_undo();
 
     return result;


### PR DESCRIPTION
Idea: use the existing NN (without additional training) more effectively in low winrate situations by modifying the tree search. 

#### 1. make c_puct proportional to winrate
When winrate is low, Makes tree search more sensitive to slight change in winrate and not so sensitive to policy prior. Potentially benefits handicapped play; getting from 0.1% to 1% would be a big deal. (Note that the opponent has high (close to 100%) winrate so c_puct on his/her turn is twice as usual (~50% winrate).) fpu reduction is also made proportional to winrate though I'm not sure whether this is the right thing to do.

Suggested way of testing: 
+ match /next with higher playouts against /next with lower playouts but with handicap stones (using the same network)
+ match my patch with higher playouts against /next with lower playouts but with handicap stones
+ compare to see if my patch fares better
+ **added**: when matched against /next with equal playouts in even games, the performance should not be worse; it's designed to work exactly the same way when winrate is 50%

I'll test myself when I manage to compile. ~~I tried to build in VS2015 through university's cloud service but keep getting 
` fatal error C1033: cannot open program database '\\Client\G$\leela-zero-next\msvc\VS2015\x64\Debug\vc140.idb' `~~ (moving files to local storage on the cloud fixed it)

#### 2. simulate a weaker opponent in tree search by effectively reducing playouts (work in progress)

When backing up the winrate of a newly expanded node to its ancestors, ignore the opponent's moves with a certain probability (depending on current winrate). More precisely, the Q-value of the opponent's last move will be updated with say 90% probability, the second-to-last move with 81% probability, the third-to-last 72.9%, and so on. (Namely the backup process has a 10% chance of terminating at each of the opponent's moves.) The probability should depend on the winrate (~~of that node or~~of the root node) or the strength difference with the actual opponent, but I haven't come up with a formula. I think I need to add ~~an argument (whether it's the opponent's turn) and~~ (let's only do partial backup for white since white is the weaker side in normal handicap games) an output (whether backup has terminated) to `play_simulation` to achieve what I want; I'll do it ~~tomorrow~~ later.