### PR TITLE
WIP: Fix imprecision when winrate is extreme

### DIFF
--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -970,8 +970,8 @@ Network::Netresult Network::get_scored_moves_internal(
     const auto winrate_out =
         innerproduct<256, 1, false>(winrate_data, ip2_val_w, ip2_val_b);
 
-    // Sigmoid
-    const auto winrate_sig = (1.0f + std::tanh(winrate_out[0])) / 2.0f;
+    // Sigmoid: tanh normalized to take value in (0,1)
+    const auto winrate_sig = 1.0f / (1.0f + std::exp(-2.0f * winrate_out[0]));
 
     Netresult result;
 


### PR DESCRIPTION
https://github.com/gcp/leela-zero/blob/c822e5e9623e796fb6dd87e7d8b587a31401ad40/src/Network.cpp#L974

When winrate is close to 0, adding 1 to it destroys precision and potentially hinder the effectiveness of MCTS. The first commit replaces the above by an equivalent but more direct and accurate formula.

With 3 passes in the opening, the imprecision is already very severe:
<details><summary>Commands</summary>
```
leelaz -t 1 -w 90560d926216c9842add40913a023fd59fde761a64014c48d8246648ddd272a3.gz -s 3836721493350202251
playmove b pass
playmove w q16
playmove b pass
playmove w d4
playmove b pass
playmove w q4
genmove b
```
</details>

before the commit: NN eval=0.000000178813934326171875 = 3 x 2^-24
after the commit: NN eval=0.0000001838196084236187743954360485076904296875 = 12935155 x 2^-46

The relative error (2.7%) isn't large, but if the winrate can only take a limited number of values it makes tree search unable to discern better moves.
With 4 passes the eval before commit is identically 0, and the tree search probably can only select children based on policy.

----
This is only a partial fix; winrate close to 1 will always be problematic by design of floating numbers, unless represented internally by 1-x. It also does not directly helps handicapped play: since the handicap stones are normally black, white has low winrate, but we currently only keeps m_blackeval internally and base all Q-value calculations on it, and we do 1-x to get white winrate which again destroys precision.

To remedy black/white disparity, my suggestion is to introduce m_whiteeval and backup both blackeval and whiteeval; when selecting child, we use the color that makes parent get_pure_b/w_eval <= 0.5. @gcp What do you think? Maybe we turn on whiteeval only in handicap games...

----
Note that 3 passes lead to ~2^-23 winrate and single precision number (which I assume we are using) can get as low as [2^-149](https://en.wikipedia.org/wiki/IEEE_754-1985#Single_precision) so we are probably safe with (arbitrarily placed) 9-stone handicap (8 passes). I'll do some tests using LZ and ELF networks to find out. For winrate out of range we may want to use winrate_out[0] directly and double precision etc.

By the way, does anyone has an explanation why ELF 4-stone value prior is higher than LZ? (See https://github.com/gcp/leela-zero/issues/1405#issuecomment-389029467)