### PR TITLE
Continue searching deeper on cache hit

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -30,6 +30,7 @@
 #include <memory>
 #include <random>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include "FastBoard.h"
@@ -577,21 +578,22 @@ bool GTP::execute(GameState & game, std::string xinput) {
         cmdstream >> symmetry;
 
         Network::Netresult vec;
+        bool cache_hit;
         if (cmdstream.fail()) {
             // Default = DIRECT with no rotation
-            vec = Network::get_scored_moves(
+            std::tie(vec, cache_hit) = Network::get_scored_moves(
                 &game, Network::Ensemble::DIRECT, 0, true);
         } else if (symmetry == "all") {
-            for (auto r = 0; r < 8; r++) {
-                vec = Network::get_scored_moves(
-                    &game, Network::Ensemble::DIRECT, r, true);
+            for (auto sym = 0; sym < 8; sym++) {
+                std::tie(vec, cache_hit) = Network::get_scored_moves(
+                    &game, Network::Ensemble::DIRECT, sym, true);
                 Network::show_heatmap(&game, vec, false);
             }
         } else if (symmetry == "average" || symmetry == "avg") {
-            vec = Network::get_scored_moves(
+            std::tie(vec, cache_hit) = Network::get_scored_moves(
                 &game, Network::Ensemble::AVERAGE, 8, true);
         } else {
-            vec = Network::get_scored_moves(
+            std::tie(vec, cache_hit) = Network::get_scored_moves(
                 &game, Network::Ensemble::DIRECT, std::stoi(symmetry), true);
         }
 

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -30,7 +30,6 @@
 #include <memory>
 #include <random>
 #include <string>
-#include <tuple>
 #include <vector>
 
 #include "FastBoard.h"
@@ -577,28 +576,27 @@ bool GTP::execute(GameState & game, std::string xinput) {
         cmdstream >> tmp;   // eat heatmap
         cmdstream >> symmetry;
 
-        Network::Netresult vec;
-        bool cache_hit;
+        Network::Netresult net_res;
         if (cmdstream.fail()) {
             // Default = DIRECT with no rotation
-            std::tie(vec, cache_hit) = Network::get_scored_moves(
+            net_res = Network::get_scored_moves(
                 &game, Network::Ensemble::DIRECT, 0, true);
         } else if (symmetry == "all") {
             for (auto sym = 0; sym < 8; sym++) {
-                std::tie(vec, cache_hit) = Network::get_scored_moves(
+                net_res = Network::get_scored_moves(
                     &game, Network::Ensemble::DIRECT, sym, true);
-                Network::show_heatmap(&game, vec, false);
+                Network::show_heatmap(&game, net_res, false);
             }
         } else if (symmetry == "average" || symmetry == "avg") {
-            std::tie(vec, cache_hit) = Network::get_scored_moves(
+            net_res = Network::get_scored_moves(
                 &game, Network::Ensemble::AVERAGE, 8, true);
         } else {
-            std::tie(vec, cache_hit) = Network::get_scored_moves(
+            net_res = Network::get_scored_moves(
                 &game, Network::Ensemble::DIRECT, std::stoi(symmetry), true);
         }
 
         if (symmetry != "all") {
-            Network::show_heatmap(&game, vec, false);
+            Network::show_heatmap(&game, net_res, false);
         }
 
         gtp_printf(id, "");

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -870,18 +870,18 @@ std::vector<float> softmax(const std::vector<float>& input,
     return output;
 }
 
-Network::Netresult Network::get_scored_moves(
+std::pair<Network::Netresult, bool> Network::get_scored_moves(
     const GameState* const state, const Ensemble ensemble,
     const int symmetry, const bool skip_cache) {
     Netresult result;
     if (state->board.get_boardsize() != BOARD_SIZE) {
-        return result;
+        return std::make_pair(result, false);
     }
 
     if (!skip_cache) {
         // See if we already have this in the cache.
         if (NNCache::get_NNCache().lookup(state->board.get_hash(), result)) {
-            return result;
+            return std::make_pair(result, true);
         }
     }
 
@@ -915,7 +915,7 @@ Network::Netresult Network::get_scored_moves(
     // Insert result into cache.
     NNCache::get_NNCache().insert(state->board.get_hash(), result);
 
-    return result;
+    return std::make_pair(result, false);
 }
 
 Network::Netresult Network::get_scored_moves_internal(

--- a/src/Network.h
+++ b/src/Network.h
@@ -51,10 +51,9 @@ public:
         Netresult() : policy(BOARD_SQUARES), policy_pass(0.0f), winrate(0.0f) {}
     };
 
-    static Netresult get_scored_moves(const GameState* const state,
-                                      const Ensemble ensemble,
-                                      const int symmetry = -1,
-                                      const bool skip_cache = false);
+    static std::pair<Netresult, bool> get_scored_moves(
+        const GameState* const state, const Ensemble ensemble,
+        const int symmetry = -1, const bool skip_cache = false);
 
     static constexpr auto INPUT_MOVES = 8;
     static constexpr auto INPUT_CHANNELS = 2 * INPUT_MOVES + 2;

--- a/src/Network.h
+++ b/src/Network.h
@@ -41,19 +41,18 @@ public:
     struct Netresult {
         // 19x19 board positions
         std::vector<float> policy;
-
-        // pass
         float policy_pass;
-
-        // winrate
         float winrate;
+        bool cache_hit;
 
-        Netresult() : policy(BOARD_SQUARES), policy_pass(0.0f), winrate(0.0f) {}
+        Netresult() : policy(BOARD_SQUARES), policy_pass(0.0f), 
+                      winrate(0.0f), cache_hit(false) {}
     };
 
-    static std::pair<Netresult, bool> get_scored_moves(
+    static Netresult get_scored_moves(
         const GameState* const state, const Ensemble ensemble,
-        const int symmetry = -1, const bool skip_cache = false);
+        const int symmetry = -1, const bool skip_cache = false, 
+        const bool stop_on_cache_miss = false);
 
     static constexpr auto INPUT_MOVES = 8;
     static constexpr auto INPUT_CHANNELS = 2 * INPUT_MOVES + 2;

--- a/src/Training.cpp
+++ b/src/Training.cpp
@@ -27,7 +27,6 @@
 #include <memory>
 #include <sstream>
 #include <stdexcept>
-#include <tuple>
 #include <utility>
 
 #include "FastBoard.h"
@@ -161,7 +160,7 @@ void Training::record(GameState& state, UCTNode& root) {
 
     auto result =
         Network::get_scored_moves(&state, Network::Ensemble::DIRECT, 0);
-    step.net_winrate = result.first.winrate;
+    step.net_winrate = result.winrate;
 
     const auto& best_node = root.get_best_root_child(step.to_move);
     step.root_uct_winrate = root.get_eval(step.to_move);

--- a/src/Training.cpp
+++ b/src/Training.cpp
@@ -27,6 +27,7 @@
 #include <memory>
 #include <sstream>
 #include <stdexcept>
+#include <tuple>
 #include <utility>
 
 #include "FastBoard.h"
@@ -160,7 +161,7 @@ void Training::record(GameState& state, UCTNode& root) {
 
     auto result =
         Network::get_scored_moves(&state, Network::Ensemble::DIRECT, 0);
-    step.net_winrate = result.winrate;
+    step.net_winrate = result.first.winrate;
 
     const auto& best_node = root.get_best_root_child(step.to_move);
     step.root_uct_winrate = root.get_eval(step.to_move);

--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -43,9 +43,18 @@ public:
     UCTNode() = delete;
     ~UCTNode() = default;
 
-    std::pair<bool, bool> create_children(
-        std::atomic<int>& nodecount, GameState& state, 
-        float& eval, float min_psa_ratio = 0.0f);
+    enum CreateChildrenResult {
+        FAIL_NOT_EXPANDABLE,
+        FAIL_FINAL_STATE,
+        FAIL_EXPANDING,
+        FAIL_CACHE_MISS,
+        SUCCESS_CACHE_HIT,
+        SUCCESS_EXPANDED
+    };
+    CreateChildrenResult create_children(
+        std::atomic<int>& nodecount, GameState& state,
+        float& eval, float min_psa_ratio = 0.0f,
+        const bool stop_on_cache_miss = false);
 
     const std::vector<UCTNodePointer>& get_children() const;
     void sort_children(int color);

--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -43,9 +43,9 @@ public:
     UCTNode() = delete;
     ~UCTNode() = default;
 
-    bool create_children(std::atomic<int>& nodecount,
-                         GameState& state, float& eval,
-                         float min_psa_ratio = 0.0f);
+    std::pair<bool, bool> create_children(
+        std::atomic<int>& nodecount, GameState& state, 
+        float& eval, float min_psa_ratio = 0.0f);
 
     const std::vector<UCTNodePointer>& get_children() const;
     void sort_children(int color);

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -189,9 +189,11 @@ float UCTSearch::get_min_psa_ratio() const {
 }
 
 SearchResult UCTSearch::play_simulation(GameState & currstate,
-                                        UCTNode* const node) {
+                                        UCTNode* const node,
+                                        const bool stop_on_cache_miss) {
     const auto color = currstate.get_to_move();
     auto result = SearchResult{};
+    auto cache_hit = false;
 
     node->virtual_loss();
 
@@ -202,24 +204,39 @@ SearchResult UCTSearch::play_simulation(GameState & currstate,
         } else if (m_nodes < MAX_TREE_SIZE) {
             float eval;
             const auto had_children = node->has_children();
-            const auto success =
+            const auto res =
                 node->create_children(m_nodes, currstate, eval,
-                                      get_min_psa_ratio());
-            if (!had_children && success.first && !success.second) {
-                result = SearchResult::from_eval(eval);
+                                      get_min_psa_ratio(),
+                                      stop_on_cache_miss);
+            cache_hit = 
+                res == UCTNode::CreateChildrenResult::SUCCESS_CACHE_HIT;
+
+            if (!had_children) {
+                if (cache_hit
+                    || res == UCTNode::CreateChildrenResult::SUCCESS_EXPANDED) {
+                    result = SearchResult::from_eval(eval);
+                } else if (stop_on_cache_miss
+                    && res == UCTNode::CreateChildrenResult::FAIL_CACHE_MISS) {
+                    result = SearchResult::from_cache_miss();
+                }
             }
         }
     }
 
-    if (node->has_children() && !result.valid()) {
+    if (node->has_children()
+        && ((!result.valid() && !result.fail_cache_miss()) || cache_hit)) {
         auto next = node->uct_select_child(color, node == m_root.get());
         auto move = next->get_move();
 
         currstate.play_move(move);
         if (move != FastBoard::PASS && currstate.superko()) {
             next->invalidate();
+            result = SearchResult{};
         } else {
-            result = play_simulation(currstate, next);
+            auto next_result = play_simulation(currstate, next, cache_hit);
+            if (!next_result.fail_cache_miss()) {
+                result = next_result;
+            }
         }
     }
 

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -205,7 +205,7 @@ SearchResult UCTSearch::play_simulation(GameState & currstate,
             const auto success =
                 node->create_children(m_nodes, currstate, eval,
                                       get_min_psa_ratio());
-            if (!had_children && success) {
+            if (!had_children && success.first && !success.second) {
                 result = SearchResult::from_eval(eval);
             }
         }


### PR DESCRIPTION
The basic idea here was to keep on searching (calling `UCTSearch::play_simulation()`) whenever there is a NNCache hit. My aim was to allow the search to best make use of looking up previous network evaluations of transpositions so it can better decide how to spend the remaining playouts. This mainly came about because I realised that by using T= 1 for self-play we will now be probably getting more cache hits whenever a node with lower visits is played, but I digress..

My first attempt continued until there was a new network evaluation but that obviously removes the time saving of using the NNCache in the first place. So I modified it to stop the cache hit chain playout on a cache miss but without performing the network evaluation and instead, return the result up from the last cache hit. Here's my initial testing results:

Fixed 800 visits with self-play settings:
`validation.exe -b leelaz_next -o "-g -v 800 --noponder -t 1 -q -d -r 5 -m 999 -n -w" -n a39b64cc -b leelaz_no_stop -o "-g -v 800 --noponder -t 1 -q -d -r 5 -m 999 -n -w" -n a39b64cc`
```
              wins        black       white
a39b64cc  108 46.15%   48 45.71%   60 46.51%
a39b64cc  126 53.85%   57 54.29%   69 53.49%
                      105 44.87%  129 55.13%
```
Fixed 800 visits with match settings:
`validation.exe -b leelaz_next -o "-g -v 800 --noponder -t 1 -q -d -r 5 -w" -n a39b64cc  -b leelaz_no_stop2 -o "-g -v 800 --noponder -t 1 -q -d -r 5 -w" -n a39b64cc  `
```
              wins        black       white
a39b64cc   87 44.85%   34 43.59%   53 45.69%
a39b64cc  107 55.15%   44 56.41%   63 54.31%
                       78 40.21%  116 59.79%
```
Fixed time with match settings (using #1459 and note that with only 10 mins my machine can't do loads of visits but I would estimate ~500-800 from how long the moves took):
`validation_ts.exe -b leelaz_next -o "-g --noponder -t 1 -q -d -r 5 -w" -n a39b64cc  --ts "600 0 0" -b leelaz_no_stop2 -o "-g --noponder -t 1 -q -d -r 5 -w" -n a39b64cc  --ts "600 0 0"`
```
              wins        black       white
a39b64cc  114 46.53%   46 45.54%   68 47.22%
a39b64cc  131 53.47%   55 54.46%   76 52.78%
                      101 41.22%  144 58.78%
```

So it looks a little better? I can't say exactly how much extra cpu time is used but from what I saw whilst they were running, in some games the changed binary was approaching +10% compared to next and in others it didn't appear to use any extra time.

After I did this I found the discussion in https://github.com/gcp/leela-zero/pull/662 and even that @roy7 [had mentioned](https://github.com/gcp/leela-zero/pull/662#issuecomment-359480316) something that sounds a bit like this. 
Either way, it looks like what I've done is probably going to be controversial. I mean it is naive in that the visit count of nodes along a cache hit chain will all be the same and their parents' visit counts will only think they had 1 visit even though many nodes were (re)discovered. I think the effect of this will be that transpositions will be slightly less likely to be played as they will have to make up for the lack of counted visits (though this will only be the length of the remaining cache hit chain).

So yeah, I'd be interested in hearing some discussion and won't be offended if this isn't merged. I had fun trying out a little idea :)