### PR TITLE
Symmetry cleanup.

### DIFF
--- a/src/FastBoard.h
+++ b/src/FastBoard.h
@@ -72,7 +72,7 @@ public:
     int get_boardsize(void) const;
     square_t get_square(int x, int y) const;
     square_t get_square(int vertex) const ;
-    int get_vertex(int i, int j) const;
+    int get_vertex(int x, int y) const;
     void set_square(int x, int y, square_t content);
     void set_square(int vertex, square_t content);
     std::pair<int, int> get_xy(int vertex) const;

--- a/src/FullBoard.h
+++ b/src/FullBoard.h
@@ -28,22 +28,23 @@ public:
     int remove_string(int i);
     int update_board(const int color, const int i);
 
-    std::uint64_t get_hash(void) const;
-    std::uint64_t get_ko_hash(void) const;
-    std::uint64_t calc_symmetry_hash(int komove = 0, int symmetry = 0) const;
+    std::uint64_t get_hash() const;
+    std::uint64_t get_ko_hash() const;
     void set_to_move(int tomove);
 
     void reset_board(int size);
     void display_board(int lastmove = -1);
 
-    std::uint64_t calc_hash(int komove = 0);
-    std::uint64_t calc_ko_hash(void);
+    std::uint64_t calc_hash(int komove = 0) const;
+    std::uint64_t calc_symmetry_hash(int komove = 0, int symmetry = 0) const;
+    std::uint64_t calc_ko_hash() const;
 
     std::uint64_t m_hash;
     std::uint64_t m_ko_hash;
 
 private:
-    int rotate_vertex(int vertex, int symmetry) const;
+    template<class Function>
+    std::uint64_t calc_hash(int komove, Function transform) const;
 };
 
 #endif

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -578,18 +578,18 @@ bool GTP::execute(GameState & game, std::string xinput) {
 
         Network::Netresult vec;
         if (cmdstream.fail()) {
-            // Default = DIRECT with no rotation
+            // Default = DIRECT with no symmetric change
             vec = Network::get_scored_moves(
                 &game, Network::Ensemble::DIRECT, 0, true);
         } else if (symmetry == "all") {
-            for (auto r = 0; r < 8; r++) {
+            for (auto s = 0; s < Network::NUM_SYMMETRIES; ++s) {
                 vec = Network::get_scored_moves(
-                    &game, Network::Ensemble::DIRECT, r, true);
+                    &game, Network::Ensemble::DIRECT, s, true);
                 Network::show_heatmap(&game, vec, false);
             }
         } else if (symmetry == "average" || symmetry == "avg") {
             vec = Network::get_scored_moves(
-                &game, Network::Ensemble::AVERAGE, 8, true);
+                &game, Network::Ensemble::AVERAGE, Network::NUM_SYMMETRIES, true);
         } else {
             vec = Network::get_scored_moves(
                 &game, Network::Ensemble::DIRECT, std::stoi(symmetry), true);

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -91,7 +91,7 @@ static std::array<float, 1> ip2_val_b;
 static bool value_head_not_stm;
 
 // Symmetry helper
-static std::array<std::array<int, BOARD_SQUARES>, 8> symmetry_nn_idx_table;
+static std::array<std::array<int, BOARD_SQUARES>, Network::NUM_SYMMETRIES> symmetry_nn_idx_table;
 
 void Network::benchmark(const GameState* const state, const int iterations) {
     const auto cpus = cfg_num_threads;
@@ -350,9 +350,11 @@ std::pair<int, int> Network::load_network_file(const std::string& filename) {
 
 void Network::initialize() {
     // Prepare symmetry table
-    for (auto s = 0; s < 8; s++) {
-        for (auto v = 0; v < BOARD_SQUARES; v++) {
-            symmetry_nn_idx_table[s][v] = get_nn_idx_symmetry(v, s);
+    for (auto s = 0; s < NUM_SYMMETRIES; ++s) {
+        for (auto v = 0; v < BOARD_SQUARES; ++v) {
+            const auto newvtx = get_symmetry({v % BOARD_SIZE, v / BOARD_SIZE}, s);
+            symmetry_nn_idx_table[s][v] = (newvtx.second * BOARD_SIZE) + newvtx.first;
+            assert(symmetry_nn_idx_table[s][v] >= 0 && symmetry_nn_idx_table[s][v] < BOARD_SQUARES);
         }
     }
 
@@ -880,7 +882,7 @@ static bool probe_cache(const GameState* const state,
     if (!cfg_noise && !cfg_random_cnt
         && state->get_movenum()
            < (state->get_timecontrol().opening_moves(BOARD_SIZE) / 2)) {
-        for (auto sym = 1; sym < 8; ++sym) {
+        for (auto sym = 1; sym < Network::NUM_SYMMETRIES; ++sym) {
             const auto hash = state->get_symmetry_hash(sym);
             if (NNCache::get_NNCache().lookup(hash, result)) {
                 decltype(result.policy) corrected_policy;
@@ -914,22 +916,22 @@ Network::Netresult Network::get_scored_moves(
     }
 
     if (ensemble == DIRECT) {
-        assert(symmetry >= 0 && symmetry <= 7);
+        assert(symmetry >= 0 && symmetry < NUM_SYMMETRIES);
         result = get_scored_moves_internal(state, symmetry);
     } else if (ensemble == AVERAGE) {
-        for (auto sym = 0; sym < 8; ++sym) {
+        for (auto sym = 0; sym < NUM_SYMMETRIES; ++sym) {
             auto tmpresult = get_scored_moves_internal(state, sym);
-            result.winrate += tmpresult.winrate / 8.0f;
-            result.policy_pass += tmpresult.policy_pass / 8.0f;
+            result.winrate += tmpresult.winrate / static_cast<float>(NUM_SYMMETRIES);
+            result.policy_pass += tmpresult.policy_pass / static_cast<float>(NUM_SYMMETRIES);
 
             for (auto idx = size_t{0}; idx < BOARD_SQUARES; idx++) {
-                result.policy[idx] += tmpresult.policy[idx] / 8.0f;
+                result.policy[idx] += tmpresult.policy[idx] / static_cast<float>(NUM_SYMMETRIES);
             }
         }
     } else {
         assert(ensemble == RANDOM_SYMMETRY);
         assert(symmetry == -1);
-        const auto rand_sym = Random::get_Rng().randfix<8>();
+        const auto rand_sym = Random::get_Rng().randfix<NUM_SYMMETRIES>();
         result = get_scored_moves_internal(state, rand_sym);
     }
 
@@ -948,7 +950,7 @@ Network::Netresult Network::get_scored_moves(
 
 Network::Netresult Network::get_scored_moves_internal(
     const GameState* const state, const int symmetry) {
-    assert(symmetry >= 0 && symmetry <= 7);
+    assert(symmetry >= 0 && symmetry < NUM_SYMMETRIES);
     constexpr auto width = BOARD_SIZE;
     constexpr auto height = BOARD_SIZE;
 
@@ -1088,7 +1090,7 @@ void Network::fill_input_plane_pair(const FullBoard& board,
 
 std::vector<net_t> Network::gather_features(const GameState* const state,
                                             const int symmetry) {
-    assert(symmetry >= 0 && symmetry <= 7);
+    assert(symmetry >= 0 && symmetry < NUM_SYMMETRIES);
     auto input_data = std::vector<net_t>(INPUT_CHANNELS * BOARD_SQUARES);
 
     const auto to_move = state->get_to_move();
@@ -1119,35 +1121,27 @@ std::vector<net_t> Network::gather_features(const GameState* const state,
     return input_data;
 }
 
-int Network::get_nn_idx_symmetry(const int vertex, int symmetry) {
-    assert(vertex >= 0 && vertex < BOARD_SQUARES);
-    assert(symmetry >= 0 && symmetry < 8);
-    auto x = vertex % BOARD_SIZE;
-    auto y = vertex / BOARD_SIZE;
-    int newx;
-    int newy;
+std::pair<int, int> Network::get_symmetry(const std::pair<int, int>& vertex, const int symmetry, const int board_size) {
+    auto x = vertex.first;
+    auto y = vertex.second;
+    assert(x >= 0 && x < board_size);
+    assert(y >= 0 && y < board_size);
+    assert(symmetry >= 0 && symmetry < NUM_SYMMETRIES);
 
-    if (symmetry >= 4) {
+    if ((symmetry & 4) != 0) {
         std::swap(x, y);
-        symmetry -= 4;
     }
 
-    if (symmetry == 0) {
-        newx = x;
-        newy = y;
-    } else if (symmetry == 1) {
-        newx = x;
-        newy = BOARD_SIZE - y - 1;
-    } else if (symmetry == 2) {
-        newx = BOARD_SIZE - x - 1;
-        newy = y;
-    } else {
-        assert(symmetry == 3);
-        newx = BOARD_SIZE - x - 1;
-        newy = BOARD_SIZE - y - 1;
+    if ((symmetry & 2) != 0) {
+        x = board_size - x - 1;
     }
 
-    const auto newvtx = (newy * BOARD_SIZE) + newx;
-    assert(newvtx >= 0 && newvtx < BOARD_SQUARES);
-    return newvtx;
+    if ((symmetry & 1) != 0) {
+        y = board_size - y - 1;
+    }
+
+    assert(x >= 0 && x < board_size);
+    assert(y >= 0 && y < board_size);
+    assert(symmetry != 0 || vertex == std::make_pair(x, y));
+    return {x, y};
 }

--- a/src/Network.h
+++ b/src/Network.h
@@ -33,6 +33,7 @@
 
 class Network {
 public:
+    static constexpr auto NUM_SYMMETRIES = 8;
     enum Ensemble {
         DIRECT, RANDOM_SYMMETRY, AVERAGE
     };
@@ -73,6 +74,9 @@ public:
 
     static std::vector<net_t> gather_features(const GameState* const state,
                                               const int symmetry);
+    static std::pair<int, int> get_symmetry(const std::pair<int, int>& vertex,
+                                            const int symmetry,
+                                            const int board_size = BOARD_SIZE);
 private:
     static std::pair<int, int> load_v1_network(std::istream& wtfile);
     static std::pair<int, int> load_network_file(const std::string& filename);
@@ -99,7 +103,6 @@ private:
     static void winograd_sgemm(const std::vector<float>& U,
                                const std::vector<float>& V,
                                std::vector<float>& M, const int C, const int K);
-    static int get_nn_idx_symmetry(const int vertex, int symmetry);
     static void fill_input_plane_pair(const FullBoard& board,
                                       std::vector<net_t>::iterator black,
                                       std::vector<net_t>::iterator white,


### PR DESCRIPTION
This salvages #1275 mainly to recover the `NUM_SYMMETRIES` constant and get rid of the duplicate symmetry and hash code.