### PR TITLE
Code restructuring part 1 : no globals

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -76,10 +76,11 @@ std::string cfg_options_str;
 bool cfg_benchmark;
 int cfg_analyze_interval_centis;
 
-std::unique_ptr<UCTSearch> GTP::search;
+Network GTP::network;
 
-void GTP::initialize(GameState & gamestate) {
-    search = std::make_unique<UCTSearch>(gamestate, cfg_weightsfile);
+void GTP::initialize() {
+    auto playouts = std::min(cfg_max_playouts, cfg_max_visits);
+    network.initialize(playouts, cfg_weightsfile);
 }
 
 void GTP::setup_default_parameters() {
@@ -192,6 +193,7 @@ std::string GTP::get_life_list(const GameState & game, bool live) {
 
 bool GTP::execute(GameState & game, std::string xinput) {
     std::string input;
+    static auto search = std::make_unique<UCTSearch>(game, network);
 
     bool transform_lowercase = true;
 
@@ -305,7 +307,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
     } else if (command.find("clear_board") == 0) {
         Training::clear_training();
         game.reset_game();
-        search->reset();
+        search = std::make_unique<UCTSearch>(game, network);
         gtp_printf(id, "");
         return true;
     } else if (command.find("komi") == 0) {
@@ -584,19 +586,19 @@ bool GTP::execute(GameState & game, std::string xinput) {
         Network::Netresult vec;
         if (cmdstream.fail()) {
             // Default = DIRECT with no symmetric change
-            vec = search->get_scored_moves(
+            vec = network.get_scored_moves(
                 &game, Network::Ensemble::DIRECT, Network::IDENTITY_SYMMETRY, true);
         } else if (symmetry == "all") {
             for (auto s = 0; s < Network::NUM_SYMMETRIES; ++s) {
-                vec = search->get_scored_moves(
+                vec = network.get_scored_moves(
                     &game, Network::Ensemble::DIRECT, s, true);
                 Network::show_heatmap(&game, vec, false);
             }
         } else if (symmetry == "average" || symmetry == "avg") {
-            vec = search->get_scored_moves(
+            vec = network.get_scored_moves(
                 &game, Network::Ensemble::AVERAGE, Network::NUM_SYMMETRIES, true);
         } else {
-            vec = search->get_scored_moves(
+            vec = network.get_scored_moves(
                 &game, Network::Ensemble::DIRECT, std::stoi(symmetry), true);
         }
 
@@ -630,7 +632,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
         cmdstream >> stones;
 
         if (!cmdstream.fail()) {
-            game.place_free_handicap(stones, search.get());
+            game.place_free_handicap(stones, network);
             auto stonestring = game.board.get_stone_list();
             gtp_printf(id, "%s", stonestring.c_str());
         } else {
@@ -752,9 +754,9 @@ bool GTP::execute(GameState & game, std::string xinput) {
         cmdstream >> iterations;
 
         if (!cmdstream.fail()) {
-            search->benchmark(&game, iterations);
+            network.benchmark(&game, iterations);
         } else {
-            search->benchmark(&game);
+            network.benchmark(&game);
         }
         gtp_printf(id, "");
         return true;

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -76,11 +76,10 @@ std::string cfg_options_str;
 bool cfg_benchmark;
 int cfg_analyze_interval_centis;
 
-Network GTP::network;
+Network * GTP::network = nullptr;
 
-void GTP::initialize() {
-    auto playouts = std::min(cfg_max_playouts, cfg_max_visits);
-    network.initialize(playouts, cfg_weightsfile);
+void GTP::initialize(Network * net) {
+    network = net;
 }
 
 void GTP::setup_default_parameters() {
@@ -193,7 +192,7 @@ std::string GTP::get_life_list(const GameState & game, bool live) {
 
 bool GTP::execute(GameState & game, std::string xinput) {
     std::string input;
-    static auto search = std::make_unique<UCTSearch>(game, network);
+    static auto search = std::make_unique<UCTSearch>(game, *network);
 
     bool transform_lowercase = true;
 
@@ -307,7 +306,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
     } else if (command.find("clear_board") == 0) {
         Training::clear_training();
         game.reset_game();
-        search = std::make_unique<UCTSearch>(game, network);
+        search = std::make_unique<UCTSearch>(game, *network);
         gtp_printf(id, "");
         return true;
     } else if (command.find("komi") == 0) {
@@ -586,19 +585,19 @@ bool GTP::execute(GameState & game, std::string xinput) {
         Network::Netresult vec;
         if (cmdstream.fail()) {
             // Default = DIRECT with no symmetric change
-            vec = network.get_scored_moves(
+            vec = network->get_scored_moves(
                 &game, Network::Ensemble::DIRECT, Network::IDENTITY_SYMMETRY, true);
         } else if (symmetry == "all") {
             for (auto s = 0; s < Network::NUM_SYMMETRIES; ++s) {
-                vec = network.get_scored_moves(
+                vec = network->get_scored_moves(
                     &game, Network::Ensemble::DIRECT, s, true);
                 Network::show_heatmap(&game, vec, false);
             }
         } else if (symmetry == "average" || symmetry == "avg") {
-            vec = network.get_scored_moves(
+            vec = network->get_scored_moves(
                 &game, Network::Ensemble::AVERAGE, Network::NUM_SYMMETRIES, true);
         } else {
-            vec = network.get_scored_moves(
+            vec = network->get_scored_moves(
                 &game, Network::Ensemble::DIRECT, std::stoi(symmetry), true);
         }
 
@@ -632,7 +631,7 @@ bool GTP::execute(GameState & game, std::string xinput) {
         cmdstream >> stones;
 
         if (!cmdstream.fail()) {
-            game.place_free_handicap(stones, network);
+            game.place_free_handicap(stones, *network);
             auto stonestring = game.board.get_stone_list();
             gtp_printf(id, "%s", stonestring.c_str());
         } else {
@@ -754,9 +753,9 @@ bool GTP::execute(GameState & game, std::string xinput) {
         cmdstream >> iterations;
 
         if (!cmdstream.fail()) {
-            network.benchmark(&game, iterations);
+            network->benchmark(&game, iterations);
         } else {
-            network.benchmark(&game);
+            network->benchmark(&game);
         }
         gtp_printf(id, "");
         return true;

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -579,19 +579,19 @@ bool GTP::execute(GameState & game, std::string xinput) {
         Network::Netresult vec;
         if (cmdstream.fail()) {
             // Default = DIRECT with no symmetric change
-            vec = Network::get_scored_moves(
+            vec = g_network.get_scored_moves(
                 &game, Network::Ensemble::DIRECT, 0, true);
         } else if (symmetry == "all") {
             for (auto s = 0; s < Network::NUM_SYMMETRIES; ++s) {
-                vec = Network::get_scored_moves(
+                vec = g_network.get_scored_moves(
                     &game, Network::Ensemble::DIRECT, s, true);
                 Network::show_heatmap(&game, vec, false);
             }
         } else if (symmetry == "average" || symmetry == "avg") {
-            vec = Network::get_scored_moves(
+            vec = g_network.get_scored_moves(
                 &game, Network::Ensemble::AVERAGE, Network::NUM_SYMMETRIES, true);
         } else {
-            vec = Network::get_scored_moves(
+            vec = g_network.get_scored_moves(
                 &game, Network::Ensemble::DIRECT, std::stoi(symmetry), true);
         }
 
@@ -747,9 +747,9 @@ bool GTP::execute(GameState & game, std::string xinput) {
         cmdstream >> iterations;
 
         if (!cmdstream.fail()) {
-            Network::benchmark(&game, iterations);
+            g_network.benchmark(&game, iterations);
         } else {
-            Network::benchmark(&game);
+            g_network.benchmark(&game);
         }
         gtp_printf(id, "");
         return true;

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -76,6 +76,12 @@ std::string cfg_options_str;
 bool cfg_benchmark;
 int cfg_analyze_interval_centis;
 
+std::unique_ptr<UCTSearch> GTP::search;
+
+void GTP::initialize(GameState & gamestate) {
+    search = std::make_unique<UCTSearch>(gamestate, cfg_weightsfile);
+}
+
 void GTP::setup_default_parameters() {
     cfg_gtp_mode = false;
     cfg_allow_pondering = true;
@@ -186,9 +192,6 @@ std::string GTP::get_life_list(const GameState & game, bool live) {
 
 bool GTP::execute(GameState & game, std::string xinput) {
     std::string input;
-
-    // When visits are limited ensure cache size is still limited.
-    static auto search = std::make_unique<UCTSearch>(game, cfg_weightsfile);
 
     bool transform_lowercase = true;
 

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -65,7 +65,10 @@ extern int cfg_analyze_interval_centis;
     GTP is meant to be used between programs. It's not a human interface.
 */
 class GTP {
+
+    static std::unique_ptr<UCTSearch> search;
 public:
+    static void initialize(GameState & gamestate);
     static bool execute(GameState & game, std::string xinput);
     static void setup_default_parameters();
 private:

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -67,8 +67,8 @@ extern int cfg_analyze_interval_centis;
 */
 class GTP {
 public:
-    static Network network;
-    static void initialize();
+    static Network * network;
+    static void initialize(Network * network);
     static bool execute(GameState & game, std::string xinput);
     static void setup_default_parameters();
 private:

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -25,6 +25,7 @@
 #include <string>
 #include <vector>
 
+#include "Network.h"
 #include "GameState.h"
 #include "UCTSearch.h"
 
@@ -65,10 +66,9 @@ extern int cfg_analyze_interval_centis;
     GTP is meant to be used between programs. It's not a human interface.
 */
 class GTP {
-
-    static std::unique_ptr<UCTSearch> search;
 public:
-    static void initialize(GameState & gamestate);
+    static Network network;
+    static void initialize();
     static bool execute(GameState & game, std::string xinput);
     static void setup_default_parameters();
 private:

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -296,7 +296,7 @@ bool GameState::valid_handicap(int handicap) {
     return true;
 }
 
-void GameState::place_free_handicap(int stones) {
+void GameState::place_free_handicap(int stones, UCTSearch * search) {
     int limit = board.get_boardsize() * board.get_boardsize();
     if (stones > limit / 2) {
         stones = limit / 2;
@@ -312,7 +312,6 @@ void GameState::place_free_handicap(int stones) {
     stones -= set_fixed_handicap_2(stones);
 
     for (int i = 0; i < stones; i++) {
-        auto search = std::make_unique<UCTSearch>(*this);
         auto move = search->think(FastBoard::BLACK, UCTSearch::NOPASS);
         play_move(FastBoard::BLACK, move);
     }

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -32,6 +32,7 @@
 #include "FullBoard.h"
 #include "KoState.h"
 #include "UCTSearch.h"
+#include "GTP.h"
 
 void GameState::init_game(int size, float komi) {
     KoState::init_game(size, komi);
@@ -296,7 +297,7 @@ bool GameState::valid_handicap(int handicap) {
     return true;
 }
 
-void GameState::place_free_handicap(int stones, UCTSearch * search) {
+void GameState::place_free_handicap(int stones, Network & network) {
     int limit = board.get_boardsize() * board.get_boardsize();
     if (stones > limit / 2) {
         stones = limit / 2;
@@ -312,6 +313,7 @@ void GameState::place_free_handicap(int stones, UCTSearch * search) {
     stones -= set_fixed_handicap_2(stones);
 
     for (int i = 0; i < stones; i++) {
+        auto search = std::make_unique<UCTSearch>(*this, network);
         auto move = search->think(FastBoard::BLACK, UCTSearch::NOPASS);
         play_move(FastBoard::BLACK, move);
     }

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -17,6 +17,7 @@
 */
 
 #include "GameState.h"
+#include "Network.h"
 
 #include <algorithm>
 #include <array>
@@ -32,7 +33,6 @@
 #include "FullBoard.h"
 #include "KoState.h"
 #include "UCTSearch.h"
-#include "GTP.h"
 
 void GameState::init_game(int size, float komi) {
     KoState::init_game(size, komi);

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -28,6 +28,8 @@
 #include "KoState.h"
 #include "TimeControl.h"
 
+class UCTSearch;
+
 class GameState : public KoState {
 public:
     explicit GameState() = default;
@@ -40,7 +42,7 @@ public:
     void reset_game();
     bool set_fixed_handicap(int stones);
     int set_fixed_handicap_2(int stones);
-    void place_free_handicap(int stones);
+    void place_free_handicap(int stones, UCTSearch * search);
     void anchor_game_history(void);
 
     void rewind(void); /* undo infinite */

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -23,11 +23,12 @@
 #include <string>
 #include <vector>
 
-#include "Network.h"
 #include "FastState.h"
 #include "FullBoard.h"
 #include "KoState.h"
 #include "TimeControl.h"
+
+class Network;
 
 class GameState : public KoState {
 public:

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -23,12 +23,11 @@
 #include <string>
 #include <vector>
 
+#include "Network.h"
 #include "FastState.h"
 #include "FullBoard.h"
 #include "KoState.h"
 #include "TimeControl.h"
-
-class UCTSearch;
 
 class GameState : public KoState {
 public:
@@ -42,7 +41,7 @@ public:
     void reset_game();
     bool set_fixed_handicap(int stones);
     int set_fixed_handicap_2(int stones);
-    void place_free_handicap(int stones, UCTSearch * search);
+    void place_free_handicap(int stones, Network & network);
     void anchor_game_history(void);
 
     void rewind(void); /* undo infinite */

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -353,12 +353,6 @@ void init_global_objects() {
     // Doing this here avoids mixing in the thread_id, which
     // improves reproducibility across platforms.
     Random::get_Rng().seedrandom(cfg_rng_seed);
-
-    // When visits are limited ensure cache size is still limited.
-    auto playouts = std::min(cfg_max_playouts, cfg_max_visits);
-
-    // Initialize network
-    g_network.initialize(playouts, cfg_weightsfile);
 }
 
 void benchmark(GameState& game) {
@@ -366,7 +360,7 @@ void benchmark(GameState& game) {
     game.play_textmove("b", "r16");
     game.play_textmove("w", "d4");
     game.play_textmove("b", "c3");
-    auto search = std::make_unique<UCTSearch>(game);
+    auto search = std::make_unique<UCTSearch>(game, cfg_weightsfile);
     game.set_to_move(FastBoard::WHITE);
     search->think(FastBoard::WHITE);
 }

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -353,6 +353,8 @@ void init_global_objects() {
     // Doing this here avoids mixing in the thread_id, which
     // improves reproducibility across platforms.
     Random::get_Rng().seedrandom(cfg_rng_seed);
+
+    GTP::initialize();
 }
 
 void benchmark(GameState& game) {
@@ -360,7 +362,12 @@ void benchmark(GameState& game) {
     game.play_textmove("b", "r16");
     game.play_textmove("w", "d4");
     game.play_textmove("b", "c3");
-    auto search = std::make_unique<UCTSearch>(game, cfg_weightsfile);
+
+    Network network;
+    auto playouts = std::min(cfg_max_playouts, cfg_max_visits);
+    network.initialize(playouts, cfg_weightsfile);
+
+    auto search = std::make_unique<UCTSearch>(game, network);
     game.set_to_move(FastBoard::WHITE);
     search->think(FastBoard::WHITE);
 }
@@ -401,7 +408,6 @@ int main(int argc, char *argv[]) {
         return 0;
     }
 
-    GTP::initialize(*maingame);
     for (;;) {
         if (!cfg_gtp_mode) {
             maingame->display_state();

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -356,10 +356,9 @@ void init_global_objects() {
 
     // When visits are limited ensure cache size is still limited.
     auto playouts = std::min(cfg_max_playouts, cfg_max_visits);
-    NNCache::get_NNCache().set_size_from_playouts(playouts);
 
     // Initialize network
-    g_network.initialize();
+    g_network.initialize(playouts);
 }
 
 void benchmark(GameState& game) {

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -401,6 +401,7 @@ int main(int argc, char *argv[]) {
         return 0;
     }
 
+    GTP::initialize(*maingame);
     for (;;) {
         if (!cfg_gtp_mode) {
             maingame->display_state();

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -358,7 +358,7 @@ void init_global_objects() {
     auto playouts = std::min(cfg_max_playouts, cfg_max_visits);
 
     // Initialize network
-    g_network.initialize(playouts);
+    g_network.initialize(playouts, cfg_weightsfile);
 }
 
 void benchmark(GameState& game) {

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -341,6 +341,15 @@ static void parse_commandline(int argc, char *argv[]) {
     cfg_options_str = out.str();
 }
 
+static Network network;
+static void initialize_network() {
+    auto playouts = std::min(cfg_max_playouts, cfg_max_visits);
+    network.initialize(playouts, cfg_weightsfile);
+
+    GTP::initialize(&network);
+}
+
+
 // Setup global objects after command line has been parsed
 void init_global_objects() {
     thread_pool.initialize(cfg_num_threads);
@@ -354,7 +363,7 @@ void init_global_objects() {
     // improves reproducibility across platforms.
     Random::get_Rng().seedrandom(cfg_rng_seed);
 
-    GTP::initialize();
+    initialize_network();
 }
 
 void benchmark(GameState& game) {
@@ -362,10 +371,6 @@ void benchmark(GameState& game) {
     game.play_textmove("b", "r16");
     game.play_textmove("w", "d4");
     game.play_textmove("b", "c3");
-
-    Network network;
-    auto playouts = std::min(cfg_max_playouts, cfg_max_visits);
-    network.initialize(playouts, cfg_weightsfile);
 
     auto search = std::make_unique<UCTSearch>(game, network);
     game.set_to_move(FastBoard::WHITE);

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -359,7 +359,7 @@ void init_global_objects() {
     NNCache::get_NNCache().set_size_from_playouts(playouts);
 
     // Initialize network
-    Network::initialize();
+    g_network.initialize();
 }
 
 void benchmark(GameState& game) {

--- a/src/NNCache.cpp
+++ b/src/NNCache.cpp
@@ -18,7 +18,6 @@
 
 #include "config.h"
 #include <functional>
-#include <memory>
 
 #include "NNCache.h"
 #include "Utils.h"

--- a/src/NNCache.cpp
+++ b/src/NNCache.cpp
@@ -18,6 +18,7 @@
 
 #include "config.h"
 #include <functional>
+#include <memory>
 
 #include "NNCache.h"
 #include "Utils.h"
@@ -25,12 +26,7 @@
 
 NNCache::NNCache(int size) : m_size(size) {}
 
-NNCache& NNCache::get_NNCache(void) {
-    static NNCache cache;
-    return cache;
-}
-
-bool NNCache::lookup(std::uint64_t hash, Network::Netresult & result) {
+bool NNCache::lookup(std::uint64_t hash, Netresult & result) {
     std::lock_guard<std::mutex> lock(m_mutex);
     ++m_lookups;
 
@@ -48,7 +44,7 @@ bool NNCache::lookup(std::uint64_t hash, Network::Netresult & result) {
 }
 
 void NNCache::insert(std::uint64_t hash,
-                     const Network::Netresult& result) {
+                     const Netresult& result) {
     std::lock_guard<std::mutex> lock(m_mutex);
 
     if (m_cache.find(hash) != m_cache.end()) {
@@ -84,7 +80,7 @@ void NNCache::set_size_from_playouts(int max_playouts) {
                  UCTSearch::UNLIMITED_PLAYOUTS / num_cache_moves);
     auto max_size = num_cache_moves * max_playouts_per_move;
     max_size = std::min(150'000, std::max(6'000, max_size));
-    NNCache::get_NNCache().resize(max_size);
+    resize(max_size);
 }
 
 void NNCache::dump_stats() {

--- a/src/NNCache.h
+++ b/src/NNCache.h
@@ -22,6 +22,7 @@
 #include "config.h"
 
 #include <deque>
+#include <memory>
 #include <mutex>
 #include <unordered_map>
 #include <vector>

--- a/src/NNCache.h
+++ b/src/NNCache.h
@@ -24,13 +24,24 @@
 #include <deque>
 #include <mutex>
 #include <unordered_map>
-
-#include "Network.h"
+#include <vector>
 
 class NNCache {
 public:
-    // return the global NNCache
-    static NNCache& get_NNCache(void);
+    struct Netresult {
+        // 19x19 board positions
+        std::vector<float> policy;
+
+        // pass
+        float policy_pass;
+
+        // winrate
+        float winrate;
+
+        Netresult() : policy(BOARD_SQUARES), policy_pass(0.0f), winrate(0.0f) {}
+    };
+
+    NNCache(int size = 150000);  // ~ 225MB
 
     // Set a reasonable size gives max number of playouts
     void set_size_from_playouts(int max_playouts);
@@ -39,11 +50,11 @@ public:
     void resize(int size);
 
     // Try and find an existing entry.
-    bool lookup(std::uint64_t hash, Network::Netresult & result);
+    bool lookup(std::uint64_t hash, Netresult & result);
 
     // Insert a new entry.
     void insert(std::uint64_t hash,
-                const Network::Netresult& result);
+                const Netresult& result);
 
     // Return the hit rate ratio.
     std::pair<int, int> hit_rate() const {
@@ -51,9 +62,7 @@ public:
     }
 
     void dump_stats();
-
 private:
-    NNCache(int size = 150000);  // ~ 225MB
 
     std::mutex m_mutex;
 
@@ -65,9 +74,9 @@ private:
     int m_inserts{0};
 
     struct Entry {
-        Entry(const Network::Netresult& r)
+        Entry(const Netresult& r)
             : result(r) {}
-        Network::Netresult result;  // ~ 1.5KB
+        Netresult result;  // ~ 1.5KB
     };
 
     // Map from hash to {features, result}

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -1117,5 +1117,3 @@ std::pair<int, int> Network::get_symmetry(const std::pair<int, int>& vertex, con
     assert(symmetry != 0 || vertex == std::make_pair(x, y));
     return {x, y};
 }
-
-Network g_network;

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -19,7 +19,6 @@
 
 #include "config.h"
 #include "Network.h"
-#include "GameState.h"
 
 #include <algorithm>
 #include <array>

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -101,7 +101,7 @@ void Network::benchmark(const GameState* const state, const int iterations) {
     std::atomic<int> runcount{0};
 
     for (auto i = 0; i < cpus; i++) {
-        tg.add_task([&runcount, iterations, state]() {
+        tg.add_task([this, &runcount, iterations, state]() {
             while (runcount < iterations) {
                 runcount++;
                 get_scored_moves(state, Ensemble::RANDOM_SYMMETRY, -1, true);
@@ -404,9 +404,9 @@ void Network::initialize() {
 
 #ifdef USE_OPENCL
     myprintf("Initializing OpenCL.\n");
-    opencl.initialize(channels);
+    m_opencl.initialize(channels);
 
-    for (const auto & opencl_net : opencl.get_networks()) {
+    for (const auto & opencl_net : m_opencl.get_networks()) {
         const auto tuners = opencl_net->getOpenCL().get_sgemm_tuners();
 
         const auto mwg = tuners[0];
@@ -962,11 +962,11 @@ Network::Netresult Network::get_scored_moves_internal(
 #endif
 #ifdef USE_OPENCL
 #ifdef USE_HALF
-    opencl.forward(input_data, policy_data_n, value_data_n);
+    m_opencl.forward(input_data, policy_data_n, value_data_n);
     std::copy(begin(policy_data_n), end(policy_data_n), begin(policy_data));
     std::copy(begin(value_data_n), end(value_data_n), begin(value_data));
 #else
-    opencl.forward(input_data, policy_data, value_data);
+    m_opencl.forward(input_data, policy_data, value_data);
 #endif
 #elif defined(USE_BLAS) && !defined(USE_OPENCL)
     forward_cpu(input_data, policy_data, value_data);
@@ -1144,3 +1144,5 @@ std::pair<int, int> Network::get_symmetry(const std::pair<int, int>& vertex, con
     assert(symmetry != 0 || vertex == std::make_pair(x, y));
     return {x, y};
 }
+
+Network g_network;

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -320,7 +320,7 @@ std::pair<int, int> Network::load_network_file(const std::string& filename) {
     return {0, 0};
 }
 
-void Network::initialize(int playouts) {
+void Network::initialize(int playouts, const std::string & weightsfile) {
     m_nncache.set_size_from_playouts(playouts);
     // Prepare symmetry table
     for (auto s = 0; s < NUM_SYMMETRIES; ++s) {
@@ -333,7 +333,7 @@ void Network::initialize(int playouts) {
 
     // Load network from file
     size_t channels, residual_blocks;
-    std::tie(channels, residual_blocks) = load_network_file(cfg_weightsfile);
+    std::tie(channels, residual_blocks) = load_network_file(weightsfile);
     if (channels == 0) {
         exit(EXIT_FAILURE);
     }

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -19,6 +19,7 @@
 
 #include "config.h"
 #include "Network.h"
+#include "GameState.h"
 
 #include <algorithm>
 #include <array>

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -62,34 +62,6 @@
 namespace x3 = boost::spirit::x3;
 using namespace Utils;
 
-// Input + residual block tower
-static std::vector<std::vector<float>> conv_weights;
-static std::vector<std::vector<float>> conv_biases;
-static std::vector<std::vector<float>> batchnorm_means;
-static std::vector<std::vector<float>> batchnorm_stddivs;
-
-// Policy head
-static std::vector<float> conv_pol_w;
-static std::vector<float> conv_pol_b;
-static std::array<float, 2> bn_pol_w1;
-static std::array<float, 2> bn_pol_w2;
-
-static std::array<float, (BOARD_SQUARES + 1) * BOARD_SQUARES * 2> ip_pol_w;
-static std::array<float, BOARD_SQUARES + 1> ip_pol_b;
-
-// Value head
-static std::vector<float> conv_val_w;
-static std::vector<float> conv_val_b;
-static std::array<float, 1> bn_val_w1;
-static std::array<float, 1> bn_val_w2;
-
-static std::array<float, BOARD_SQUARES * 256> ip1_val_w;
-static std::array<float, 256> ip1_val_b;
-
-static std::array<float, 256> ip2_val_w;
-static std::array<float, 1> ip2_val_b;
-static bool value_head_not_stm;
-
 // Symmetry helper
 static std::array<std::array<int, BOARD_SQUARES>, Network::NUM_SYMMETRIES> symmetry_nn_idx_table;
 

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -732,7 +732,7 @@ void batchnorm(const size_t channels,
 
 void Network::forward_cpu(const std::vector<float>& input,
                           std::vector<float>& output_pol,
-                          std::vector<float>& output_val) {
+                          std::vector<float>& output_val) const {
     // Input convolution
     constexpr auto width = BOARD_SIZE;
     constexpr auto height = BOARD_SIZE;

--- a/src/Network.h
+++ b/src/Network.h
@@ -79,45 +79,75 @@ public:
                                             const int symmetry,
                                             const int board_size = BOARD_SIZE);
 private:
-    static std::pair<int, int> load_v1_network(std::istream& wtfile);
-    static std::pair<int, int> load_network_file(const std::string& filename);
-    static void process_bn_var(std::vector<float>& weights,
+    std::pair<int, int> load_v1_network(std::istream& wtfile);
+    std::pair<int, int> load_network_file(const std::string& filename);
+    void process_bn_var(std::vector<float>& weights,
                                const float epsilon = 1e-5f);
 
-    static std::vector<float> winograd_transform_f(const std::vector<float>& f,
+    std::vector<float> winograd_transform_f(const std::vector<float>& f,
         const int outputs, const int channels);
-    static std::vector<float> zeropad_U(const std::vector<float>& U,
+    std::vector<float> zeropad_U(const std::vector<float>& U,
         const int outputs, const int channels,
         const int outputs_pad, const int channels_pad);
-    static void winograd_transform_in(const std::vector<float>& in,
+    void winograd_transform_in(const std::vector<float>& in,
                                       std::vector<float>& V,
                                       const int C);
-    static void winograd_transform_out(const std::vector<float>& M,
+    void winograd_transform_out(const std::vector<float>& M,
                                        std::vector<float>& Y,
                                        const int K);
-    static void winograd_convolve3(const int outputs,
+    void winograd_convolve3(const int outputs,
                                    const std::vector<float>& input,
                                    const std::vector<float>& U,
                                    std::vector<float>& V,
                                    std::vector<float>& M,
                                    std::vector<float>& output);
-    static void winograd_sgemm(const std::vector<float>& U,
+    void winograd_sgemm(const std::vector<float>& U,
                                const std::vector<float>& V,
                                std::vector<float>& M, const int C, const int K);
+    Netresult get_scored_moves_internal(const GameState* const state,
+                                               const int symmetry);
+
     static void fill_input_plane_pair(const FullBoard& board,
                                       std::vector<net_t>::iterator black,
                                       std::vector<net_t>::iterator white,
                                       const int symmetry);
-    Netresult get_scored_moves_internal(const GameState* const state,
-                                               const int symmetry);
 #if defined(USE_BLAS)
-    static void forward_cpu(const std::vector<float>& input,
+    void forward_cpu(const std::vector<float>& input,
                             std::vector<float>& output_pol,
                             std::vector<float>& output_val);
 
 #endif
 
     OpenCLScheduler m_opencl;
+    // Input + residual block tower
+    std::vector<std::vector<float>> conv_weights;
+    std::vector<std::vector<float>> conv_biases;
+    std::vector<std::vector<float>> batchnorm_means;
+    std::vector<std::vector<float>> batchnorm_stddivs;
+    
+    // Policy head
+    std::vector<float> conv_pol_w;
+    std::vector<float> conv_pol_b;
+    std::array<float, 2> bn_pol_w1;
+    std::array<float, 2> bn_pol_w2;
+    
+    std::array<float, (BOARD_SQUARES + 1) * BOARD_SQUARES * 2> ip_pol_w;
+    std::array<float, BOARD_SQUARES + 1> ip_pol_b;
+    
+    // Value head
+    std::vector<float> conv_val_w;
+    std::vector<float> conv_val_b;
+    std::array<float, 1> bn_val_w1;
+    std::array<float, 1> bn_val_w2;
+    
+    std::array<float, BOARD_SQUARES * 256> ip1_val_w;
+    std::array<float, 256> ip1_val_b;
+    
+    std::array<float, 256> ip2_val_w;
+    std::array<float, 1> ip2_val_b;
+    bool value_head_not_stm;
+
+
 };
 
 extern Network g_network;

--- a/src/Network.h
+++ b/src/Network.h
@@ -73,27 +73,27 @@ public:
 private:
     std::pair<int, int> load_v1_network(std::istream& wtfile);
     std::pair<int, int> load_network_file(const std::string& filename);
-    void process_bn_var(std::vector<float>& weights,
+    static void process_bn_var(std::vector<float>& weights,
                                const float epsilon = 1e-5f);
 
-    std::vector<float> winograd_transform_f(const std::vector<float>& f,
-        const int outputs, const int channels);
-    std::vector<float> zeropad_U(const std::vector<float>& U,
-        const int outputs, const int channels,
-        const int outputs_pad, const int channels_pad);
-    void winograd_transform_in(const std::vector<float>& in,
+    static std::vector<float> winograd_transform_f(const std::vector<float>& f,
+                                                   const int outputs, const int channels);
+    static std::vector<float> zeropad_U(const std::vector<float>& U,
+                                        const int outputs, const int channels,
+                                        const int outputs_pad, const int channels_pad);
+    static void winograd_transform_in(const std::vector<float>& in,
                                       std::vector<float>& V,
                                       const int C);
-    void winograd_transform_out(const std::vector<float>& M,
+    static void winograd_transform_out(const std::vector<float>& M,
                                        std::vector<float>& Y,
                                        const int K);
-    void winograd_convolve3(const int outputs,
+    static void winograd_convolve3(const int outputs,
                                    const std::vector<float>& input,
                                    const std::vector<float>& U,
                                    std::vector<float>& V,
                                    std::vector<float>& M,
                                    std::vector<float>& output);
-    void winograd_sgemm(const std::vector<float>& U,
+    static void winograd_sgemm(const std::vector<float>& U,
                                const std::vector<float>& V,
                                std::vector<float>& M, const int C, const int K);
     Netresult get_scored_moves_internal(const GameState* const state,

--- a/src/Network.h
+++ b/src/Network.h
@@ -56,7 +56,7 @@ public:
     static constexpr auto WINOGRAD_ALPHA = 4;
     static constexpr auto WINOGRAD_TILE = WINOGRAD_ALPHA * WINOGRAD_ALPHA;
 
-    void initialize(int playouts);
+    void initialize(int playouts, const std::string & weightsfile);
     void benchmark(const GameState * const state,
                           const int iterations = 1600);
     static void show_heatmap(const FastState * const state,

--- a/src/Network.h
+++ b/src/Network.h
@@ -30,10 +30,11 @@
 
 #include "NNCache.h"
 #include "FastState.h"
-#include "GameState.h"
 #ifdef USE_OPENCL
 #include "OpenCLScheduler.h"
 #endif
+
+class GameState;
 
 class Network {
 public:

--- a/src/Network.h
+++ b/src/Network.h
@@ -140,6 +140,4 @@ private:
     std::array<float, 1> ip2_val_b;
     bool value_head_not_stm;
 };
-
-extern Network g_network;
 #endif

--- a/src/Network.h
+++ b/src/Network.h
@@ -31,7 +31,9 @@
 #include "NNCache.h"
 #include "FastState.h"
 #include "GameState.h"
+#ifdef USE_OPENCL
 #include "OpenCLScheduler.h"
+#endif
 
 class Network {
 public:
@@ -110,7 +112,9 @@ private:
 
 #endif
 
+#ifdef USE_OPENCL
     OpenCLScheduler m_opencl;
+#endif
     NNCache m_nncache;
 
     // Input + residual block tower
@@ -118,25 +122,25 @@ private:
     std::vector<std::vector<float>> conv_biases;
     std::vector<std::vector<float>> batchnorm_means;
     std::vector<std::vector<float>> batchnorm_stddivs;
-    
+
     // Policy head
     std::vector<float> conv_pol_w;
     std::vector<float> conv_pol_b;
     std::array<float, 2> bn_pol_w1;
     std::array<float, 2> bn_pol_w2;
-    
+
     std::array<float, (BOARD_SQUARES + 1) * BOARD_SQUARES * 2> ip_pol_w;
     std::array<float, BOARD_SQUARES + 1> ip_pol_b;
-    
+
     // Value head
     std::vector<float> conv_val_w;
     std::vector<float> conv_val_b;
     std::array<float, 1> bn_val_w1;
     std::array<float, 1> bn_val_w2;
-    
+
     std::array<float, BOARD_SQUARES * 256> ip1_val_w;
     std::array<float, 256> ip1_val_b;
-    
+
     std::array<float, 256> ip2_val_w;
     std::array<float, 1> ip2_val_b;
     bool value_head_not_stm;

--- a/src/Network.h
+++ b/src/Network.h
@@ -46,9 +46,9 @@ public:
     using Netresult = NNCache::Netresult;
 
     Netresult get_scored_moves(const GameState* const state,
-                                      const Ensemble ensemble,
-                                      const int symmetry = -1,
-                                      const bool skip_cache = false);
+                               const Ensemble ensemble,
+                               const int symmetry = -1,
+                               const bool skip_cache = false);
 
     static constexpr auto INPUT_MOVES = 8;
     static constexpr auto INPUT_CHANNELS = 2 * INPUT_MOVES + 2;
@@ -61,7 +61,7 @@ public:
 
     void initialize(int playouts, const std::string & weightsfile);
     void benchmark(const GameState * const state,
-                          const int iterations = 1600);
+                   const int iterations = 1600);
     static void show_heatmap(const FastState * const state,
                              const Netresult & netres, const bool topmoves);
 
@@ -97,7 +97,7 @@ private:
                                const std::vector<float>& V,
                                std::vector<float>& M, const int C, const int K);
     Netresult get_scored_moves_internal(const GameState* const state,
-                                               const int symmetry);
+                                        const int symmetry);
 
     static void fill_input_plane_pair(const FullBoard& board,
                                       std::vector<net_t>::iterator black,
@@ -107,8 +107,8 @@ private:
     bool probe_cache(const GameState* const state, Network::Netresult& result);
 #if defined(USE_BLAS)
     void forward_cpu(const std::vector<float>& input,
-                            std::vector<float>& output_pol,
-                            std::vector<float>& output_val);
+                     std::vector<float>& output_pol,
+                     std::vector<float>& output_val) const;
 
 #endif
 

--- a/src/Network.h
+++ b/src/Network.h
@@ -30,6 +30,7 @@
 
 #include "FastState.h"
 #include "GameState.h"
+#include "OpenCLScheduler.h"
 
 class Network {
 public:
@@ -52,7 +53,7 @@ public:
         Netresult() : policy(BOARD_SQUARES), policy_pass(0.0f), winrate(0.0f) {}
     };
 
-    static Netresult get_scored_moves(const GameState* const state,
+    Netresult get_scored_moves(const GameState* const state,
                                       const Ensemble ensemble,
                                       const int symmetry = -1,
                                       const bool skip_cache = false);
@@ -66,8 +67,8 @@ public:
     static constexpr auto WINOGRAD_ALPHA = 4;
     static constexpr auto WINOGRAD_TILE = WINOGRAD_ALPHA * WINOGRAD_ALPHA;
 
-    static void initialize();
-    static void benchmark(const GameState * const state,
+    void initialize();
+    void benchmark(const GameState * const state,
                           const int iterations = 1600);
     static void show_heatmap(const FastState * const state,
                              const Netresult & netres, const bool topmoves);
@@ -107,7 +108,7 @@ private:
                                       std::vector<net_t>::iterator black,
                                       std::vector<net_t>::iterator white,
                                       const int symmetry);
-    static Netresult get_scored_moves_internal(const GameState* const state,
+    Netresult get_scored_moves_internal(const GameState* const state,
                                                const int symmetry);
 #if defined(USE_BLAS)
     static void forward_cpu(const std::vector<float>& input,
@@ -115,6 +116,9 @@ private:
                             std::vector<float>& output_val);
 
 #endif
+
+    OpenCLScheduler m_opencl;
 };
 
+extern Network g_network;
 #endif

--- a/src/Network.h
+++ b/src/Network.h
@@ -33,8 +33,7 @@
 #ifdef USE_OPENCL
 #include "OpenCLScheduler.h"
 #endif
-
-class GameState;
+#include "GameState.h"
 
 class Network {
 public:

--- a/src/OpenCL.cpp
+++ b/src/OpenCL.cpp
@@ -412,7 +412,7 @@ const std::string sourceCode_sgemm =
 ;
 #endif
 
-void OpenCL::ensure_thread_initialized(OpenCLContext &opencl_context) {
+void OpenCL::ensure_context_initialized(OpenCLContext &opencl_context) {
     if (!opencl_context.m_is_initialized) {
         // Make kernels
         opencl_context.m_convolve1_kernel =
@@ -464,7 +464,7 @@ void OpenCL_Network::forward(const std::vector<net_t>& input,
     const auto finalSize_pol = m_layers[m_layers.size()-2].outputs * one_plane;
     const auto finalSize_val = m_layers.back().outputs * one_plane;
 
-    m_opencl.ensure_thread_initialized(opencl_context);
+    m_opencl.ensure_context_initialized(opencl_context);
 
     if (!opencl_context.m_buffers_allocated) {
         auto max_channels = unsigned{0};
@@ -1097,9 +1097,9 @@ void OpenCL::initialize(const int channels, const std::vector<int> & gpus,
         throw std::runtime_error("Error building OpenCL kernels.");
     }
 
-    // dummy gpu number, putting bogus number so that we don't misuse it
-    OpenCLContext tdata(0xffff);
-    ensure_thread_initialized(tdata);
+    // putting bogus number so that we don't misuse it
+    OpenCLContext tdata;
+    ensure_context_initialized(tdata);
 
     process_tuners(sgemm_tuners);
 

--- a/src/OpenCL.cpp
+++ b/src/OpenCL.cpp
@@ -412,24 +412,24 @@ const std::string sourceCode_sgemm =
 ;
 #endif
 
-void OpenCL::ensure_thread_initialized(ThreadData &opencl_thread_data) {
-    if (!opencl_thread_data.m_is_initialized) {
+void OpenCL::ensure_thread_initialized(OpenCLContext &opencl_context) {
+    if (!opencl_context.m_is_initialized) {
         // Make kernels
-        opencl_thread_data.m_convolve1_kernel =
+        opencl_context.m_convolve1_kernel =
             cl::Kernel(m_program, "convolve1");
-        opencl_thread_data.m_merge_kernel =
+        opencl_context.m_merge_kernel =
             cl::Kernel(m_program, "merge");
-        opencl_thread_data.m_in_transform_kernel =
+        opencl_context.m_in_transform_kernel =
             cl::Kernel(m_program, "in_transform");
-        opencl_thread_data.m_sgemm_kernel =
+        opencl_context.m_sgemm_kernel =
             cl::Kernel(m_program, "XgemmBatched");
-        opencl_thread_data.m_out_transform_bn_kernel =
+        opencl_context.m_out_transform_bn_kernel =
             cl::Kernel(m_program, "out_transform_fused_bn");
-        opencl_thread_data.m_out_transform_bn_in_kernel =
+        opencl_context.m_out_transform_bn_in_kernel =
             cl::Kernel(m_program, "out_transform_fused_bn_in");
-        opencl_thread_data.m_commandqueue =
+        opencl_context.m_commandqueue =
             cl::CommandQueue(m_context, m_device);
-        opencl_thread_data.m_is_initialized = true;
+        opencl_context.m_is_initialized = true;
     }
 }
 
@@ -456,7 +456,7 @@ void OpenCL_Network::add_weights(size_t layer,
 void OpenCL_Network::forward(const std::vector<net_t>& input,
                              std::vector<net_t>& output_pol,
                              std::vector<net_t>& output_val,
-                             ThreadData & opencl_thread_data) {
+                             OpenCLContext & opencl_context) {
     constexpr auto width = BOARD_SIZE;
     constexpr auto height = BOARD_SIZE;
     constexpr auto tiles = WINOGRAD_P;
@@ -464,9 +464,9 @@ void OpenCL_Network::forward(const std::vector<net_t>& input,
     const auto finalSize_pol = m_layers[m_layers.size()-2].outputs * one_plane;
     const auto finalSize_val = m_layers.back().outputs * one_plane;
 
-    m_opencl.ensure_thread_initialized(opencl_thread_data);
+    m_opencl.ensure_thread_initialized(opencl_context);
 
-    if (!opencl_thread_data.m_buffers_allocated) {
+    if (!opencl_context.m_buffers_allocated) {
         auto max_channels = unsigned{0};
         for (const auto& layer : m_layers) {
             max_channels = std::max(max_channels,
@@ -488,35 +488,35 @@ void OpenCL_Network::forward(const std::vector<net_t>& input,
 
         auto v_zeros = std::vector<net_t>(alloc_vm_size);
 
-        opencl_thread_data.m_inBuffer = cl::Buffer(
+        opencl_context.m_inBuffer = cl::Buffer(
             m_opencl.m_context,
             CL_MEM_READ_WRITE, alloc_inSize);
-        opencl_thread_data.m_inBuffer2 = cl::Buffer(
+        opencl_context.m_inBuffer2 = cl::Buffer(
             m_opencl.m_context,
             CL_MEM_READ_WRITE, alloc_inSize);
-        opencl_thread_data.m_VBuffer = cl::Buffer(
+        opencl_context.m_VBuffer = cl::Buffer(
             m_opencl.m_context,
             CL_MEM_READ_WRITE | CL_MEM_HOST_NO_ACCESS | CL_MEM_COPY_HOST_PTR,
             alloc_vm_size, v_zeros.data(), nullptr);
-        opencl_thread_data.m_MBuffer = cl::Buffer(
+        opencl_context.m_MBuffer = cl::Buffer(
             m_opencl.m_context,
             CL_MEM_READ_WRITE | CL_MEM_HOST_NO_ACCESS, alloc_vm_size);
 
-        opencl_thread_data.m_pinnedOutBuffer_pol = cl::Buffer(
+        opencl_context.m_pinnedOutBuffer_pol = cl::Buffer(
             m_opencl.m_context,
             CL_MEM_WRITE_ONLY | CL_MEM_ALLOC_HOST_PTR, finalSize_pol);
-        opencl_thread_data.m_pinnedOutBuffer_val = cl::Buffer(
+        opencl_context.m_pinnedOutBuffer_val = cl::Buffer(
             m_opencl.m_context,
             CL_MEM_WRITE_ONLY | CL_MEM_ALLOC_HOST_PTR, finalSize_val);
 
-        opencl_thread_data.m_buffers_allocated = true;
+        opencl_context.m_buffers_allocated = true;
     }
 
-    cl::Buffer & inBuffer = opencl_thread_data.m_inBuffer;
-    cl::Buffer & inBuffer2 = opencl_thread_data.m_inBuffer2;
-    cl::Buffer & VBuffer = opencl_thread_data.m_VBuffer;
-    cl::Buffer & MBuffer = opencl_thread_data.m_MBuffer;
-    cl::CommandQueue & queue = opencl_thread_data.m_commandqueue;
+    cl::Buffer & inBuffer = opencl_context.m_inBuffer;
+    cl::Buffer & inBuffer2 = opencl_context.m_inBuffer2;
+    cl::Buffer & VBuffer = opencl_context.m_VBuffer;
+    cl::Buffer & MBuffer = opencl_context.m_MBuffer;
+    cl::CommandQueue & queue = opencl_context.m_commandqueue;
 
     const auto inSize = sizeof(net_t) * input.size();
     queue.enqueueWriteBuffer(inBuffer, CL_FALSE, 0, inSize, input.data());
@@ -534,7 +534,7 @@ void OpenCL_Network::forward(const std::vector<net_t>& input,
             if (niter->is_residual_block) {
                 skip_next_in_trans = true;
             }
-            convolve3(opencl_thread_data,
+            convolve3(opencl_context,
                      layer.channels,
                      layer.outputs,
                      inBuffer,
@@ -553,7 +553,7 @@ void OpenCL_Network::forward(const std::vector<net_t>& input,
             auto bn1_weights   = begin(layer.weights) + 1;
             auto conv2_weights = begin(layer.weights) + 3;
             auto bn2_weights   = begin(layer.weights) + 4;
-            convolve3(opencl_thread_data,
+            convolve3(opencl_context,
                       layer.channels,
                       layer.outputs,
                       inBuffer,
@@ -569,7 +569,7 @@ void OpenCL_Network::forward(const std::vector<net_t>& input,
             if (niter->is_residual_block) {
                 skip_next_in_trans = true;
             }
-            convolve3(opencl_thread_data,
+            convolve3(opencl_context,
                       layer.channels,
                       layer.outputs,
                       inBuffer2,
@@ -586,12 +586,12 @@ void OpenCL_Network::forward(const std::vector<net_t>& input,
 
             cl::Buffer out_buffer;
             if (niter == cend(m_layers)) {
-                out_buffer = opencl_thread_data.m_pinnedOutBuffer_val;
+                out_buffer = opencl_context.m_pinnedOutBuffer_val;
             } else {
-                out_buffer = opencl_thread_data.m_pinnedOutBuffer_pol;
+                out_buffer = opencl_context.m_pinnedOutBuffer_pol;
             }
 
-            convolve1(opencl_thread_data, layer.channels,
+            convolve1(opencl_context, layer.channels,
                     layer.outputs,
                     inBuffer,
                     out_buffer,
@@ -601,10 +601,10 @@ void OpenCL_Network::forward(const std::vector<net_t>& input,
     }
 
     auto pinnedOutBufferHost_pol = queue.enqueueMapBuffer(
-        opencl_thread_data.m_pinnedOutBuffer_pol, CL_FALSE,
+        opencl_context.m_pinnedOutBuffer_pol, CL_FALSE,
         CL_MAP_READ, 0, finalSize_pol);
     auto pinnedOutBufferHost_val = queue.enqueueMapBuffer(
-        opencl_thread_data.m_pinnedOutBuffer_val, CL_FALSE,
+        opencl_context.m_pinnedOutBuffer_val, CL_FALSE,
         CL_MAP_READ, 0, finalSize_val);
 
     {
@@ -617,14 +617,14 @@ void OpenCL_Network::forward(const std::vector<net_t>& input,
     std::memcpy(output_pol.data(), pinnedOutBufferHost_pol, finalSize_pol);
     std::memcpy(output_val.data(), pinnedOutBufferHost_val, finalSize_val);
 
-    queue.enqueueUnmapMemObject(opencl_thread_data.m_pinnedOutBuffer_pol,
+    queue.enqueueUnmapMemObject(opencl_context.m_pinnedOutBuffer_pol,
             pinnedOutBufferHost_pol);
-    queue.enqueueUnmapMemObject(opencl_thread_data.m_pinnedOutBuffer_val,
+    queue.enqueueUnmapMemObject(opencl_context.m_pinnedOutBuffer_val,
             pinnedOutBufferHost_val);
 
 }
 
-void OpenCL_Network::convolve3(ThreadData & opencl_thread_data,
+void OpenCL_Network::convolve3(OpenCLContext & opencl_context,
                               int channels, int outputs,
                               cl::Buffer& bufferIn,
                               cl::Buffer& bufferOut,
@@ -637,12 +637,12 @@ void OpenCL_Network::convolve3(ThreadData & opencl_thread_data,
                               bool fuse_in_transform,
                               bool store_inout) {
 
-    cl::Kernel & in_transform_kernel = opencl_thread_data.m_in_transform_kernel;
-    cl::Kernel & sgemm_kernel = opencl_thread_data.m_sgemm_kernel;
+    cl::Kernel & in_transform_kernel = opencl_context.m_in_transform_kernel;
+    cl::Kernel & sgemm_kernel = opencl_context.m_sgemm_kernel;
     cl::Kernel & out_transform_bn_kernel =
-        opencl_thread_data.m_out_transform_bn_kernel;
+        opencl_context.m_out_transform_bn_kernel;
     cl::Kernel & out_transform_bn_in_kernel =
-        opencl_thread_data.m_out_transform_bn_in_kernel;
+        opencl_context.m_out_transform_bn_in_kernel;
 
     auto mwg = m_opencl.m_sgemm_tuners.mwg;
     auto nwg = m_opencl.m_sgemm_tuners.nwg;
@@ -671,7 +671,7 @@ void OpenCL_Network::convolve3(ThreadData & opencl_thread_data,
     auto n_ceil = int(ceilMultiple(ceilMultiple(tiles, nwg), vwn));
     auto k_ceil = int(ceilMultiple(ceilMultiple(channels, kwg), vwm));
 
-    cl::CommandQueue & queue = opencl_thread_data.m_commandqueue;
+    cl::CommandQueue & queue = opencl_context.m_commandqueue;
 
     if (!skip_in_transform) {
         try {
@@ -767,7 +767,7 @@ void OpenCL_Network::convolve3(ThreadData & opencl_thread_data,
     }
 }
 
-void OpenCL_Network::convolve1(ThreadData & opencl_thread_data,
+void OpenCL_Network::convolve1(OpenCLContext & opencl_context,
                               int channels, int outputs,
                               cl::Buffer& bufferInput,
                               cl::Buffer& bufferOutput,
@@ -784,7 +784,7 @@ void OpenCL_Network::convolve1(ThreadData & opencl_thread_data,
     constexpr int rowGroup = 1;
     size_t outputGroup = std::min(outputs, 32);
 
-    auto m_convolve_kernel = &opencl_thread_data.m_convolve1_kernel;
+    auto m_convolve_kernel = &opencl_context.m_convolve1_kernel;
 
 #ifndef NDEBUG
     // Total output size after reducing
@@ -801,7 +801,7 @@ void OpenCL_Network::convolve1(ThreadData & opencl_thread_data,
     int rowBuffer = std::min<int>(channelGroup, 7);
     size_t rowSize = channelGroup * outputGroup * rowBuffer * sizeof(float);
 
-    cl::CommandQueue & queue = opencl_thread_data.m_commandqueue;
+    cl::CommandQueue & queue = opencl_context.m_commandqueue;
 
     try {
         m_convolve_kernel->setArg(0, bufferInput);
@@ -819,7 +819,7 @@ void OpenCL_Network::convolve1(ThreadData & opencl_thread_data,
         throw;
     }
 
-    cl::Kernel & merge_kernel = opencl_thread_data.m_merge_kernel;
+    cl::Kernel & merge_kernel = opencl_context.m_merge_kernel;
     assert(channels % (1 << channelShift) == 0);
 
     try {
@@ -1097,7 +1097,8 @@ void OpenCL::initialize(const int channels, const std::vector<int> & gpus,
         throw std::runtime_error("Error building OpenCL kernels.");
     }
 
-    ThreadData tdata;
+    // dummy gpu number, putting bogus number so that we don't misuse it
+    OpenCLContext tdata(0xffff);
     ensure_thread_initialized(tdata);
 
     process_tuners(sgemm_tuners);

--- a/src/OpenCL.h
+++ b/src/OpenCL.h
@@ -36,7 +36,7 @@
 static constexpr auto WINOGRAD_P = (BOARD_SIZE + 1) * (BOARD_SIZE + 1) / 4;
 static constexpr auto WINOGRAD_TILE = 4 * 4;
 
-class OpenCLScheduler;
+// class OpenCLScheduler;
 class OpenCL;
 
 class Layer {
@@ -54,9 +54,7 @@ private:
 class OpenCLContext {
     friend class OpenCL;
     friend class OpenCL_Network;
-    friend class OpenCLScheduler;
 private:
-    size_t m_gpu_num = 0;
     bool m_is_initialized{false};
     cl::CommandQueue m_commandqueue;
     cl::Kernel m_convolve1_kernel;
@@ -72,9 +70,6 @@ private:
     cl::Buffer m_pinnedOutBuffer_pol;
     cl::Buffer m_pinnedOutBuffer_val;
     bool m_buffers_allocated{false};
-public:
-    OpenCLContext(size_t gpu_num) :
-        m_gpu_num(gpu_num) {}
 };
 
 class OpenCL_Network {
@@ -183,7 +178,7 @@ class OpenCL {
 public:
     void initialize(const int channels, const std::vector<int> & gpus,
                     bool silent = false);
-    void ensure_thread_initialized(OpenCLContext & opencl_context);
+    void ensure_context_initialized(OpenCLContext & opencl_context);
     std::string get_device_name();
 
     std::vector<size_t> get_sgemm_tuners(void);

--- a/src/OpenCL.h
+++ b/src/OpenCL.h
@@ -132,7 +132,8 @@ public:
 
     void forward(const std::vector<net_t>& input,
             std::vector<net_t>& output_pol,
-            std::vector<net_t>& output_val);
+            std::vector<net_t>& output_val,
+            ThreadData & opencl_thread_data);
 
 private:
     using weight_slice_t = std::vector<cl::Buffer>::const_iterator;
@@ -142,7 +143,8 @@ private:
     }
     void add_weights(size_t layer, size_t size, const float* weights);
 
-    void convolve3(int channels, int outputs,
+    void convolve3(ThreadData & opencl_thread_data,
+                    int channels, int outputs,
                     cl::Buffer& bufferIn,
                     cl::Buffer& bufferOut,
                     cl::Buffer& bufferV,
@@ -152,7 +154,8 @@ private:
                     bool skip_in_transform,
                     bool fuse_in_transform, bool store_inout);
 
-    void convolve1(int channels, int outputs,
+    void convolve1(ThreadData & opencl_thread_data,
+                  int channels, int outputs,
                   cl::Buffer& bufferInput,
                   cl::Buffer& bufferOutput,
                   cl::Buffer& bufferMerge,
@@ -174,7 +177,7 @@ class OpenCL {
 public:
     void initialize(const int channels, const std::vector<int> & gpus,
                     bool silent = false);
-    void ensure_thread_initialized(void);
+    void ensure_thread_initialized(ThreadData & opencl_thread_data);
     std::string get_device_name();
 
     std::vector<size_t> get_sgemm_tuners(void);
@@ -200,7 +203,6 @@ private:
     bool m_init_ok{false};
 };
 
-extern thread_local ThreadData opencl_thread_data;
 extern const std::string sourceCode_sgemm;
 
 #endif

--- a/src/OpenCLScheduler.cpp
+++ b/src/OpenCLScheduler.cpp
@@ -53,7 +53,7 @@ void OpenCLScheduler::initialize(const int channels) {
         silent = true;
 
         for (auto i = 0; i < num_threads; i++) {
-            m_context[i].push_back(std::make_unique<OpenCLContext>(gnum));
+            m_context[i].emplace_back(new OpenCLContext(gnum));
         }
         gnum++;
     }

--- a/src/OpenCLScheduler.cpp
+++ b/src/OpenCLScheduler.cpp
@@ -22,13 +22,13 @@
 #include "Random.h"
 #include "OpenCLScheduler.h"
 
-thread_local auto current_thread_gpu_num = size_t{0};
 OpenCLScheduler opencl;
 
 void OpenCLScheduler::initialize(const int channels) {
     // multi-gpu?
     if (!cfg_gpus.empty()) {
         auto silent{false};
+        auto gnum = size_t{0};
         for (auto gpu : cfg_gpus) {
             auto opencl = std::make_unique<OpenCL>();
             auto net = std::make_unique<OpenCL_Network>(*opencl);
@@ -36,24 +36,20 @@ void OpenCLScheduler::initialize(const int channels) {
             m_opencl.push_back(std::move(opencl));
             m_networks.push_back(std::move(net));
 
-            // Clear thread data on every init call.  We don't know which GPU
-            // this thread will be eventually be assigned to
-            opencl_thread_data = ThreadData();
-
             // starting next GPU, let's not dump full list of GPUs
             silent = true;
-        }
 
-        for (size_t gnum = 0; gnum < m_networks.size(); gnum++) {
             // launch the worker thread.  2 threads so that we can fully
             // utilize GPU, since the worker thread consists of some CPU
             // work for task preparation.
             constexpr auto num_threads = 2;
             for (auto i = 0; i < num_threads; i++) {
-                m_threadpool.add_thread([gnum] {
-                    current_thread_gpu_num = gnum;
-                });
+                OpenCLContext ctx;
+                ctx.gpu_num = gnum;
+                ctx.opencl_thread_data = std::make_unique<ThreadData>();
+                m_context.push_back(std::move(ctx));
             }
+            gnum++;
         }
     } else {
         auto opencl = std::make_unique<OpenCL>();
@@ -62,21 +58,39 @@ void OpenCLScheduler::initialize(const int channels) {
 
         m_opencl.push_back(std::move(opencl));
         m_networks.push_back(std::move(net));
+    
+        // launch the worker thread.  2 threads so that we can fully
+        // utilize GPU, since the worker thread consists of some CPU
+        // work for task preparation.
+        constexpr auto num_threads = 2;
+        for (auto i = 0; i < num_threads; i++) {
+            OpenCLContext ctx;
+            ctx.gpu_num = 0;
+            ctx.opencl_thread_data = std::make_unique<ThreadData>();
+            m_context.push_back(std::move(ctx));
+        }
     }
 }
 
 void OpenCLScheduler::forward(const std::vector<net_t>& input,
                               std::vector<net_t>& output_pol,
                               std::vector<net_t>& output_val) {
-    if (m_networks.size() == 1) {
-        m_networks[0]->forward(input, output_pol, output_val);
-        return;
+    OpenCLContext ctx;
+
+    {
+        std::unique_lock<std::mutex> lk(m_context_lock);
+        m_context_condvar.wait(lk, [this]{return !m_context.empty();});
+        ctx = std::move(m_context.front());
+        m_context.pop_front();
     }
-
-    auto f = m_threadpool.add_task([this, &input, &output_pol, &output_val]{
-        m_networks[current_thread_gpu_num]->forward(input, output_pol, output_val);
-    });
-
-    f.get();
+  
+    m_networks[ctx.gpu_num]->forward(input, output_pol, output_val, *ctx.opencl_thread_data);
+ 
+    {
+        std::unique_lock<std::mutex> lk(m_context_lock);
+        m_context.push_back(std::move(ctx));
+        lk.unlock();
+        m_context_condvar.notify_one();
+    }
 }
 #endif

--- a/src/OpenCLScheduler.cpp
+++ b/src/OpenCLScheduler.cpp
@@ -50,7 +50,7 @@ void OpenCLScheduler::initialize(const int channels) {
         silent = true;
 
         for (auto i = 0; i < num_threads; i++) {
-            m_context[i].emplace_back(new OpenCLContext(gnum));
+            m_context[i].emplace_back(std::make_shared<OpenCLContext>(gnum));
         }
         gnum++;
     }
@@ -79,6 +79,9 @@ void OpenCLScheduler::forward(const std::vector<net_t>& input,
             }
             queue_num++;
         }
+        // if this failed, it means the condition variable exited itself
+        // when the predicate condition return false
+        assert(ctx != nullptr);
     }
 
     m_networks[ctx->m_gpu_num]->forward(input, output_pol, output_val, *ctx);

--- a/src/OpenCLScheduler.cpp
+++ b/src/OpenCLScheduler.cpp
@@ -22,7 +22,6 @@
 #include "Random.h"
 #include "OpenCLScheduler.h"
 
-OpenCLScheduler opencl;
 
 void OpenCLScheduler::initialize(const int channels) {
     // multi-gpu?

--- a/src/OpenCLScheduler.h
+++ b/src/OpenCLScheduler.h
@@ -45,7 +45,7 @@ private:
 
     std::vector<std::unique_ptr<OpenCL_Network>> m_networks;
     std::vector<std::unique_ptr<OpenCL>> m_opencl;
-    std::list<OpenCLContext> m_context;
+    std::vector<std::list<OpenCLContext>> m_context;
     std::mutex m_context_lock;
     std::condition_variable m_context_condvar;
 };

--- a/src/OpenCLScheduler.h
+++ b/src/OpenCLScheduler.h
@@ -39,9 +39,12 @@ public:
 private:
     std::vector<std::unique_ptr<OpenCL_Network>> m_networks;
     std::vector<std::unique_ptr<OpenCL>> m_opencl;
+
     // XXX : I failed to figure out how to make this compile with unique_ptr
     // especially on visual studio
-    std::vector<std::list<std::shared_ptr<OpenCLContext>>> m_context;
+    using OpenCLContextQueue = std::list<std::shared_ptr<OpenCLContext>>;
+    std::vector<OpenCLContextQueue> m_context;
+
     std::mutex m_context_lock;
     std::condition_variable m_context_condvar;
 };

--- a/src/OpenCLScheduler.h
+++ b/src/OpenCLScheduler.h
@@ -39,7 +39,9 @@ public:
 private:
     std::vector<std::unique_ptr<OpenCL_Network>> m_networks;
     std::vector<std::unique_ptr<OpenCL>> m_opencl;
-    std::vector<std::list<std::unique_ptr<OpenCLContext>>> m_context;
+    // XXX : I failed to figure out how to make this compile with unique_ptr
+    // especially on visual studio
+    std::vector<std::list<std::shared_ptr<OpenCLContext>>> m_context;
     std::mutex m_context_lock;
     std::condition_variable m_context_condvar;
 };

--- a/src/OpenCLScheduler.h
+++ b/src/OpenCLScheduler.h
@@ -50,6 +50,4 @@ private:
     std::condition_variable m_context_condvar;
 };
 
-extern OpenCLScheduler opencl;
-
 #endif

--- a/src/OpenCLScheduler.h
+++ b/src/OpenCLScheduler.h
@@ -28,6 +28,12 @@
 #include "ThreadPool.h"
 
 class OpenCLScheduler {
+    class ContextPoolEntry {
+    public:
+        size_t net_index;
+        OpenCLContext context;
+        ContextPoolEntry(size_t index) : net_index(index) {}
+    };
 public:
     void initialize(const int channels);
     std::vector<std::unique_ptr<OpenCL_Network>> & get_networks() {
@@ -40,13 +46,11 @@ private:
     std::vector<std::unique_ptr<OpenCL_Network>> m_networks;
     std::vector<std::unique_ptr<OpenCL>> m_opencl;
 
-    // XXX : I failed to figure out how to make this compile with unique_ptr
-    // especially on visual studio
-    using OpenCLContextQueue = std::list<std::shared_ptr<OpenCLContext>>;
-    std::vector<OpenCLContextQueue> m_context;
+    using ContextPoolQueue = std::list<std::shared_ptr<ContextPoolEntry>>;
+    std::vector<ContextPoolQueue> m_context_pool;
 
-    std::mutex m_context_lock;
-    std::condition_variable m_context_condvar;
+    std::mutex m_context_pool_lock;
+    std::condition_variable m_context_pool_condvar;
 };
 
 #endif

--- a/src/OpenCLScheduler.h
+++ b/src/OpenCLScheduler.h
@@ -20,6 +20,7 @@
 #define OPENCL_SCHEDULER_H_INCLUDED
 #include "config.h"
 
+#include <list>
 #include <vector>
 #include <future>
 
@@ -36,20 +37,17 @@ public:
                  std::vector<net_t>& output_pol,
                  std::vector<net_t>& output_val);
 private:
-    class ForwardTask {
+    class OpenCLContext {
     public:
-        const std::vector<net_t> *input;
-        std::vector<net_t> * output;
-        std::promise<void> prom;
-        ForwardTask() : input(nullptr), output(nullptr) {}
-        ForwardTask(const std::vector<net_t> * in,
-                    std::vector<net_t> * out)
-            : input(in), output(out) {}
+        size_t gpu_num;
+        std::unique_ptr<ThreadData> opencl_thread_data;
     };
 
     std::vector<std::unique_ptr<OpenCL_Network>> m_networks;
     std::vector<std::unique_ptr<OpenCL>> m_opencl;
-    Utils::ThreadPool m_threadpool;
+    std::list<OpenCLContext> m_context;
+    std::mutex m_context_lock;
+    std::condition_variable m_context_condvar;
 };
 
 extern OpenCLScheduler opencl;

--- a/src/OpenCLScheduler.h
+++ b/src/OpenCLScheduler.h
@@ -37,15 +37,9 @@ public:
                  std::vector<net_t>& output_pol,
                  std::vector<net_t>& output_val);
 private:
-    class OpenCLContext {
-    public:
-        size_t gpu_num;
-        std::unique_ptr<ThreadData> opencl_thread_data;
-    };
-
     std::vector<std::unique_ptr<OpenCL_Network>> m_networks;
     std::vector<std::unique_ptr<OpenCL>> m_opencl;
-    std::vector<std::list<OpenCLContext>> m_context;
+    std::vector<std::list<std::unique_ptr<OpenCLContext>>> m_context;
     std::mutex m_context_lock;
     std::condition_variable m_context_condvar;
 };

--- a/src/Training.cpp
+++ b/src/Training.cpp
@@ -159,7 +159,7 @@ void Training::record(GameState& state, UCTNode& root) {
     step.planes = get_planes(&state);
 
     auto result =
-        Network::get_scored_moves(&state, Network::Ensemble::DIRECT, 0);
+        g_network.get_scored_moves(&state, Network::Ensemble::DIRECT, 0);
     step.net_winrate = result.winrate;
 
     const auto& best_node = root.get_best_root_child(step.to_move);

--- a/src/Training.cpp
+++ b/src/Training.cpp
@@ -153,13 +153,13 @@ TimeStep::NNPlanes Training::get_planes(const GameState* const state) {
     return planes;
 }
 
-void Training::record(GameState& state, UCTNode& root) {
+void Training::record(Network & network, GameState& state, UCTNode& root) {
     auto step = TimeStep{};
     step.to_move = state.board.get_to_move();
     step.planes = get_planes(&state);
 
     auto result =
-        g_network.get_scored_moves(&state, Network::Ensemble::DIRECT, 0);
+        network.get_scored_moves(&state, Network::Ensemble::DIRECT, 0);
     step.net_winrate = result.winrate;
 
     const auto& best_node = root.get_best_root_child(step.to_move);

--- a/src/Training.h
+++ b/src/Training.h
@@ -71,7 +71,7 @@ public:
     static void dump_training(int winner_color,
                               const std::string& out_filename);
     static void dump_debug(const std::string& out_filename);
-    static void record(GameState& state, UCTNode& node);
+    static void record(Network & network, GameState& state, UCTNode& node);
 
     static void dump_supervised(const std::string& sgf_file,
                                 const std::string& out_filename);

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -51,7 +51,7 @@ SMP::Mutex& UCTNode::get_mutex() {
     return m_nodemutex;
 }
 
-bool UCTNode::create_children(Network & network, 
+bool UCTNode::create_children(Network & network,
                               std::atomic<int>& nodecount,
                               GameState& state,
                               float& eval,

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -51,7 +51,8 @@ SMP::Mutex& UCTNode::get_mutex() {
     return m_nodemutex;
 }
 
-bool UCTNode::create_children(std::atomic<int>& nodecount,
+bool UCTNode::create_children(Network & network, 
+                              std::atomic<int>& nodecount,
                               GameState& state,
                               float& eval,
                               float min_psa_ratio) {
@@ -77,7 +78,7 @@ bool UCTNode::create_children(std::atomic<int>& nodecount,
     m_is_expanding = true;
     lock.unlock();
 
-    const auto raw_netlist = g_network.get_scored_moves(
+    const auto raw_netlist = network.get_scored_moves(
         &state, Network::Ensemble::RANDOM_SYMMETRY);
 
     // DCNN returns winrate as side to move

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -77,7 +77,7 @@ bool UCTNode::create_children(std::atomic<int>& nodecount,
     m_is_expanding = true;
     lock.unlock();
 
-    const auto raw_netlist = Network::get_scored_moves(
+    const auto raw_netlist = g_network.get_scored_moves(
         &state, Network::Ensemble::RANDOM_SYMMETRY);
 
     // DCNN returns winrate as side to move

--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -43,7 +43,8 @@ public:
     UCTNode() = delete;
     ~UCTNode() = default;
 
-    bool create_children(std::atomic<int>& nodecount,
+    bool create_children(Network & network,
+                         std::atomic<int>& nodecount,
                          GameState& state, float& eval,
                          float min_psa_ratio = 0.0f);
 
@@ -74,7 +75,7 @@ public:
 
     // Defined in UCTNodeRoot.cpp, only to be called on m_root in UCTSearch
     void randomize_first_proportionally();
-    void prepare_root_node(int color,
+    void prepare_root_node(Network & network, int color,
                            std::atomic<int>& nodecount,
                            GameState& state);
 

--- a/src/UCTNodeRoot.cpp
+++ b/src/UCTNodeRoot.cpp
@@ -177,13 +177,13 @@ void UCTNode::inflate_all_children() {
     }
 }
 
-void UCTNode::prepare_root_node(int color,
+void UCTNode::prepare_root_node(Network & network, int color,
                                 std::atomic<int>& nodes,
                                 GameState& root_state) {
     float root_eval;
     const auto had_children = has_children();
     if (expandable()) {
-        create_children(nodes, root_state, root_eval);
+        create_children(network, nodes, root_state, root_eval);
     }
     if (had_children) {
         root_eval = get_eval(color);

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -84,7 +84,7 @@ UCTSearch::UCTSearch(GameState& g, const std::string & weightsfile)
 void UCTSearch::reset() {
     m_root = std::make_unique<UCTNode>(FastBoard::PASS, 0.0f);
     m_last_rootstate.reset();
-   
+
     assert(m_nodes == 0);
     assert(m_playouts == 0);
     assert(m_run == false);

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -71,23 +71,12 @@ private:
 };
 
 
-UCTSearch::UCTSearch(GameState& g, const std::string & weightsfile)
-    : m_rootstate(g) {
+UCTSearch::UCTSearch(GameState& g, Network& network)
+    : m_rootstate(g), m_network(network) {
     set_playout_limit(cfg_max_playouts);
     set_visit_limit(cfg_max_visits);
-    auto playouts = std::min(cfg_max_playouts, cfg_max_visits);
-    m_network.initialize(playouts, weightsfile);
 
     m_root = std::make_unique<UCTNode>(FastBoard::PASS, 0.0f);
-}
-
-void UCTSearch::reset() {
-    m_root = std::make_unique<UCTNode>(FastBoard::PASS, 0.0f);
-    m_last_rootstate.reset();
-
-    assert(m_nodes == 0);
-    assert(m_playouts == 0);
-    assert(m_run == false);
 }
 
 bool UCTSearch::advance_to_new_rootstate() {
@@ -813,17 +802,3 @@ void UCTSearch::set_visit_limit(int visits) {
     // Limit to type max / 2 to prevent overflow when multithreading.
     m_maxvisits = std::min(visits, UNLIMITED_PLAYOUTS);
 }
-
-void UCTSearch::benchmark(const GameState * const state,
-                          const int iterations) {
-    m_network.benchmark(state, iterations);
-}
-
-Network::Netresult UCTSearch::get_scored_moves(const GameState* const state,
-                                      const Network::Ensemble ensemble,
-                                      const int symmetry,
-                                      const bool skip_cache) {
-    return m_network.get_scored_moves(state, ensemble, symmetry, skip_cache);
-}
-
-

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -92,9 +92,7 @@ public:
     static constexpr auto UNLIMITED_PLAYOUTS =
         std::numeric_limits<int>::max() / 2;
 
-    UCTSearch(GameState& g,
-              const std::string & weightsfile);
-    void reset();
+    UCTSearch(GameState& g, Network & network);
     int think(int color, passflag_t passflag = NORMAL);
     void set_playout_limit(int playouts);
     void set_visit_limit(int visits);
@@ -103,15 +101,6 @@ public:
     void increment_playouts();
     SearchResult play_simulation(GameState& currstate, UCTNode* const node);
 
-    // bypass to Network class
-    void benchmark(const GameState * const state,
-                          const int iterations = 1600);
-
-    // bypass to Network class
-    Network::Netresult get_scored_moves(const GameState* const state,
-                                      const Network::Ensemble ensemble,
-                                      const int symmetry = -1,
-                                      const bool skip_cache = false);
 private:
     float get_min_psa_ratio() const;
     void dump_stats(FastState& state, UCTNode& parent);
@@ -140,7 +129,7 @@ private:
 
     std::list<Utils::ThreadGroup> m_delete_futures;
 
-    Network m_network;
+    Network & m_network;
 };
 
 class UCTWorker {

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -31,6 +31,7 @@
 #include "FastState.h"
 #include "GameState.h"
 #include "UCTNode.h"
+#include "Network.h"
 
 
 class SearchResult {
@@ -91,7 +92,9 @@ public:
     static constexpr auto UNLIMITED_PLAYOUTS =
         std::numeric_limits<int>::max() / 2;
 
-    UCTSearch(GameState& g);
+    UCTSearch(GameState& g,
+              const std::string & weightsfile);
+    void reset();
     int think(int color, passflag_t passflag = NORMAL);
     void set_playout_limit(int playouts);
     void set_visit_limit(int visits);
@@ -100,6 +103,15 @@ public:
     void increment_playouts();
     SearchResult play_simulation(GameState& currstate, UCTNode* const node);
 
+    // bypass to Network class
+    void benchmark(const GameState * const state,
+                          const int iterations = 1600);
+
+    // bypass to Network class
+    Network::Netresult get_scored_moves(const GameState* const state,
+                                      const Network::Ensemble ensemble,
+                                      const int symmetry = -1,
+                                      const bool skip_cache = false);
 private:
     float get_min_psa_ratio() const;
     void dump_stats(FastState& state, UCTNode& parent);
@@ -127,6 +139,8 @@ private:
     int m_maxvisits;
 
     std::list<Utils::ThreadGroup> m_delete_futures;
+
+    Network m_network;
 };
 
 class UCTWorker {

--- a/src/tests/gtests.cpp
+++ b/src/tests/gtests.cpp
@@ -52,6 +52,7 @@ void expect_regex(std::string s, std::string re, bool positive = true) {
 
 class LeelaEnv: public ::testing::Environment {
 public:
+    Network network;
     ~LeelaEnv() {}
     void SetUp() {
         GTP::setup_default_parameters();
@@ -71,7 +72,9 @@ public:
 
         cfg_weightsfile = "../src/tests/0k.txt";
 
-        GTP::initialize();
+        auto playouts = std::min(cfg_max_playouts, cfg_max_visits);
+        network.initialize(playouts, cfg_weightsfile);
+        GTP::initialize(&network);
     }
     void TearDown() {}
 };

--- a/src/tests/gtests.cpp
+++ b/src/tests/gtests.cpp
@@ -69,10 +69,8 @@ public:
         // improves reproducibility across platforms.
         Random::get_Rng().seedrandom(cfg_rng_seed);
 
-        NNCache::get_NNCache().set_size_from_playouts(cfg_max_playouts);
-
         cfg_weightsfile = "../src/tests/0k.txt";
-        Network::initialize();
+        Network::initialize(cfg_max_playouts);
     }
     void TearDown() {}
 };

--- a/src/tests/gtests.cpp
+++ b/src/tests/gtests.cpp
@@ -70,7 +70,6 @@ public:
         Random::get_Rng().seedrandom(cfg_rng_seed);
 
         cfg_weightsfile = "../src/tests/0k.txt";
-        Network::initialize(cfg_max_playouts);
     }
     void TearDown() {}
 };
@@ -87,6 +86,8 @@ public:
 
         m_gamestate = std::make_unique<GameState>();
         m_gamestate->init_game(19, 7.5f);
+
+        GTP::initialize(get_gamestate());
     }
 
     GameState& get_gamestate() {

--- a/src/tests/gtests.cpp
+++ b/src/tests/gtests.cpp
@@ -70,6 +70,8 @@ public:
         Random::get_Rng().seedrandom(cfg_rng_seed);
 
         cfg_weightsfile = "../src/tests/0k.txt";
+
+        GTP::initialize();
     }
     void TearDown() {}
 };
@@ -87,7 +89,6 @@ public:
         m_gamestate = std::make_unique<GameState>();
         m_gamestate->init_game(19, 7.5f);
 
-        GTP::initialize(get_gamestate());
     }
 
     GameState& get_gamestate() {


### PR DESCRIPTION
Restructured code to remove:
- No global / thread_local OpenCL structures
- Network is now all non-static methods with instance variables
- NNCache is a member of Network, OpenCLScheduler is also a member of Network
- ThreadData is renamed to OpenCLContext (it's no longer thread-specific!)
- Other accompanying fixes
