### PR TITLE
FPU reduction proportional to root eval

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -97,7 +97,7 @@ void GTP::setup_default_parameters() {
 #endif
     cfg_puct = 0.8f;
     cfg_softmax_temp = 1.0f;
-    cfg_fpu_reduction = 0.25f;
+    cfg_fpu_reduction = 0.60f;
     // see UCTSearch::should_resign
     cfg_resignpct = -1;
     cfg_noise = false;

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -272,8 +272,8 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
     if (!is_root || !cfg_noise) {
         fpu_reduction = cfg_fpu_reduction * std::sqrt(total_visited_policy);
     }
-    // Estimated eval for unknown nodes = original parent NN eval - reduction
-    auto fpu_eval = get_net_eval(color) - fpu_reduction;
+    // Estimated eval for unknown nodes
+    auto fpu_eval = get_net_eval(color) * (1.0f - fpu_reduction);
 
     auto best = static_cast<UCTNodePointer*>(nullptr);
     auto best_value = std::numeric_limits<double>::lowest();


### PR DESCRIPTION
I did some statistics about the optimal FPU reduction. I first changed FPU to 1 to expand all the first level nodes, added code to save child node net evaluations and then played some self play games to gather enough data. In the analysis script I calculated the difference between child node net evaluation and root net evaluation for every node, this would be the optimal FPU reduction constant to use for that node. Code is available at: https://github.com/Ttl/leela-zero/tree/fpu_estimation

Here is histogram of the evaluation difference of child and root:

![fpu_hist](https://user-images.githubusercontent.com/544240/41510411-723474ce-7264-11e8-82f8-da751e0a1613.png)

As expected most of the moves are worse than the root which is why root evaluation minus constant is a more accurate initialization than just root evaluation.

Here is L2 loss plot with different FPU reduction constants:

![fpu_constant_l2](https://user-images.githubusercontent.com/544240/41510426-ad6d0344-7264-11e8-9f04-6fe418b29f3a.png)

The minimum is very close to what was previously determined to be strongest using CLOP. Estimated maximum was -0.3 in the last tuning run (#1211) and in this analysis -0.29 has the lowest L2 loss.

Plotting FPU reduction vs. root evaluation gives the following plot:

![fpu_winrate](https://user-images.githubusercontent.com/544240/41510449-2c4e6be4-7265-11e8-8009-f19a621d31fa.png)

As the winrate can't go lower than 0 it makes sense to use FPU reduction that is proportional to the root evaluation instead of just subtracting a constant. In the plot green line is the least squares fitted FPU reduction vs. winrate (This pull request).

Plotting the FPU reduction vs. policy head output gives:

![fpu_policy](https://user-images.githubusercontent.com/544240/41510476-a15dc736-7265-11e8-88c9-f5b015f73c8a.png)

As would be expected moves with high policy output usually have value network evaluation close to the root and low policy moves are often much worse, although there are exceptions. This plot does give some explanation why `sqrt(total_visited_policy)` works: It lowers the reduction for moves with high policy that are expanded first and that are usually close to the root evaluation. In green lines are the FPU reductions with 0.1, 0.5 and 0.9 root evaluations using the equation in this pull request.

There are many different functions that could be used to initialize nodes from policy and root evaluation, but I decided to keep it simple and avoid adding any more tunable variables. The equation in this pull request gives lower L2 loss than simple subtraction. I didn't try to find any better formula for taking the policy output into account and used the current `sqrt(total_visited_policy)` for that.

L2 loss for this equation in prediction the child evaluation is 0.033 using the latest network compared to 0.051 using the current equation. -0.6 is the best reduction using this formula with this network. As was earlier observed when FPU reduction was first introduced it does depend on the network. Minigo-303 optimum is at -0.29 and ELF is at -0.7. The new formula is more accurate also for them by about the same amount as for LZ net.

I have been running a match between this pull request vs. next for one week now using a very weak laptop. Command line parameters are:  `-g -d -t 1 --noponder -v 800 --timemanage off -r 10 -w d01879964d578b676714251164f7289da023f14c0063b1721e5e3cd2e8d51ae0.gz`

Current results:
```
lz_fpu_est v lz_next (131/400 games)
board size: 19   komi: 7.5
             wins              black         white       avg cpu
lz_fpu_est     71 54.20%       29 43.94%     42 64.62%    500.59
lz_next        60 45.80%       23 35.38%     37 56.06%    508.49
                               52 39.69%     79 60.31%
```

It's not statistically significant yet and it looks like completing the 400 games takes about two more weeks. I don't think there is currently any hope for me to test this at higher playouts. I hope that someone will help with testing or invent a more accurate initialization scheme using the analysis results.