### PR TITLE
Initialize node eval immediately after NN eval

### DIFF
--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -274,7 +274,7 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
     if (!is_root || !cfg_noise) {
         fpu_reduction = cfg_fpu_reduction * std::sqrt(total_visited_policy) * pure_eval / 0.5;
     }
-    // Estimated eval for unknown nodes = original parent NN eval - reduction
+    // Estimated eval for unknown nodes = current parent winrate - reduction
     auto fpu_eval = pure_eval - fpu_reduction;
 
     auto best = static_cast<UCTNodePointer*>(nullptr);

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -75,6 +75,7 @@ bool UCTNode::create_children(std::atomic<int>& nodecount,
     }
     // We'll be the one queueing this node for expansion, stop others
     m_is_expanding = true;
+    lock.unlock();
 
     const auto raw_netlist = Network::get_scored_moves(
         &state, Network::Ensemble::RANDOM_SYMMETRY);
@@ -87,7 +88,6 @@ bool UCTNode::create_children(std::atomic<int>& nodecount,
         m_net_eval = 1.0f - m_net_eval;
     }
     update(m_net_eval);
-    lock.unlock();
     eval = m_net_eval;
 
     std::vector<Network::ScoreVertexPair> nodelist;

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -270,7 +270,6 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
     // Lower the expected eval for moves that are likely not the best.
     // Do not do this if we have introduced noise at this node exactly
     // to explore more.
-    
     if (!is_root || !cfg_noise) {
         fpu_reduction = cfg_fpu_reduction * std::sqrt(total_visited_policy);
     }

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -269,11 +269,13 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
     // Lower the expected eval for moves that are likely not the best.
     // Do not do this if we have introduced noise at this node exactly
     // to explore more.
+    
+    auto pure_eval = get_pure_eval(color); 
     if (!is_root || !cfg_noise) {
-        fpu_reduction = cfg_fpu_reduction * std::sqrt(total_visited_policy);
+        fpu_reduction = cfg_fpu_reduction * std::sqrt(total_visited_policy) * pure_eval / 0.5;
     }
     // Estimated eval for unknown nodes = original parent NN eval - reduction
-    auto fpu_eval = get_net_eval(color) - fpu_reduction;
+    auto fpu_eval = pure_eval - fpu_reduction;
 
     auto best = static_cast<UCTNodePointer*>(nullptr);
     auto best_value = std::numeric_limits<double>::lowest();
@@ -289,7 +291,7 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
         }
         auto psa = child.get_score();
         auto denom = 1.0 + child.get_visits();
-        auto puct = cfg_puct * psa * (numerator / denom);
+        auto puct = cfg_puct * psa * (numerator / denom) * pure_eval / 0.5;
         auto value = winrate + puct;
         assert(value > std::numeric_limits<double>::lowest());
 

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -271,12 +271,11 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
     // Do not do this if we have introduced noise at this node exactly
     // to explore more.
     
-    auto pure_eval = get_pure_eval(color); 
     if (!is_root || !cfg_noise) {
-        fpu_reduction = cfg_fpu_reduction * std::sqrt(total_visited_policy) * pure_eval / 0.5;
+        fpu_reduction = cfg_fpu_reduction * std::sqrt(total_visited_policy);
     }
     // Estimated eval for unknown nodes = current parent winrate - reduction
-    auto fpu_eval = pure_eval - fpu_reduction;
+    auto fpu_eval = get_pure_eval(color) - fpu_reduction;
 
     auto best = static_cast<UCTNodePointer*>(nullptr);
     auto best_value = std::numeric_limits<double>::lowest();
@@ -292,7 +291,7 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
         }
         auto psa = child.get_score();
         auto denom = 1.0 + child.get_visits();
-        auto puct = cfg_puct * psa * (numerator / denom) * pure_eval / 0.5;
+        auto puct = cfg_puct * psa * (numerator / denom);
         auto value = winrate + puct;
         assert(value > std::numeric_limits<double>::lowest());
 

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -274,7 +274,7 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
     if (!is_root || !cfg_noise) {
         fpu_reduction = cfg_fpu_reduction * std::sqrt(total_visited_policy);
     }
-    // Estimated eval for unknown nodes = current parent winrate - reduction
+    // Estimated eval for unknown nodes = original parent NN eval - reduction
     auto fpu_eval = get_net_eval(color) - fpu_reduction;
 
     auto best = static_cast<UCTNodePointer*>(nullptr);

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -75,7 +75,6 @@ bool UCTNode::create_children(std::atomic<int>& nodecount,
     }
     // We'll be the one queueing this node for expansion, stop others
     m_is_expanding = true;
-    lock.unlock();
 
     const auto raw_netlist = Network::get_scored_moves(
         &state, Network::Ensemble::RANDOM_SYMMETRY);
@@ -87,6 +86,8 @@ bool UCTNode::create_children(std::atomic<int>& nodecount,
     if (state.board.white_to_move()) {
         m_net_eval = 1.0f - m_net_eval;
     }
+    update(m_net_eval);
+    lock.unlock();
     eval = m_net_eval;
 
     std::vector<Network::ScoreVertexPair> nodelist;

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -275,7 +275,7 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
         fpu_reduction = cfg_fpu_reduction * std::sqrt(total_visited_policy);
     }
     // Estimated eval for unknown nodes = current parent winrate - reduction
-    auto fpu_eval = get_pure_eval(color) - fpu_reduction;
+    auto fpu_eval = get_net_eval(color) - fpu_reduction;
 
     auto best = static_cast<UCTNodePointer*>(nullptr);
     auto best_value = std::numeric_limits<double>::lowest();

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -196,7 +196,6 @@ SearchResult UCTSearch::play_simulation(GameState & currstate,
         }
     }
 
-
     node->virtual_loss_undo();
 
     return result;

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -168,6 +168,7 @@ SearchResult UCTSearch::play_simulation(GameState & currstate,
         if (currstate.get_passes() >= 2) {
             auto score = currstate.final_score();
             result = SearchResult::from_score(score);
+            node->update(result.eval());
         } else if (m_nodes < MAX_TREE_SIZE) {
             float eval;
             const auto had_children = node->has_children();
@@ -189,12 +190,13 @@ SearchResult UCTSearch::play_simulation(GameState & currstate,
             next->invalidate();
         } else {
             result = play_simulation(currstate, next);
+            if (result.valid()) {
+                node->update(result.eval());
+            }
         }
     }
 
-    if (result.valid()) {
-        node->update(result.eval());
-    }
+
     node->virtual_loss_undo();
 
     return result;

--- a/src/config.h
+++ b/src/config.h
@@ -78,7 +78,7 @@
  * USE_TUNER: Expose some extra command line parameters that allow tuning the
  * search algorithm.
  */
-#define USE_TUNER
+//#define USE_TUNER
 
 #define PROGRAM_NAME "Leela Zero"
 #define PROGRAM_VERSION "0.15"

--- a/src/config.h
+++ b/src/config.h
@@ -78,7 +78,7 @@
  * USE_TUNER: Expose some extra command line parameters that allow tuning the
  * search algorithm.
  */
-//#define USE_TUNER
+#define USE_TUNER
 
 #define PROGRAM_NAME "Leela Zero"
 #define PROGRAM_VERSION "0.15"


### PR DESCRIPTION
This allows get_pure_eval (for the parent) be used in e.g. uct_select_child without causing crashes with multiple threads. Previously, when another thread visited the node, it could already have children but have no visits, so get_pure_eval wouldn't work. Discussions starting at https://github.com/gcp/leela-zero/pull/1435#issuecomment-391485532.

(Please ignore the commit descriptions and only look at the diffs.)