### PR TITLE
AutoGTP: allow three quitting conditions simultaneously

### DIFF
--- a/autogtp/main.cpp
+++ b/autogtp/main.cpp
@@ -149,13 +149,13 @@ int main(int argc, char *argv[]) {
     if (parser.isSet(timeoutOption)) {
         QObject::connect(timer, &QTimer::timeout, &app, &QCoreApplication::quit);
         timer->start(parser.value(timeoutOption).toInt() * 60000);
-    } else {
-        if (parser.isSet(singleOption) || parser.isSet(maxOption)) {
-            QObject::connect(boss, &Management::sendQuit, &app, &QCoreApplication::quit);
-        } else {
-            cons = new Console();
-            QObject::connect(cons, &Console::sendQuit, &app, &QCoreApplication::quit);
-        }
+    }
+    if (parser.isSet(singleOption) || parser.isSet(maxOption)) {
+        QObject::connect(boss, &Management::sendQuit, &app, &QCoreApplication::quit);
+    }
+    if (true) {
+        cons = new Console();
+        QObject::connect(cons, &Console::sendQuit, &app, &QCoreApplication::quit);
     }
     return app.exec();
 }


### PR DESCRIPTION
The three conditions are time limit, number of games limit, and console input q+Enter, as implemented by @marcocalignano.
See https://github.com/gcp/leela-zero/issues/1535#issuecomment-399418103.
The `if (true)` condition is added to make it easier to change it to `if (false)`; I have to disable console on Big Red II for some reason.