### PR TITLE
Packaging improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ add_subdirectory(gtest EXCLUDE_FROM_ALL) # We don't want to install gtest, exclu
 # Required Packages
 set(Boost_MIN_VERSION "1.58.0")
 set(Boost_USE_MULTITHREADED ON)
-find_package(Boost 1.58.0 REQUIRED program_options)
+find_package(Boost 1.58.0 REQUIRED program_options filesystem)
 find_package(Threads REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(OpenCL REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ target_link_libraries(leelaz ${BLAS_LIBRARIES})
 target_link_libraries(leelaz ${OpenCL_LIBRARIES})
 target_link_libraries(leelaz ${ZLIB_LIBRARIES})
 target_link_libraries(leelaz ${CMAKE_THREAD_LIBS_INIT})
-install(TARGETS leelaz DESTINATION bin)
+install(TARGETS leelaz DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 if(Qt5Core_FOUND)
     if(NOT Qt5Core_VERSION VERSION_LESS "5.3.0")

--- a/autogtp/CMakeLists.txt
+++ b/autogtp/CMakeLists.txt
@@ -7,4 +7,4 @@ add_executable(autogtp
 set_target_properties(autogtp PROPERTIES AUTOMOC 1)
 target_link_libraries(autogtp Qt5::Core)
 
-install(TARGETS autogtp DESTINATION bin)
+install(TARGETS autogtp DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -102,6 +102,7 @@ void GTP::setup_default_parameters() {
     cfg_max_visits = UCTSearch::UNLIMITED_PLAYOUTS;
     cfg_timemanage = TimeManagement::AUTO;
     cfg_lagbuffer_cs = 100;
+    cfg_weightsfile = leelaz_file("best-network");
 #ifdef USE_OPENCL
     cfg_gpus = { };
     cfg_sgemm_exhaustive = false;

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -68,7 +68,7 @@ static void parse_commandline(int argc, char *argv[]) {
         ("resignpct,r", po::value<int>()->default_value(cfg_resignpct),
                         "Resign when winrate is less than x%.\n"
                         "-1 uses 10% but scales for handicap.")
-        ("weights,w", po::value<std::string>(), "File with network weights.")
+        ("weights,w", po::value<std::string>()->default_value(cfg_weightsfile), "File with network weights.")
         ("logfile,l", po::value<std::string>(), "File to log input/output to.")
         ("quiet,q", "Disable all diagnostic output.")
         ("timemanage", po::value<std::string>()->default_value("auto"),

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -20,6 +20,7 @@
 
 #include <cstdint>
 #include <algorithm>
+#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/program_options.hpp>
 #include <cstdio>
@@ -194,10 +195,10 @@ static void parse_commandline(int argc, char *argv[]) {
         cfg_logfile_handle = fopen(cfg_logfile.c_str(), "a");
     }
 
-    if (vm.count("weights")) {
-        cfg_weightsfile = vm["weights"].as<std::string>();
-    } else {
+    cfg_weightsfile = vm["weights"].as<std::string>();
+    if (vm["weights"].defaulted() && !boost::filesystem::exists(cfg_weightsfile)) {
         printf("A network weights file is required to use the program.\n");
+        printf("By default, Leela Zero looks for it in %s.\n", cfg_weightsfile.c_str());
         exit(EXIT_FAILURE);
     }
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -21,7 +21,7 @@ clang:
 		LDFLAGS='$(LDFLAGS) -flto -fuse-linker-plugin' \
 		leelaz
 
-DYNAMIC_LIBS = -lboost_program_options -lpthread -lz
+DYNAMIC_LIBS = -lboost_system -lboost_filesystem -lboost_program_options -lpthread -lz
 LIBS =
 
 ifeq ($(THE_OS),Linux)

--- a/src/Tuner.cpp
+++ b/src/Tuner.cpp
@@ -465,10 +465,11 @@ std::string Tuner<net_t>::tune_sgemm(const int m, const int n, const int k,
 template <typename net_t>
 void Tuner<net_t>::store_sgemm_tuners(const int m, const int n, const int k,
                                const int batch_size, std::string tuners) {
+    auto tuner_file = leelaz_file(TUNER_FILE_LOCAL);
     auto file_contents = std::vector<std::string>();
     {
         // Read the previous contents to string
-        auto file = std::ifstream{TUNER_FILE_LOCAL};
+        auto file = std::ifstream{tuner_file};
         if (file.good()) {
             auto line = std::string{};
             while (std::getline(file, line)) {
@@ -476,7 +477,7 @@ void Tuner<net_t>::store_sgemm_tuners(const int m, const int n, const int k,
             }
         }
     }
-    auto file = std::ofstream{TUNER_FILE_LOCAL};
+    auto file = std::ofstream{tuner_file};
 
     auto device_name = m_opencl.get_device_name();
     auto tuning_params = std::stringstream{};
@@ -501,7 +502,7 @@ void Tuner<net_t>::store_sgemm_tuners(const int m, const int n, const int k,
     if (file.fail()) {
         myprintf("Could not save the tuning result.\n");
         myprintf("Do I have write permissions on %s?\n",
-            TUNER_FILE_LOCAL.c_str());
+            tuner_file);
     }
 }
 
@@ -555,7 +556,8 @@ std::string Tuner<net_t>::sgemm_tuners_from_line(std::string line,
 template <typename net_t>
 std::string Tuner<net_t>::load_sgemm_tuners(const int m, const int n, const int k,
                                      const int batch_size) {
-    auto file = std::ifstream{TUNER_FILE_LOCAL};
+    auto tuner_file = leelaz_file(TUNER_FILE_LOCAL);
+    auto file = std::ifstream{tuner_file};
     if (!cfg_sgemm_exhaustive && file.good()) {
         auto line = std::string{};
         while (std::getline(file, line)) {

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -168,32 +168,34 @@ size_t Utils::ceilMultiple(size_t a, size_t b) {
 #ifdef _WIN32
 // https://stackoverflow.com/a/3999597
 // Convert a wide Unicode string to an UTF8 string
-// Thanks Windows, saving developers time since 1995
 std::string utf8_encode(const std::wstring &wstr)
 {
-    if ( wstr.empty() ) return std::string();
-    int size_needed = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), NULL, 0, NULL, NULL);
+    if (wstr.empty()) {
+        return std::string();
+    }
+    int size_needed = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), nullptr, 0, nullptr, nullptr);
     std::string strTo(size_needed, 0);
-    WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &strTo[0], size_needed, NULL, NULL);
+    WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &strTo[0], size_needed, nullptr, nullptr);
     return strTo;
 }
 #endif
 
-std::string Utils::leelaz_file(std::string file) {
+const std::string Utils::leelaz_file(std::string file) {
 #ifdef _WIN32
     // https://stackoverflow.com/a/11032792 but avoiding the UNICODE mess and just using W variants
     wchar_t szPath[MAX_PATH];
-    if (!SUCCEEDED(SHGetFolderPathW(NULL, CSIDL_COMMON_APPDATA, NULL, 0, szPath)))
-        return NULL;
+    if (!SUCCEEDED(SHGetFolderPathW(nullptr, CSIDL_COMMON_APPDATA, nullptr, 0, szPath))) {
+        return std::string();
+    }
     PathAppendW(szPath, L"\\Leela Zero\\");
     boost::filesystem::path dir(utf8_encode(szPath));
 #else
     // https://stackoverflow.com/a/26696759
     const char *homedir;
-    if ((homedir = getenv("HOME")) == NULL) {
+    if ((homedir = getenv("HOME")) == nullptr) {
         struct passwd *pwd;
-        if ((pwd = getpwuid(getuid())) == NULL) { // NOLINT(runtime/threadsafe_fn)
-            return NULL;
+        if ((pwd = getpwuid(getuid())) == nullptr) { // NOLINT(runtime/threadsafe_fn)
+            return std::string();
         }
         homedir = pwd->pw_dir;
     }

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -27,9 +27,6 @@
 
 #ifdef _WIN32
 #include <windows.h>
-#include <shlwapi.h>
-#pragma comment(lib,"shlwapi.lib")
-#include "shlobj.h"
 #else
 #include <sys/select.h>
 #include <unistd.h>
@@ -165,30 +162,9 @@ size_t Utils::ceilMultiple(size_t a, size_t b) {
     return ret;
 }
 
-#ifdef _WIN32
-// https://stackoverflow.com/a/3999597
-// Convert a wide Unicode string to an UTF8 string
-std::string utf8_encode(const std::wstring &wstr)
-{
-    if (wstr.empty()) {
-        return std::string();
-    }
-    int size_needed = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), nullptr, 0, nullptr, nullptr);
-    std::string strTo(size_needed, 0);
-    WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &strTo[0], size_needed, nullptr, nullptr);
-    return strTo;
-}
-#endif
-
 const std::string Utils::leelaz_file(std::string file) {
 #ifdef _WIN32
-    // https://stackoverflow.com/a/11032792 but avoiding the UNICODE mess and just using W variants
-    wchar_t szPath[MAX_PATH];
-    if (!SUCCEEDED(SHGetFolderPathW(nullptr, CSIDL_COMMON_APPDATA, nullptr, 0, szPath))) {
-        return std::string();
-    }
-    PathAppendW(szPath, L"\\Leela Zero\\");
-    boost::filesystem::path dir(utf8_encode(szPath));
+    boost::filesystem::path dir(boost::filesystem::current_path());
 #else
     // https://stackoverflow.com/a/26696759
     const char *homedir;

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -53,6 +53,8 @@ namespace Utils {
     }
 
     size_t ceilMultiple(size_t a, size_t b);
+
+    std::string leelaz_file(std::string file);
 }
 
 #endif

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -54,7 +54,7 @@ namespace Utils {
 
     size_t ceilMultiple(size_t a, size_t b);
 
-    std::string leelaz_file(std::string file);
+    const std::string leelaz_file(std::string file);
 }
 
 #endif

--- a/validation/CMakeLists.txt
+++ b/validation/CMakeLists.txt
@@ -7,4 +7,4 @@ add_executable(validation
 set_target_properties(validation PROPERTIES AUTOMOC 1)
 target_link_libraries(validation Qt5::Core)
 
-install(TARGETS validation DESTINATION bin)
+install(TARGETS validation DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
In preparation for uploading this to Debian, I had to tweak a few things relating to installation.

> Can you describe more about how to set ${CMAKE_INSTALL_BINDIR} when building by cmake or make?

`cmake -D` is how you set cmake variables in general.

> Validation can handle other engines than just leelaz, though. And I don't see much risk of autogtp clashing.

Can you suggest a better name for `validation`? For `autogtp` it's still specific to `leelaz` but that's not reflected in the name.

> @infinity0 There is already some works on making Debian package in the “next” branch. See #1445 for reference.

That creates a Debian binary package, which isn't how one gets packages into Debian official repositories (`ftp.debian.org`). I'm talking about the necessary changes to adhere to software Debian policy standards, to upload it to the Debian official repositories. In general you create a `debian/` directory and build a source package `.dsc` out of it, and use `dpkg-buildpackage` to build a binary package `.deb`. This carries many extra benefits like automatic packages with split debugging symbols.

To avoid latency I've gone ahead and uploaded leela-zero with my patches to Debian already and it's just [awaiting copyright review](https://ftp-master.debian.org/new/leela-zero_0.15-1.html). Will be happy to change the names of the binaries though.
