### PR TITLE
Restrict the use of "score".

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -585,19 +585,19 @@ bool GTP::execute(GameState & game, std::string xinput) {
         Network::Netresult vec;
         if (cmdstream.fail()) {
             // Default = DIRECT with no symmetric change
-            vec = network->get_scored_moves(
+            vec = network->get_output(
                 &game, Network::Ensemble::DIRECT, Network::IDENTITY_SYMMETRY, true);
         } else if (symmetry == "all") {
             for (auto s = 0; s < Network::NUM_SYMMETRIES; ++s) {
-                vec = network->get_scored_moves(
+                vec = network->get_output(
                     &game, Network::Ensemble::DIRECT, s, true);
                 Network::show_heatmap(&game, vec, false);
             }
         } else if (symmetry == "average" || symmetry == "avg") {
-            vec = network->get_scored_moves(
+            vec = network->get_output(
                 &game, Network::Ensemble::AVERAGE, Network::NUM_SYMMETRIES, true);
         } else {
-            vec = network->get_scored_moves(
+            vec = network->get_output(
                 &game, Network::Ensemble::DIRECT, std::stoi(symmetry), true);
         }
 

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -76,7 +76,7 @@ void Network::benchmark(const GameState* const state, const int iterations) {
         tg.add_task([this, &runcount, iterations, state]() {
             while (runcount < iterations) {
                 runcount++;
-                get_scored_moves(state, Ensemble::RANDOM_SYMMETRY, -1, true);
+                get_output(state, Ensemble::RANDOM_SYMMETRY, -1, true);
             }
         });
     }
@@ -307,7 +307,7 @@ std::pair<int, int> Network::load_network_file(const std::string& filename) {
             return {0, 0};
         } else {
             // Version 2 networks are identical to v1, except
-            // that they return the score for black instead of
+            // that they return the value for black instead of
             // the player to move. This is used by ELF Open Go.
             if (format_version == 2) {
                 value_head_not_stm = true;
@@ -875,7 +875,7 @@ bool Network::probe_cache(const GameState* const state,
     return false;
 }
 
-Network::Netresult Network::get_scored_moves(
+Network::Netresult Network::get_output(
     const GameState* const state, const Ensemble ensemble,
     const int symmetry, const bool skip_cache) {
     Netresult result;
@@ -892,10 +892,10 @@ Network::Netresult Network::get_scored_moves(
 
     if (ensemble == DIRECT) {
         assert(symmetry >= 0 && symmetry < NUM_SYMMETRIES);
-        result = get_scored_moves_internal(state, symmetry);
+        result = get_output_internal(state, symmetry);
     } else if (ensemble == AVERAGE) {
         for (auto sym = 0; sym < NUM_SYMMETRIES; ++sym) {
-            auto tmpresult = get_scored_moves_internal(state, sym);
+            auto tmpresult = get_output_internal(state, sym);
             result.winrate += tmpresult.winrate / static_cast<float>(NUM_SYMMETRIES);
             result.policy_pass += tmpresult.policy_pass / static_cast<float>(NUM_SYMMETRIES);
 
@@ -907,7 +907,7 @@ Network::Netresult Network::get_scored_moves(
         assert(ensemble == RANDOM_SYMMETRY);
         assert(symmetry == -1);
         const auto rand_sym = Random::get_Rng().randfix<NUM_SYMMETRIES>();
-        result = get_scored_moves_internal(state, rand_sym);
+        result = get_output_internal(state, rand_sym);
     }
 
     // v2 format (ELF Open Go) returns black value, not stm
@@ -923,7 +923,7 @@ Network::Netresult Network::get_scored_moves(
     return result;
 }
 
-Network::Netresult Network::get_scored_moves_internal(
+Network::Netresult Network::get_output_internal(
     const GameState* const state, const int symmetry) {
     assert(symmetry >= 0 && symmetry < NUM_SYMMETRIES);
     constexpr auto width = BOARD_SIZE;
@@ -967,7 +967,7 @@ Network::Netresult Network::get_scored_moves_internal(
             policy_data, ip_pol_w, ip_pol_b);
     const auto outputs = softmax(policy_out, cfg_softmax_temp);
 
-    // Now get the score
+    // Now get the value
     batchnorm<BOARD_SQUARES>(OUTPUTS_VALUE, value_data,
         bn_val_w1.data(), bn_val_w2.data());
     const auto winrate_data =
@@ -999,13 +999,13 @@ void Network::show_heatmap(const FastState* const state,
 
     for (unsigned int y = 0; y < BOARD_SIZE; y++) {
         for (unsigned int x = 0; x < BOARD_SIZE; x++) {
-            auto score = 0;
+            auto policy = 0;
             const auto vertex = state->board.get_vertex(x, y);
             if (state->board.get_square(vertex) == FastBoard::EMPTY) {
-                score = result.policy[y * BOARD_SIZE + x] * 1000;
+                policy = result.policy[y * BOARD_SIZE + x] * 1000;
             }
 
-            line += boost::str(boost::format("%3d ") % score);
+            line += boost::str(boost::format("%3d ") % policy);
         }
 
         display_map.push_back(line);
@@ -1015,12 +1015,12 @@ void Network::show_heatmap(const FastState* const state,
     for (int i = display_map.size() - 1; i >= 0; --i) {
         myprintf("%s\n", display_map[i].c_str());
     }
-    const auto pass_score = int(result.policy_pass * 1000);
-    myprintf("pass: %d\n", pass_score);
+    const auto pass_policy = int(result.policy_pass * 1000);
+    myprintf("pass: %d\n", pass_policy);
     myprintf("winrate: %f\n", result.winrate);
 
     if (topmoves) {
-        std::vector<Network::ScoreVertexPair> moves;
+        std::vector<Network::PolicyVertexPair> moves;
         for (auto i=0; i < BOARD_SQUARES; i++) {
             const auto x = i % BOARD_SIZE;
             const auto y = i / BOARD_SIZE;

--- a/src/Network.h
+++ b/src/Network.h
@@ -42,13 +42,13 @@ public:
     enum Ensemble {
         DIRECT, RANDOM_SYMMETRY, AVERAGE
     };
-    using ScoreVertexPair = std::pair<float,int>;
+    using PolicyVertexPair = std::pair<float,int>;
     using Netresult = NNCache::Netresult;
 
-    Netresult get_scored_moves(const GameState* const state,
-                               const Ensemble ensemble,
-                               const int symmetry = -1,
-                               const bool skip_cache = false);
+    Netresult get_output(const GameState* const state,
+                         const Ensemble ensemble,
+                         const int symmetry = -1,
+                         const bool skip_cache = false);
 
     static constexpr auto INPUT_MOVES = 8;
     static constexpr auto INPUT_CHANNELS = 2 * INPUT_MOVES + 2;
@@ -96,8 +96,8 @@ private:
     static void winograd_sgemm(const std::vector<float>& U,
                                const std::vector<float>& V,
                                std::vector<float>& M, const int C, const int K);
-    Netresult get_scored_moves_internal(const GameState* const state,
-                                        const int symmetry);
+    Netresult get_output_internal(const GameState* const state,
+                                  const int symmetry);
 
     static void fill_input_plane_pair(const FullBoard& board,
                                       std::vector<net_t>::iterator black,

--- a/src/Training.cpp
+++ b/src/Training.cpp
@@ -159,7 +159,7 @@ void Training::record(Network & network, GameState& state, UCTNode& root) {
     step.planes = get_planes(&state);
 
     auto result =
-        network.get_scored_moves(&state, Network::Ensemble::DIRECT, 0);
+        network.get_output(&state, Network::Ensemble::DIRECT, 0);
     step.net_winrate = result.winrate;
 
     const auto& best_node = root.get_best_root_child(step.to_move);

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -40,7 +40,7 @@
 
 using namespace Utils;
 
-UCTNode::UCTNode(int vertex, float score) : m_move(vertex), m_score(score) {
+UCTNode::UCTNode(int vertex, float policy) : m_move(vertex), m_policy(policy) {
 }
 
 bool UCTNode::first_visit() const {
@@ -78,7 +78,7 @@ bool UCTNode::create_children(Network & network,
     m_is_expanding = true;
     lock.unlock();
 
-    const auto raw_netlist = network.get_scored_moves(
+    const auto raw_netlist = network.get_output(
         &state, Network::Ensemble::RANDOM_SYMMETRY);
 
     // DCNN returns winrate as side to move
@@ -90,7 +90,7 @@ bool UCTNode::create_children(Network & network,
     }
     eval = m_net_eval;
 
-    std::vector<Network::ScoreVertexPair> nodelist;
+    std::vector<Network::PolicyVertexPair> nodelist;
 
     auto legal_sum = 0.0f;
     for (auto i = 0; i < BOARD_SQUARES; i++) {
@@ -123,7 +123,7 @@ bool UCTNode::create_children(Network & network,
 }
 
 void UCTNode::link_nodelist(std::atomic<int>& nodecount,
-                            std::vector<Network::ScoreVertexPair>& nodelist,
+                            std::vector<Network::PolicyVertexPair>& nodelist,
                             float min_psa_ratio) {
     assert(min_psa_ratio < m_min_psa_ratio_children);
 
@@ -193,28 +193,28 @@ bool UCTNode::expandable(const float min_psa_ratio) const {
     return min_psa_ratio < m_min_psa_ratio_children;
 }
 
-float UCTNode::get_score() const {
-    return m_score;
+float UCTNode::get_policy() const {
+    return m_policy;
 }
 
-void UCTNode::set_score(float score) {
-    m_score = score;
+void UCTNode::set_policy(float policy) {
+    m_policy = policy;
 }
 
 int UCTNode::get_visits() const {
     return m_visits;
 }
 
-// Return the true score, without taking into account virtual losses.
+// Return the true evaluation, without taking into account virtual losses.
 float UCTNode::get_pure_eval(int tomove) const {
     auto visits = get_visits();
     assert(visits > 0);
     auto blackeval = get_blackevals();
-    auto score = static_cast<float>(blackeval / double(visits));
+    auto eval = static_cast<float>(blackeval / double(visits));
     if (tomove == FastBoard::WHITE) {
-        score = 1.0f - score;
+        eval = 1.0f - eval;
     }
-    return score;
+    return eval;
 }
 
 float UCTNode::get_eval(int tomove) const {
@@ -228,11 +228,11 @@ float UCTNode::get_eval(int tomove) const {
     if (tomove == FastBoard::WHITE) {
         blackeval += static_cast<double>(virtual_loss);
     }
-    auto score = static_cast<float>(blackeval / double(visits));
+    auto eval = static_cast<float>(blackeval / double(visits));
     if (tomove == FastBoard::WHITE) {
-        score = 1.0f - score;
+        eval = 1.0f - eval;
     }
-    return score;
+    return eval;
 }
 
 float UCTNode::get_net_eval(int tomove) const {
@@ -260,7 +260,7 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
         if (child.valid()) {
             parentvisits += child.get_visits();
             if (child.get_visits() > 0) {
-                total_visited_policy += child.get_score();
+                total_visited_policy += child.get_policy();
             }
         }
     }
@@ -288,7 +288,7 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
         if (child.get_visits() > 0) {
             winrate = child.get_eval(color);
         }
-        auto psa = child.get_score();
+        auto psa = child.get_policy();
         auto denom = 1.0 + child.get_visits();
         auto puct = cfg_puct * psa * (numerator / denom);
         auto value = winrate + puct;
@@ -316,9 +316,9 @@ public:
             return a.get_visits() < b.get_visits();
         }
 
-        // neither has visits, sort on prior score
+        // neither has visits, sort on policy prior
         if (a.get_visits() == 0) {
-            return a.get_score() < b.get_score();
+            return a.get_policy() < b.get_policy();
         }
 
         // both have same non-zero number of visits

--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -39,7 +39,7 @@ public:
     // search tree.
     static constexpr auto VIRTUAL_LOSS_COUNT = 3;
     // Defined in UCTNode.cpp
-    explicit UCTNode(int vertex, float score);
+    explicit UCTNode(int vertex, float policy);
     UCTNode() = delete;
     ~UCTNode() = default;
 
@@ -64,8 +64,8 @@ public:
     bool active() const;
     int get_move() const;
     int get_visits() const;
-    float get_score() const;
-    void set_score(float score);
+    float get_policy() const;
+    void set_policy(float policy);
     float get_eval(int tomove) const;
     float get_pure_eval(int tomove) const;
     float get_net_eval(int tomove) const;
@@ -91,7 +91,7 @@ private:
         ACTIVE
     };
     void link_nodelist(std::atomic<int>& nodecount,
-                       std::vector<Network::ScoreVertexPair>& nodelist,
+                       std::vector<Network::PolicyVertexPair>& nodelist,
                        float min_psa_ratio);
     double get_blackevals() const;
     void accumulate_eval(float eval);
@@ -108,12 +108,12 @@ private:
     std::atomic<std::int16_t> m_virtual_loss{0};
     std::atomic<int> m_visits{0};
     // UCT eval
-    float m_score;
+    float m_policy;
     // Original net eval for this node (not children).
     float m_net_eval{0.0f};
     std::atomic<double> m_blackevals{0.0};
     std::atomic<Status> m_status{ACTIVE};
-    // Is someone adding scores to this node?
+    // Is someone adding policy priors to this node?
     bool m_is_expanding{false};
     SMP::Mutex m_nodemutex;
 

--- a/src/UCTNodePointer.cpp
+++ b/src/UCTNodePointer.cpp
@@ -39,12 +39,12 @@ UCTNodePointer::UCTNodePointer(UCTNodePointer&& n) {
     n.m_data = 1; // non-inflated garbage
 }
 
-UCTNodePointer::UCTNodePointer(std::int16_t vertex, float score) {
-    std::uint32_t i_score;
+UCTNodePointer::UCTNodePointer(std::int16_t vertex, float policy) {
+    std::uint32_t i_policy;
     auto i_vertex = static_cast<std::uint16_t>(vertex);
-    std::memcpy(&i_score, &score, sizeof(i_score));
+    std::memcpy(&i_policy, &policy, sizeof(i_policy));
 
-    m_data =  (static_cast<std::uint64_t>(i_score)  << 32)
+    m_data =  (static_cast<std::uint64_t>(i_policy)  << 32)
             | (static_cast<std::uint64_t>(i_vertex) << 16) | 1ULL;
 }
 
@@ -61,7 +61,7 @@ UCTNodePointer& UCTNodePointer::operator=(UCTNodePointer&& n) {
 void UCTNodePointer::inflate() const {
     if (is_inflated()) return;
     m_data = reinterpret_cast<std::uint64_t>(
-        new UCTNode(read_vertex(), read_score()));
+        new UCTNode(read_vertex(), read_policy()));
 }
 
 bool UCTNodePointer::valid() const {
@@ -74,9 +74,9 @@ int UCTNodePointer::get_visits() const {
     return 0;
 }
 
-float UCTNodePointer::get_score() const {
-    if (is_inflated()) return read_ptr()->get_score();
-    return read_score();
+float UCTNodePointer::get_policy() const {
+    if (is_inflated()) return read_ptr()->get_policy();
+    return read_policy();
 }
 
 bool UCTNodePointer::active() const {

--- a/src/UCTNodePointer.h
+++ b/src/UCTNodePointer.h
@@ -46,7 +46,7 @@ class UCTNodePointer {
 private:
     // the raw storage used here.
     // if bit 0 is 0, m_data is the actual pointer.
-    // if bit 0 is 1, bit [31:16] is the vertex value, bit [63:32] is the score.
+    // if bit 0 is 1, bit [31:16] is the vertex value, bit [63:32] is the policy prior.
     // (C-style bit fields and unions are not portable)
     mutable uint64_t m_data = 1;
 
@@ -60,7 +60,7 @@ private:
         return static_cast<std::int16_t>(m_data >> 16);
     }
 
-    float read_score() const {
+    float read_policy() const {
         static_assert(sizeof(float) == 4,
             "This code assumes floats are 32-bit");
         assert(!is_inflated());
@@ -74,7 +74,7 @@ private:
 public:
     ~UCTNodePointer();
     UCTNodePointer(UCTNodePointer&& n);
-    UCTNodePointer(std::int16_t vertex, float score);
+    UCTNodePointer(std::int16_t vertex, float policy);
     UCTNodePointer(const UCTNodePointer&) = delete;
 
     bool is_inflated() const {
@@ -98,14 +98,14 @@ public:
         return ret;
     }
 
-    // construct UCTNode instance from the vertex/score pair
+    // construct UCTNode instance from the vertex/policy pair
     void inflate() const;
 
     // proxy of UCTNode methods which can be called without
     // constructing UCTNode
     bool valid() const;
     int get_visits() const;
-    float get_score() const;
+    float get_policy() const;
     bool active() const;
     int get_move() const;
     // this can only be called if it is an inflated pointer

--- a/src/UCTNodeRoot.cpp
+++ b/src/UCTNodeRoot.cpp
@@ -94,10 +94,10 @@ void UCTNode::dirichlet_noise(float epsilon, float alpha) {
 
     child_cnt = 0;
     for (auto& child : m_children) {
-        auto score = child->get_score();
+        auto policy = child->get_policy();
         auto eta_a = dirichlet_vector[child_cnt++];
-        score = score * (1 - epsilon) + epsilon * eta_a;
-        child->set_score(score);
+        policy = policy * (1 - epsilon) + epsilon * eta_a;
+        child->set_policy(policy);
     }
 }
 

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -107,7 +107,7 @@ private:
     void tree_stats(const UCTNode& node);
     std::string get_pv(FastState& state, UCTNode& parent);
     void dump_analysis(int playouts);
-    bool should_resign(passflag_t passflag, float bestscore);
+    bool should_resign(passflag_t passflag, float besteval);
     bool have_alternate_moves(int elapsed_centis, int time_for_move);
     int est_playouts_left(int elapsed_centis, int time_for_move) const;
     size_t prune_noncontenders(int elapsed_centis = 0, int time_for_move = 0,


### PR DESCRIPTION
I think that using "score" as a nonspecific term (and not when it, for example, refers to the count at the end of game) makes it unnecessarily hard to understand the code and see how it matches with the literature.