### PR TITLE
Add `input_pending` in `UCTSearch::think`

### DIFF
--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -721,7 +721,7 @@ int UCTSearch::think(int color, passflag_t passflag) {
         keeprunning  = is_running();
         keeprunning &= !stop_thinking(elapsed_centis, time_for_move);
         keeprunning &= have_alternate_moves(elapsed_centis, time_for_move);
-    } while (keeprunning);
+    } while (!Utils::input_pending() && keeprunning);
 
     // stop the search
     m_run = false;


### PR DESCRIPTION
Sometimes you only know a position and which color to move, but you don't know the game record, so the next color couldn't be determined automatically.

While "lz-analyze" command can do analyzing, we cannot choose which color to move arbitrarily.

"lz-genmove_analyze" can choose the color, but we can't press ENTER to stop.

To resolve it, I just did a small change: Adding `input_pending` in `UCTSearch::think`.

See: #1640 