### PR TITLE
Increase error budget in tuner

### DIFF
--- a/src/Tuner.cpp
+++ b/src/Tuner.cpp
@@ -48,10 +48,10 @@
 const auto TUNER_FILE_LOCAL = std::string("leelaz_opencl_tuning");
 #ifdef USE_HALF
 const auto TUNER_KERNEL = std::string("XgemmBatchedHalf");
-constexpr auto MAX_ERROR = 1e-2f;
+constexpr auto MAX_ERROR = 5e-2f;
 #else
 const auto TUNER_KERNEL = std::string("XgemmBatched");
-constexpr auto MAX_ERROR = 1e-4f;
+constexpr auto MAX_ERROR = 1e-3f;
 #endif
 
 using namespace Utils;


### PR DESCRIPTION
Fixes #1645. Tuner has 0.5 % error with the previous SGEMM dimensions with 256 channel network but it increases to 1.3 % with the new dimensions required for the new Winograd convolution. The network output seems to be fine even with the larger error so just increase the error limits in the tuner. 