### PR TITLE
Runtime selection of fp16/fp32

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -64,6 +64,9 @@ bool cfg_dumbpass;
 std::vector<int> cfg_gpus;
 bool cfg_sgemm_exhaustive;
 bool cfg_tune_only;
+#ifdef USE_HALF
+bool cfg_use_half;
+#endif
 #endif
 float cfg_puct;
 float cfg_softmax_temp;
@@ -101,6 +104,9 @@ void GTP::setup_default_parameters() {
     cfg_gpus = { };
     cfg_sgemm_exhaustive = false;
     cfg_tune_only = false;
+#ifdef USE_HALF
+    cfg_use_half = false;
+#endif
 #endif
     cfg_puct = 0.8f;
     cfg_softmax_temp = 1.0f;

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -48,6 +48,9 @@ extern bool cfg_dumbpass;
 extern std::vector<int> cfg_gpus;
 extern bool cfg_sgemm_exhaustive;
 extern bool cfg_tune_only;
+#ifdef USE_HALF
+extern bool cfg_use_half;
+#endif
 #endif
 extern float cfg_puct;
 extern float cfg_softmax_temp;

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -90,6 +90,9 @@ static void parse_commandline(int argc, char *argv[]) {
                 "ID of the OpenCL device(s) to use (disables autodetection).")
         ("full-tuner", "Try harder to find an optimal OpenCL tuning.")
         ("tune-only", "Tune OpenCL only and then exit.")
+#ifdef USE_HALF
+        ("use-half", "Use half-precision OpenCL code.  Traades off some accuracy for higher performance")
+#endif
         ;
 #endif
     po::options_description selfplay_desc("Self-play options");
@@ -318,6 +321,12 @@ static void parse_commandline(int argc, char *argv[]) {
     if (vm.count("tune-only")) {
         cfg_tune_only = true;
     }
+
+#ifdef USE_HALF
+    if (vm.count("use-half")) {
+        cfg_use_half = true;
+    }
+#endif
 #endif
 
     if (vm.count("benchmark")) {

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -91,7 +91,7 @@ static void parse_commandline(int argc, char *argv[]) {
         ("full-tuner", "Try harder to find an optimal OpenCL tuning.")
         ("tune-only", "Tune OpenCL only and then exit.")
 #ifdef USE_HALF
-        ("use-half", "Use half-precision OpenCL code.  Traades off some accuracy for higher performance")
+        ("use-half", "Use half-precision OpenCL code.  Trades off some accuracy for higher performance")
 #endif
         ;
 #endif

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -510,6 +510,9 @@ T relative_difference(const T a, const T b) {
     return fabs(fa - fb) / std::min(fa, fb);
 }
 
+#endif
+
+#ifdef USE_OPENCL_SELFCHECK
 void Network::compare_net_outputs(Netresult& data,
                                   Netresult& ref) {
     // We accept an error up to 20%, but output values
@@ -540,7 +543,7 @@ void Network::compare_net_outputs(Netresult& data,
     LOCK(m_selfcheck_mutex, selfcheck_lock);
     if (selfcheck_fail) {
         m_selfcheck_fails.push_back(true);
-        if (std::count(m_selfcheck_fails.begin(), m_selfcheck_fails.end(), true) >= max_failures) {
+        if (std::count(begin(m_selfcheck_fails), end(m_selfcheck_fails), true) >= max_failures) {
             printf("Error in OpenCL calculation: Update your GPU drivers or reduce the amount of games "
                    "played simultaneously.\n");
             throw std::runtime_error("OpenCL self-check mismatch.");
@@ -681,6 +684,7 @@ Network::Netresult Network::get_output_internal(
         m_forward->forward(input_data, policy_data, value_data);
     }
 #else
+    m_forward->forward(input_data, policy_data, value_data);
     (void) selfcheck;
 #endif
 

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -356,7 +356,6 @@ void Network::initialize(int playouts, const std::string & weightsfile) {
         if (cfg_use_half) {
             myprintf("Initializing OpenCL (half precision).\n");
             m_forward = std::make_unique<OpenCLScheduler<half_float::half>>();
-            use_selfcheck = false;
         } else {
             myprintf("Initializing OpenCL (single precision).\n");
             m_forward = std::make_unique<OpenCLScheduler<float>>();
@@ -493,7 +492,7 @@ T relative_difference(const T a, const T b) {
         return std::numeric_limits<T>::max();
     }
 
-    constexpr auto small_number = 1e-3f;
+    constexpr auto small_number = 1.0f/361.0f;
     auto fa = std::fabs(a);
     auto fb = std::fabs(b);
 
@@ -511,20 +510,47 @@ T relative_difference(const T a, const T b) {
     return fabs(fa - fb) / std::min(fa, fb);
 }
 
-void compare_net_outputs(std::vector<float>& data,
-                         std::vector<float>& ref) {
-    // We accept an error up to 5%, but output values
-    // smaller than 1/1000th are "rounded up" for the comparison.
-    constexpr auto relative_error = 5e-2f;
-    for (auto idx = size_t{0}; idx < data.size(); ++idx) {
-        const auto err = relative_difference(data[idx], ref[idx]);
+void Network::compare_net_outputs(Netresult& data,
+                                  Netresult& ref) {
+    // We accept an error up to 20%, but output values
+    // smaller than 1/361th are "rounded up" for the comparison.
+    constexpr auto relative_error = 2e-1f;
+
+    // assert-fail when we hit 3 failures out of last 10 checks
+    constexpr auto max_failures = 3;
+    constexpr auto last_failure_window = 10;
+
+    auto selfcheck_fail = false;
+    for (auto idx = size_t{0}; idx < data.policy.size(); ++idx) {
+        const auto err = relative_difference(data.policy[idx], ref.policy[idx]);
         if (err > relative_error) {
-            printf("Error in OpenCL calculation: expected %f got %f "
-                   "(error=%f%%)\n", ref[idx], data[idx], err * 100.0);
-            printf("Update your GPU drivers or reduce the amount of games "
+            selfcheck_fail = true;
+            break;
+        }
+    }
+    const auto err_pass = relative_difference(data.policy_pass, ref.policy_pass);
+    const auto err_winrate = relative_difference(data.winrate, ref.winrate);
+    if (err_pass > relative_error) {
+        selfcheck_fail = true;
+    }
+    if (err_winrate > relative_error) {
+        selfcheck_fail = true;
+    }
+
+    LOCK(m_selfcheck_mutex, selfcheck_lock);
+    if (selfcheck_fail) {
+        m_selfcheck_fails.push_back(true);
+        if (std::count(m_selfcheck_fails.begin(), m_selfcheck_fails.end(), true) >= max_failures) {
+            printf("Error in OpenCL calculation: Update your GPU drivers or reduce the amount of games "
                    "played simultaneously.\n");
             throw std::runtime_error("OpenCL self-check mismatch.");
         }
+    } else {
+        m_selfcheck_fails.push_back(false);
+    }
+
+    while (m_selfcheck_fails.size() >= last_failure_window) {
+        m_selfcheck_fails.pop_front();
     }
 }
 #endif
@@ -614,6 +640,16 @@ Network::Netresult Network::get_output(
         assert(symmetry == -1);
         const auto rand_sym = Random::get_Rng().randfix<NUM_SYMMETRIES>();
         result = get_output_internal(state, rand_sym);
+#ifdef USE_OPENCL_SELFCHECK
+        // Both implementations are available, self-check the OpenCL driver by
+        // running both with a probability of 1/2000.
+        // selfcheck is done here because this is the only place NN evaluation is done
+        // on actual gameplay.
+        if (m_forward_cpu != nullptr && Random::get_Rng().randfix<SELFCHECK_PROBABILITY>() == 0) {
+            auto result_ref = get_output_internal(state, rand_sym, true);
+            compare_net_outputs(result, result_ref);
+        }
+#endif
     }
 
     // v2 format (ELF Open Go) returns black value, not stm
@@ -630,7 +666,7 @@ Network::Netresult Network::get_output(
 }
 
 Network::Netresult Network::get_output_internal(
-    const GameState* const state, const int symmetry) {
+    const GameState* const state, const int symmetry, bool selfcheck) {
     assert(symmetry >= 0 && symmetry < NUM_SYMMETRIES);
     constexpr auto width = BOARD_SIZE;
     constexpr auto height = BOARD_SIZE;
@@ -638,17 +674,14 @@ Network::Netresult Network::get_output_internal(
     const auto input_data = gather_features(state, symmetry);
     std::vector<float> policy_data(OUTPUTS_POLICY * width * height);
     std::vector<float> value_data(OUTPUTS_VALUE * width * height);
-    m_forward->forward(input_data, policy_data, value_data);
 #ifdef USE_OPENCL_SELFCHECK
-    // Both implementations are available, self-check the OpenCL driver by
-    // running both with a probability of 1/2000.
-    if (m_forward_cpu != nullptr && Random::get_Rng().randfix<SELFCHECK_PROBABILITY>() == 0) {
-        auto cpu_policy_data = std::vector<float>(policy_data.size());
-        auto cpu_value_data = std::vector<float>(value_data.size());
-        m_forward_cpu->forward(input_data, cpu_policy_data, cpu_value_data);
-        compare_net_outputs(policy_data, cpu_policy_data);
-        compare_net_outputs(value_data, cpu_value_data);
+    if (selfcheck) {
+        m_forward_cpu->forward(input_data, policy_data, value_data);
+    } else {
+        m_forward->forward(input_data, policy_data, value_data);
     }
+#else
+    (void) selfcheck;
 #endif
 
     // Get the moves

--- a/src/Network.h
+++ b/src/Network.h
@@ -21,6 +21,7 @@
 
 #include "config.h"
 
+#include <deque>
 #include <array>
 #include <memory>
 #include <string>
@@ -37,6 +38,10 @@
 #include "ForwardPipe.h"
 #ifdef USE_OPENCL
 #include "OpenCLScheduler.h"
+#endif
+
+#ifdef USE_OPENCL_SELFCHECK
+#include "SMP.h"
 #endif
 
 
@@ -104,15 +109,22 @@ private:
                                const std::vector<float>& V,
                                std::vector<float>& M, const int C, const int K);
     Netresult get_output_internal(const GameState* const state,
-                                  const int symmetry);
+                                  const int symmetry, bool selfcheck = false);
     static void fill_input_plane_pair(const FullBoard& board,
                                       std::vector<float>::iterator black,
                                       std::vector<float>::iterator white,
                                       const int symmetry);
+    void compare_net_outputs(Netresult& data, Netresult& ref);
     bool probe_cache(const GameState* const state, Network::Netresult& result);
     std::unique_ptr<ForwardPipe> m_forward;
 #ifdef USE_OPENCL_SELFCHECK
     std::unique_ptr<ForwardPipe> m_forward_cpu;
+
+    // records the result of most recent selfchecks
+    std::deque<bool> m_selfcheck_fails;
+
+    // mutex that protects m_selfcheck_fails
+    SMP::Mutex m_selfcheck_mutex;
 #endif
 
     NNCache m_nncache;

--- a/src/Network.h
+++ b/src/Network.h
@@ -114,10 +114,10 @@ private:
                                       std::vector<float>::iterator black,
                                       std::vector<float>::iterator white,
                                       const int symmetry);
-    void compare_net_outputs(Netresult& data, Netresult& ref);
     bool probe_cache(const GameState* const state, Network::Netresult& result);
     std::unique_ptr<ForwardPipe> m_forward;
 #ifdef USE_OPENCL_SELFCHECK
+    void compare_net_outputs(Netresult& data, Netresult& ref);
     std::unique_ptr<ForwardPipe> m_forward_cpu;
 
     // records the result of most recent selfchecks

--- a/src/OpenCL.cpp
+++ b/src/OpenCL.cpp
@@ -44,12 +44,12 @@ using namespace Utils;
 template <typename net_t> static std::string getClArgs();
 
 template <> std::string getClArgs<float>() {
-    return 
+    return
         "-cl-mad-enable -cl-fast-relaxed-math -cl-no-signed-zeros -cl-denorms-are-zero";
 }
 #ifdef USE_HALF
 template <> std::string getClArgs<half_float::half>() {
-    return 
+    return
         "-DUSE_HALF "
         "-cl-mad-enable -cl-fast-relaxed-math -cl-no-signed-zeros -cl-denorms-are-zero";
 }

--- a/src/OpenCL.h
+++ b/src/OpenCL.h
@@ -34,6 +34,9 @@
 
 #include "Tuner.h"
 
+typedef float net_t;
+
+class OpenCLScheduler;
 class OpenCL;
 
 class Layer {
@@ -178,7 +181,7 @@ private:
 
 class OpenCL {
     friend class OpenCL_Network;
-    friend class Tuner;
+    friend class Tuner<net_t>;
 public:
     void initialize(const int channels, int gpu, bool silent = false);
     void ensure_context_initialized(OpenCLContext & opencl_context);

--- a/src/OpenCL.h
+++ b/src/OpenCL.h
@@ -34,13 +34,11 @@
 
 #include "Tuner.h"
 
-typedef float net_t;
-
-class OpenCLScheduler;
-class OpenCL;
+template <typename net_t> class OpenCL;
+template <typename net_t> class OpenCL_Network;
 
 class Layer {
-    friend class OpenCL_Network;
+    template <typename> friend class OpenCL_Network;
 private:
     unsigned int channels{0};
     unsigned int outputs{0};
@@ -52,8 +50,8 @@ private:
 };
 
 class OpenCLContext {
-    friend class OpenCL;
-    friend class OpenCL_Network;
+    template <typename> friend class OpenCL;
+    template <typename> friend class OpenCL_Network;
 private:
     bool m_is_initialized{false};
     cl::CommandQueue m_commandqueue;
@@ -72,10 +70,11 @@ private:
     bool m_buffers_allocated{false};
 };
 
+template <typename net_t>
 class OpenCL_Network {
 public:
-    OpenCL_Network(OpenCL & opencl) : m_opencl(opencl) {}
-    OpenCL & getOpenCL() {
+    OpenCL_Network(OpenCL<net_t> & opencl) : m_opencl(opencl) {}
+    OpenCL<net_t> & getOpenCL() {
         return m_opencl;
     }
 
@@ -169,7 +168,7 @@ private:
                   weight_slice_t weights,
                   int batch_size);
 
-    OpenCL & m_opencl;
+    OpenCL<net_t> & m_opencl;
 
     // this mutex is not required for correctness, but this exists simply
     // because queue.finish() is a busy wait and having a lot of threads
@@ -179,8 +178,9 @@ private:
     std::vector<Layer> m_layers;
 };
 
+template <typename net_t>
 class OpenCL {
-    friend class OpenCL_Network;
+    friend class OpenCL_Network<net_t>;
     friend class Tuner<net_t>;
 public:
     void initialize(const int channels, int gpu, bool silent = false);

--- a/src/OpenCLScheduler.h
+++ b/src/OpenCLScheduler.h
@@ -27,6 +27,8 @@
 #include "OpenCL.h"
 #include "ThreadPool.h"
 
+
+template <typename net_t>
 class OpenCLScheduler : public ForwardPipe {
     class ContextPoolEntry {
     public:
@@ -63,8 +65,8 @@ public:
                                const std::vector<float>& weights);
 
 private:
-    std::vector<std::unique_ptr<OpenCL_Network>> m_networks;
-    std::vector<std::unique_ptr<OpenCL>> m_opencl;
+    std::vector<std::unique_ptr<OpenCL_Network<net_t>>> m_networks;
+    std::vector<std::unique_ptr<OpenCL<net_t>>> m_opencl;
 
     using ContextPoolQueue = std::list<std::shared_ptr<ContextPoolEntry>>;
     std::vector<ContextPoolQueue> m_context_pool;

--- a/src/Tuner.h
+++ b/src/Tuner.h
@@ -27,11 +27,11 @@
 using Configurations = std::pair<std::string, std::vector<size_t>>;
 using Parameters = std::map<std::string, size_t>;
 
-class OpenCL;
+template <typename net_t> class OpenCL;
 
 template <typename net_t>
 class Tuner {
-    OpenCL & m_opencl;
+    OpenCL<net_t> & m_opencl;
     cl::Context m_context;
     cl::Device m_device;
 public:
@@ -41,7 +41,7 @@ public:
                                   const int batch_size);
 
     static constexpr auto TUNER_VERSION = 0;
-    Tuner(OpenCL & opencl, cl::Context context, cl::Device device) :
+    Tuner(OpenCL<net_t> & opencl, cl::Context context, cl::Device device) :
         m_opencl(opencl), m_context(context), m_device(device) {}
 private:
     void store_sgemm_tuners(const int m, const int n, const int k,

--- a/src/Tuner.h
+++ b/src/Tuner.h
@@ -29,6 +29,7 @@ using Parameters = std::map<std::string, size_t>;
 
 class OpenCL;
 
+template <typename net_t>
 class Tuner {
     OpenCL & m_opencl;
     cl::Context m_context;

--- a/src/config.h
+++ b/src/config.h
@@ -117,7 +117,7 @@
 #include "half/half.hpp"
 #endif
 
-#if defined(USE_BLAS) && defined(USE_OPENCL) 
+#if defined(USE_BLAS) && defined(USE_OPENCL)
 // If both BLAS and OpenCL are fully usable, then check the OpenCL
 // results against BLAS with some probability.
 #define USE_OPENCL_SELFCHECK

--- a/src/config.h
+++ b/src/config.h
@@ -73,6 +73,17 @@
  */
 #ifndef USE_CPU_ONLY
 #define USE_OPENCL
+
+/*
+ * USE_HALF: Include the half-precision OpenCL implementation when building.
+ * Unlike previous versions, this does not enable half-precision by default,
+ * it just compiles half-precision support.  You have to use the command line
+ * argument --use-half explicitly to enable half-precision.
+ * half-precision OpenCL gains performance on some GPUs while losing some
+ * accuracy on the calculation, so please test before enabling it.
+ */
+#define USE_HALF
+
 #endif
 
 /* Maximum supported batch size for OpenCL.
@@ -106,7 +117,7 @@
 #include "half/half.hpp"
 #endif
 
-#if defined(USE_BLAS) && defined(USE_OPENCL) && !defined(USE_HALF)
+#if defined(USE_BLAS) && defined(USE_OPENCL) 
 // If both BLAS and OpenCL are fully usable, then check the OpenCL
 // results against BLAS with some probability.
 #define USE_OPENCL_SELFCHECK

--- a/src/config.h
+++ b/src/config.h
@@ -104,9 +104,6 @@
 
 #ifdef USE_HALF
 #include "half/half.hpp"
-using net_t = half_float::half;
-#else
-using net_t = float;
 #endif
 
 #if defined(USE_BLAS) && defined(USE_OPENCL) && !defined(USE_HALF)


### PR DESCRIPTION
This adds --use-half as a command line option, and users can select between fp16/fp32 based on command line.
