### PR TITLE
Rearrange network globals.

### DIFF
--- a/src/GTP.h
+++ b/src/GTP.h
@@ -68,8 +68,8 @@ extern int cfg_analyze_interval_centis;
 */
 class GTP {
 public:
-    static Network * network;
-    static void initialize(Network * network);
+    static std::unique_ptr<Network> s_network;
+    static void initialize(std::unique_ptr<Network>&& network);
     static bool execute(GameState & game, std::string xinput);
     static void setup_default_parameters();
 private:

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -346,14 +346,13 @@ static void parse_commandline(int argc, char *argv[]) {
     cfg_options_str = out.str();
 }
 
-static Network network;
 static void initialize_network() {
+    auto network = std::make_unique<Network>();
     auto playouts = std::min(cfg_max_playouts, cfg_max_visits);
-    network.initialize(playouts, cfg_weightsfile);
+    network->initialize(playouts, cfg_weightsfile);
 
-    GTP::initialize(&network);
+    GTP::initialize(std::move(network));
 }
-
 
 // Setup global objects after command line has been parsed
 void init_global_objects() {
@@ -377,7 +376,7 @@ void benchmark(GameState& game) {
     game.play_textmove("w", "d4");
     game.play_textmove("b", "c3");
 
-    auto search = std::make_unique<UCTSearch>(game, network);
+    auto search = std::make_unique<UCTSearch>(game, *GTP::s_network);
     game.set_to_move(FastBoard::WHITE);
     search->think(FastBoard::WHITE);
 }

--- a/src/tests/gtests.cpp
+++ b/src/tests/gtests.cpp
@@ -52,7 +52,6 @@ void expect_regex(std::string s, std::string re, bool positive = true) {
 
 class LeelaEnv: public ::testing::Environment {
 public:
-    Network network;
     ~LeelaEnv() {}
     void SetUp() {
         GTP::setup_default_parameters();
@@ -73,8 +72,9 @@ public:
         cfg_weightsfile = "../src/tests/0k.txt";
 
         auto playouts = std::min(cfg_max_playouts, cfg_max_visits);
-        network.initialize(playouts, cfg_weightsfile);
-        GTP::initialize(&network);
+        auto network = std::make_unique<Network>();
+        network->initialize(playouts, cfg_weightsfile);
+        GTP::initialize(std::move(network));
     }
     void TearDown() {}
 };


### PR DESCRIPTION
Keep a single "network" global in GTP, owned by a unique_ptr and move
things around when needed.