### PR TITLE
Add Validation support for specifying GTP commands for each binary (2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ training/tf/venv
 leelaz-model*
 *.orig
 leelaz_opencl_tuning
+/validation/validation.pro.user
+/build-validation-Desktop_Qt_5_10_0_MSVC2017_64bit-Debug
+/build-validation-Desktop_Qt_5_10_0_MSVC2017_64bit-Release

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,4 @@ training/tf/venv
 leelaz-model*
 *.orig
 leelaz_opencl_tuning
-/validation/validation.pro.user
-/build-validation-Desktop_Qt_5_10_0_MSVC2017_64bit-Debug
-/build-validation-Desktop_Qt_5_10_0_MSVC2017_64bit-Release
+/build-validation-*

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ training/tf/venv
 leelaz-model*
 *.orig
 leelaz_opencl_tuning
+/build-autogtp-*
 /build-validation-*

--- a/autogtp/.gitignore
+++ b/autogtp/.gitignore
@@ -5,6 +5,7 @@
 /*.gz
 /moc_*.cpp
 /moc_*.h
+/autogtp.pro.user
 
 # Weight files
 /[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]

--- a/autogtp/Game.cpp
+++ b/autogtp/Game.cpp
@@ -23,11 +23,12 @@
 #include <QFileInfo>
 #include "Game.h"
 
-Game::Game(const QString& weights, const QString& opt, const QString& binary) :
+Game::Game(const QString& weights, const QString& opt, const QString& binary,
+           const QString& time_settings) :
     QProcess(),
     m_cmdLine(""),
     m_binary(binary),
-    m_timeSettings("time_settings 0 1 0"),
+    m_timeSettings("time_settings " + time_settings),
     m_resignation(false),
     m_blackToMove(true),
     m_blackResigned(false),

--- a/autogtp/Game.cpp
+++ b/autogtp/Game.cpp
@@ -181,7 +181,11 @@ bool Game::gameStart(const VersionTuple &min_version) {
     checkVersion(min_version);
     QTextStream(stdout) << "Engine has started." << endl;
     for (auto command : m_commands) {
-        sendGtpCommand(command);
+        if (!sendGtpCommand(command))
+        {
+            QTextStream(stdout) << "GTP failed on: " << command << endl;
+            exit(EXIT_FAILURE);
+        }
     }
     QTextStream(stdout) << "Thinking time set." << endl;
     return true;

--- a/autogtp/Game.cpp
+++ b/autogtp/Game.cpp
@@ -24,11 +24,11 @@
 #include "Game.h"
 
 Game::Game(const QString& weights, const QString& opt, const QString& binary,
-           const QString& time_settings) :
+           const QStringList& commands) :
     QProcess(),
     m_cmdLine(""),
     m_binary(binary),
-    m_timeSettings("time_settings " + time_settings),
+    m_commands(commands),
     m_resignation(false),
     m_blackToMove(true),
     m_blackResigned(false),
@@ -180,8 +180,10 @@ bool Game::gameStart(const VersionTuple &min_version) {
     // check any return values.
     checkVersion(min_version);
     QTextStream(stdout) << "Engine has started." << endl;
-    sendGtpCommand(m_timeSettings);
-    QTextStream(stdout) << "Infinite thinking time set." << endl;
+    for (auto command : m_commands) {
+        sendGtpCommand(command);
+    }
+    QTextStream(stdout) << "Thinking time set." << endl;
     return true;
 }
 

--- a/autogtp/Game.cpp
+++ b/autogtp/Game.cpp
@@ -181,6 +181,7 @@ bool Game::gameStart(const VersionTuple &min_version) {
     checkVersion(min_version);
     QTextStream(stdout) << "Engine has started." << endl;
     for (auto command : m_commands) {
+        QTextStream(stdout) << command << endl;
         if (!sendGtpCommand(command))
         {
             QTextStream(stdout) << "GTP failed on: " << command << endl;

--- a/autogtp/Game.h
+++ b/autogtp/Game.h
@@ -28,7 +28,8 @@ class Game : QProcess {
 public:
     Game(const QString& weights,
          const QString& opt,
-         const QString& binary = QString("./leelaz"));
+         const QString& binary = QString("./leelaz"),
+         const QString& time_settings = QString("0 1 0"));
     ~Game() = default;
     bool gameStart(const VersionTuple& min_version);
     void move();

--- a/autogtp/Game.h
+++ b/autogtp/Game.h
@@ -29,7 +29,7 @@ public:
     Game(const QString& weights,
          const QString& opt,
          const QString& binary = QString("./leelaz"),
-         const QString& time_settings = QString("0 1 0"));
+         const QStringList& commands = QStringList("time_settings 0 1 0"));
     ~Game() = default;
     bool gameStart(const VersionTuple& min_version);
     void move();
@@ -70,7 +70,7 @@ private:
     };
     QString m_cmdLine;
     QString m_binary;
-    QString m_timeSettings;
+    QStringList m_commands;
     QString m_winner;
     QString m_fileName;
     QString m_moveDone;

--- a/validation/.gitignore
+++ b/validation/.gitignore
@@ -1,3 +1,5 @@
+validation.pro.user
+
 /Makefile
 /.qmake.stash
 /validation

--- a/validation/Validation.cpp
+++ b/validation/Validation.cpp
@@ -28,14 +28,14 @@ const VersionTuple min_leelaz_version{0, 10, 0};
 
 void ValidationWorker::run() {
     do {
-        Game first(m_engines[0].network, m_engines[0].options,
-                   m_engines[0].binary, m_engines[0].commands);
+        Game first(m_engines[0].m_network, m_engines[0].m_options,
+                   m_engines[0].m_binary, m_engines[0].m_commands);
         if (!first.gameStart(min_leelaz_version)) {
             emit resultReady(Sprt::NoResult, Game::BLACK);
             return;
         }
-        Game second(m_engines[1].network, m_engines[1].options,
-                    m_engines[1].binary, m_engines[1].commands);
+        Game second(m_engines[1].m_network, m_engines[1].m_options,
+                    m_engines[1].m_binary, m_engines[1].m_commands);
         if (!second.gameStart(min_leelaz_version)) {
             emit resultReady(Sprt::NoResult, Game::BLACK);
             return;
@@ -109,13 +109,13 @@ void ValidationWorker::run() {
 }
 
 void ValidationWorker::init(const QString& gpuIndex,
-                            const QVector<engine_t>& engines,
+                            const QVector<Engine>& engines,
                             const QString& keep,
                             int expected) {
     m_engines = engines;
     if (!gpuIndex.isEmpty()) {
-        m_engines[0].options.prepend(" --gpu=" + gpuIndex + " ");
-        m_engines[1].options.prepend(" --gpu=" + gpuIndex + " ");
+        m_engines[0].m_options.prepend(" --gpu=" + gpuIndex + " ");
+        m_engines[1].m_options.prepend(" --gpu=" + gpuIndex + " ");
     }
     m_expected = expected;
     m_keepPath = keep;
@@ -125,7 +125,7 @@ void ValidationWorker::init(const QString& gpuIndex,
 Validation::Validation(const int gpus,
                        const int games,
                        const QStringList& gpuslist,
-                       QVector<engine_t>& engines,
+                       QVector<Engine>& engines,
                        const QString& keep,
                        QMutex* mutex,
                        const float& h0,
@@ -181,7 +181,7 @@ void Validation::saveSprt() {
     out << m_statistic;
     out << m_results;
     f.close();
-    m_results.printResults(m_engines[0].network, m_engines[1].network);
+    m_results.printResults(m_engines[0].m_network, m_engines[1].m_network);
     printSprtStatus(m_statistic.status());
 }
 
@@ -205,7 +205,7 @@ void Validation::loadSprt() {
     f.close();
     QFile::remove(fi.fileName());
     QTextStream(stdout) << "Initial Statistics" << endl;
-    m_results.printResults(m_engines[0].network, m_engines[1].network);
+    m_results.printResults(m_engines[0].m_network, m_engines[1].m_network);
     printSprtStatus(m_statistic.status());
 }
 
@@ -238,7 +238,7 @@ void Validation::getResult(Sprt::GameResult result, int net_one_color) {
             << "The first net is "
             <<  ((status.result ==  Sprt::AcceptH0) ? "worse " : "better ")
             << "than the second" << endl;
-        m_results.printResults(m_engines[0].network, m_engines[1].network);
+        m_results.printResults(m_engines[0].m_network, m_engines[1].m_network);
         //sendQuit();
     } else {
         printSprtStatus(status);

--- a/validation/Validation.h
+++ b/validation/Validation.h
@@ -28,9 +28,17 @@
 #include "../autogtp/Game.h"
 #include "Results.h"
 
+typedef struct engine {
+    QString binary;
+    QString options;
+    QString network;
+    QStringList commands;
+} engine_t;
+
 class ValidationWorker : public QThread {
     Q_OBJECT
 public:
+
     enum {
         RUNNING = 0,
         FINISHING
@@ -39,14 +47,7 @@ public:
     ValidationWorker(const ValidationWorker& w) : QThread(w.parent()) {}
     ~ValidationWorker() = default;
     void init(const QString& gpuIndex,
-              const QString& firstNet,
-              const QString& secondNet,
-              const QString& firstBin,
-              const QString& secondBin,
-              const QString& firstOpts,
-              const QString& secondOpts,
-              const QString& firstTimes,
-              const QString& secondTimes,
+              const QVector<engine_t>& engines,
               const QString& keep,
               int expected);
     void run() override;
@@ -55,16 +56,9 @@ public:
 signals:
     void resultReady(Sprt::GameResult r, int net_one_color);
 private:
-    QString m_firstNet;
-    QString m_secondNet;
+    QVector<engine_t> m_engines;
     int m_expected;
     QString m_keepPath;
-    QString m_firstBin;
-    QString m_secondBin;
-    QString m_firstOpts;
-    QString m_secondOpts;
-    QString m_firstTimes;
-    QString m_secondTimes;
     QAtomicInt m_state;
 };
 
@@ -74,16 +68,9 @@ class Validation : public QObject {
 public:
     Validation(const int gpus, const int games,
                const QStringList& gpusList,
-               const QString& firstNet,
-               const QString& secondNet,
+               QVector<engine_t>& engines,
                const QString& keep,
                QMutex* mutex,
-               const QString& firstBin,
-               const QString& secondBin,
-               const QString& firstOpts,
-               const QString& secondOpts,
-               const QString& firstTimes,
-               const QString& secondTimes,
                const float& h0,
                const float& h1);
     ~Validation() = default;
@@ -104,14 +91,7 @@ private:
     int m_games;
     int m_gpus;
     QStringList m_gpusList;
-    QString m_firstNet;
-    QString m_secondNet;
-    QString m_firstBin;
-    QString m_secondBin;
-    QString m_firstOpts;
-    QString m_secondOpts;
-    QString m_firstTimes;
-    QString m_secondTimes;
+    QVector<engine_t>& m_engines;
     QString m_keepPath;
     void quitThreads();
     void saveSprt();

--- a/validation/Validation.h
+++ b/validation/Validation.h
@@ -45,6 +45,8 @@ public:
               const QString& secondBin,
               const QString& firstOpts,
               const QString& secondOpts,
+              const QString& firstTimes,
+              const QString& secondTimes,
               const QString& keep,
               int expected);
     void run() override;
@@ -61,6 +63,8 @@ private:
     QString m_secondBin;
     QString m_firstOpts;
     QString m_secondOpts;
+    QString m_firstTimes;
+    QString m_secondTimes;
     QAtomicInt m_state;
 };
 
@@ -78,6 +82,8 @@ public:
                const QString& secondBin,
                const QString& firstOpts,
                const QString& secondOpts,
+               const QString& firstTimes,
+               const QString& secondTimes,
                const float& h0,
                const float& h1);
     ~Validation() = default;
@@ -104,6 +110,8 @@ private:
     QString m_secondBin;
     QString m_firstOpts;
     QString m_secondOpts;
+    QString m_firstTimes;
+    QString m_secondTimes;
     QString m_keepPath;
     void quitThreads();
     void saveSprt();

--- a/validation/Validation.h
+++ b/validation/Validation.h
@@ -28,12 +28,20 @@
 #include "../autogtp/Game.h"
 #include "Results.h"
 
-typedef struct engine {
-    QString binary;
-    QString options;
-    QString network;
-    QStringList commands;
-} engine_t;
+class Engine {
+public:
+    Engine(const QString& network,
+           const QString& options,
+           const QStringList& commands = QStringList("time_settings 0 1 0"),
+           const QString& binary = QString("./leelaz")) :
+        m_binary(binary), m_options(options),
+        m_network(network), m_commands(commands) {}
+    Engine() = default;
+    QString m_binary;
+    QString m_options;
+    QString m_network;
+    QStringList m_commands;
+};
 
 class ValidationWorker : public QThread {
     Q_OBJECT
@@ -47,7 +55,7 @@ public:
     ValidationWorker(const ValidationWorker& w) : QThread(w.parent()) {}
     ~ValidationWorker() = default;
     void init(const QString& gpuIndex,
-              const QVector<engine_t>& engines,
+              const QVector<Engine>& engines,
               const QString& keep,
               int expected);
     void run() override;
@@ -56,7 +64,7 @@ public:
 signals:
     void resultReady(Sprt::GameResult r, int net_one_color);
 private:
-    QVector<engine_t> m_engines;
+    QVector<Engine> m_engines;
     int m_expected;
     QString m_keepPath;
     QAtomicInt m_state;
@@ -68,7 +76,7 @@ class Validation : public QObject {
 public:
     Validation(const int gpus, const int games,
                const QStringList& gpusList,
-               QVector<engine_t>& engines,
+               QVector<Engine>& engines,
                const QString& keep,
                QMutex* mutex,
                const float& h0,
@@ -91,7 +99,7 @@ private:
     int m_games;
     int m_gpus;
     QStringList m_gpusList;
-    QVector<engine_t>& m_engines;
+    QVector<Engine>& m_engines;
     QString m_keepPath;
     void quitThreads();
     void saveSprt();

--- a/validation/main.cpp
+++ b/validation/main.cpp
@@ -122,9 +122,9 @@ int main(int argc, char *argv[]) {
     QStringList commandList = {"time_settings 0 1 0"};
     commandList << parser.values(gtpCommandOption);
 
-    auto engines = QVector<engine_t>({
-        {"./leelaz", optsList[0], netList[0], commandList},
-        {"./leelaz", optsList[1], netList[1], commandList}});
+    auto engines =
+        QVector<Engine>({Engine(netList[0], optsList[0], commandList),
+                         Engine(netList[1], optsList[1], commandList)});
 
     auto engine_idx = 0;
     auto pos_args = parser.positionalArguments();
@@ -132,9 +132,9 @@ int main(int argc, char *argv[]) {
         if (engine_idx >= 2) {
             parser.showHelp();
         }
-        engines[engine_idx].binary = pos_args[0];
+        engines[engine_idx].m_binary = pos_args[0];
         parser.process(pos_args);
-        engines[engine_idx].commands << parser.values(gtpCommandOption);
+        engines[engine_idx].m_commands << parser.values(gtpCommandOption);
         pos_args = parser.positionalArguments();
         engine_idx++;
     }

--- a/validation/main.cpp
+++ b/validation/main.cpp
@@ -52,7 +52,11 @@ int main(int argc, char *argv[]) {
             "filename");
     QCommandLineOption optionsOption(
         {"o", "options"},
-            "Options for the binary given by -b (default '-g -p 1600 --noponder -t 1 -q -d -r 0 -w').",
+            "Options for the binary given by -b (default \"-g -p 1600 --noponder -t 1 -q -d -r 0 -w\").",
+            "opt_string");
+    QCommandLineOption timesettingsOption(
+        {"ts", "time_settings"},
+            "time_settings command for the binary given by -b (default \"0 1 0\").",
             "opt_string");
     QCommandLineOption sprtOption(
         {"s", "sprt"},
@@ -76,6 +80,7 @@ int main(int argc, char *argv[]) {
     parser.addOption(networkOption);
     parser.addOption(binaryOption);
     parser.addOption(optionsOption);
+    parser.addOption(timesettingsOption);
     parser.addOption(sprtOption);
     parser.addOption(keepSgfOption);
 
@@ -94,6 +99,11 @@ int main(int argc, char *argv[]) {
     QStringList optsList = parser.values(optionsOption);
     while (optsList.count() != 2) {
         optsList << " -g  -p 1600 --noponder -t 1 -q -d -r 0 -w ";
+    }
+
+    QStringList timesList = parser.values(timesettingsOption);
+    while (timesList.count() != 2) {
+        timesList << "0 1 0";
     }
 
     QString sprtOpt = parser.value(sprtOption);
@@ -121,11 +131,12 @@ int main(int argc, char *argv[]) {
 
     Console *cons = nullptr;
     Validation *validate = new Validation(gpusNum, gamesNum, gpusList,
-                        netList.at(0), netList.at(1),
-                        parser.value(keepSgfOption), &mutex,
-                        binList.at(0), binList.at(1),
-                        optsList.at(0), optsList.at(1),
-                        h0, h1);
+                                          netList.at(0), netList.at(1),
+                                          parser.value(keepSgfOption), &mutex,
+                                          binList.at(0), binList.at(1),
+                                          optsList.at(0), optsList.at(1),
+                                          timesList.at(0), timesList.at(1),
+                                          h0, h1);
     QObject::connect(&app, &QCoreApplication::aboutToQuit, validate, &Validation::storeSprt);
     validate->loadSprt();
     validate->startGames();

--- a/validation/main.cpp
+++ b/validation/main.cpp
@@ -80,11 +80,10 @@ int main(int argc, char *argv[]) {
     parser.addOption(networkOption);
     parser.addOption(optionsOption);
     parser.addOption(gtpCommandOption);
-    parser.addPositionalArgument("binary",
+    parser.addPositionalArgument(
+        "[-- binary [--gtp-command...] [-- binary [--gtp-command...]]]",
         "Binary to execute for the game (default ./leelaz).\n"
         "Only --gtp-command options are parsed after a binary is specified");
-
-    parser.setOptionsAfterPositionalArgumentsMode(QCommandLineParser::ParseAsPositionalArguments);
 
     // Process the actual command line arguments given by the user
     parser.process(app);

--- a/validation/main.cpp
+++ b/validation/main.cpp
@@ -130,12 +130,14 @@ int main(int argc, char *argv[]) {
     QTextStream(stdout) << "SPRT : " << sprtOpt << " h0 " << h0 << " h1 " << h1 << endl;
 
     Console *cons = nullptr;
+    auto engines = QVector<engine_t>({{
+        binList.at(0), optsList.at(0), netList.at(0),
+        {QString("time_settings " + timesList.at(0))}}, {
+        binList.at(1), optsList.at(1), netList.at(1),
+        {QString("time_settings " + timesList.at(1))}}});
     Validation *validate = new Validation(gpusNum, gamesNum, gpusList,
-                                          netList.at(0), netList.at(1),
+                                          engines,
                                           parser.value(keepSgfOption), &mutex,
-                                          binList.at(0), binList.at(1),
-                                          optsList.at(0), optsList.at(1),
-                                          timesList.at(0), timesList.at(1),
                                           h0, h1);
     QObject::connect(&app, &QCoreApplication::aboutToQuit, validate, &Validation::storeSprt);
     validate->loadSprt();


### PR DESCRIPTION
Second attempt at #1459 but this time not dependent on Qt 5.6. Instead, each binary argument has to be preceded by "--" (otherwise all GTP commands are sent to all binaries).
Note though that I haven't actually tried building with Qt 5.3.
```
validation.exe -h
Usage: validation.exe [options] [-- binary [--gtp-command...] [-- binary [--gtp-
command...]]]

Options:
  -?, -h, --help                    Displays this help.
  -v, --version                     Displays version information.
  -g, --gamesNum <num>              Play 'gamesNum' games on one GPU at the
                                    same time.
  -u, --gpus <num>                  Index of the GPU to use for multiple GPUs
                                    support.
  -s, --sprt <lower:upper>          Set the SPRT hypothesis (default
                                    '0.0:35.0').
  -k, --keepSgf <output directory>  Save SGF files after each self-play game.
  -n, --network <filename>          Networks to use as players in competition
                                    mode (two are needed).
  -o, --options <opt_string>        Options for the binary given by -b (default
                                    "-g -v 3200 --noponder -t 1 -q -d -r 0 -w").

  -c, --gtp-command <command>       GTP command to send to the binary on
                                    startup (default "time_settings 0 1 0").
                                    Multiple commands are sent in the order they

                                    are specified.
                                    Commands apply to the preceeding binary or
                                    both if specified before all binaries.

Arguments:
  [-- binary [--gtp-command...] [-- binary [--gtp-command...]]] Binary to
                                                                execute for the
                                                                game (default
                                                                ./leelaz).
                                                                Only
                                                                --gtp-command
                                                                options are
                                                                parsed after a
                                                                binary is
                                                                specified
```