### PR TITLE
Fix a bug that an SGF file/string cannot contain 2 consecutive moves of the same color

### DIFF
--- a/src/SGFTree.cpp
+++ b/src/SGFTree.cpp
@@ -71,14 +71,14 @@ GameState SGFTree::follow_mainline_state(unsigned int movenum) {
     for (unsigned int i = 0; i <= movenum && link != nullptr; i++) {
         // root position has no associated move
         if (i != 0) {
-            int move = link->get_move(result.get_to_move());
-            if (move != SGFTree::EOT) {
-                if (move != FastBoard::PASS && move != FastBoard::EMPTY
-                    && result.board.get_square(move) != FastBoard::EMPTY) {
+            auto colored_move = link->get_colored_move();
+            if (colored_move.first != FastBoard::INVAL) {
+                if (colored_move.second != FastBoard::PASS && colored_move.second != FastBoard::EMPTY
+                    && result.board.get_square(colored_move.second) != FastBoard::EMPTY) {
                     // Fail loading
                     return result;
                 }
-                result.play_move(move);
+                result.play_move(colored_move.first, colored_move.second);
             }
         }
         link = link->get_child(0);
@@ -241,9 +241,9 @@ void SGFTree::populate_states(void) {
 
         // XXX: maybe move this to the recursive call
         // get move for side to move
-        int move = child_state.get_move(m_state.get_to_move());
-        if (move != EOT) {
-            child_state.apply_move(move);
+        auto colored_move = child_state.get_colored_move();
+        if (colored_move.first != FastBoard::INVAL) {
+            child_state.apply_move(colored_move.first, colored_move.second);
         }
 
         child_state.populate_states();
@@ -351,6 +351,18 @@ int SGFTree::get_move(int tomove) {
     }
 
     return SGFTree::EOT;
+}
+
+std::pair<int, int> SGFTree::get_colored_move(void) {
+    for (auto it = m_properties.cbegin(); it != m_properties.cend(); ++it) {
+        if (it->first == "B") {
+            return std::make_pair(FastBoard::BLACK, string_to_vertex(it->second));
+        }
+        else if (it->first == "W") {
+            return std::make_pair(FastBoard::WHITE, string_to_vertex(it->second));
+        }
+    }
+    return std::make_pair(FastBoard::INVAL, 0);
 }
 
 FastBoard::square_t SGFTree::get_winner() const {

--- a/src/SGFTree.h
+++ b/src/SGFTree.h
@@ -46,6 +46,7 @@ public:
     SGFTree * add_child();
     SGFTree * get_child(size_t count);
     int get_move(int tomove);
+    std::pair<int, int> get_colored_move(void);
     bool is_initialized() const {
         return m_initialized;
     }


### PR DESCRIPTION
Fixes #1469.

As I'm not a C++ developer, please check my modifications carefully to see if they are all correct. I've tested, but maybe there're coding style or other problems.

This bug will be triggered if:

- There're 2 or more consecutive moves of the same color; or
- There's `AW` and the first move is WHITE; or
- There's no `AW` but there's `AB`, and the first move is BLACK.

The reason is that SGFTree passes `get_to_move()` as the argument when calling `get_move` method, so if all moves are not "black, white, black, white...", then it won't be loaded correctly. (Here all handicap/setup stones can be considered as one move and the color can be considered as black if there's no `AW`, or white if there's `AW`.)

I've replaced 2 places of `get_move`. There's still one place left, but that's related to training so it's impossible to trigger this bug (but maybe better also change it?).

The `follow_mainline_state` modification is required. But during my test, I found `populate_states` modification takes no effect, that is, it seems also OK if unchanged.

Another thing I don't know why is that `std::make_pair(FastBoard::INVAL, 0)` works, but if modified to `std::make_pair(FastBoard::INVAL, SGFTree::EOT)` then it will report error when compiling.