### PR TITLE
Implemented NN eval fp16/fp32 autodetect

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -65,7 +65,7 @@ std::vector<int> cfg_gpus;
 bool cfg_sgemm_exhaustive;
 bool cfg_tune_only;
 #ifdef USE_HALF
-bool cfg_use_half;
+std::string cfg_precision;
 #endif
 #endif
 float cfg_puct;
@@ -105,7 +105,7 @@ void GTP::setup_default_parameters() {
     cfg_sgemm_exhaustive = false;
     cfg_tune_only = false;
 #ifdef USE_HALF
-    cfg_use_half = false;
+    cfg_precision = "auto";
 #endif
 #endif
     cfg_puct = 0.8f;

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -65,7 +65,7 @@ std::vector<int> cfg_gpus;
 bool cfg_sgemm_exhaustive;
 bool cfg_tune_only;
 #ifdef USE_HALF
-std::string cfg_precision;
+precision_t cfg_precision;
 #endif
 #endif
 float cfg_puct;
@@ -105,7 +105,7 @@ void GTP::setup_default_parameters() {
     cfg_sgemm_exhaustive = false;
     cfg_tune_only = false;
 #ifdef USE_HALF
-    cfg_precision = "auto";
+    cfg_precision = precision_t::AUTO;
 #endif
 #endif
     cfg_puct = 0.8f;

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -49,7 +49,10 @@ extern std::vector<int> cfg_gpus;
 extern bool cfg_sgemm_exhaustive;
 extern bool cfg_tune_only;
 #ifdef USE_HALF
-extern std::string cfg_precision;
+enum class precision_t {
+    AUTO, SINGLE, HALF
+};
+extern precision_t cfg_precision;
 #endif
 #endif
 extern float cfg_puct;

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -49,7 +49,7 @@ extern std::vector<int> cfg_gpus;
 extern bool cfg_sgemm_exhaustive;
 extern bool cfg_tune_only;
 #ifdef USE_HALF
-extern bool cfg_use_half;
+extern std::string cfg_precision;
 #endif
 #endif
 extern float cfg_puct;

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -91,8 +91,7 @@ static void parse_commandline(int argc, char *argv[]) {
         ("full-tuner", "Try harder to find an optimal OpenCL tuning.")
         ("tune-only", "Tune OpenCL only and then exit.")
 #ifdef USE_HALF
-        ("use-half", "Use half-precision OpenCL code.\n"
-                     "Trades off some accuracy for higher performance.")
+        ("precision", po::value<std::string>(), "Floating-point precision (single/half/auto)")
 #endif
         ;
 #endif
@@ -324,8 +323,13 @@ static void parse_commandline(int argc, char *argv[]) {
     }
 
 #ifdef USE_HALF
-    if (vm.count("use-half")) {
-        cfg_use_half = true;
+    if (vm.count("precision")) {
+        cfg_precision = vm["precision"].as<std::string>();
+        auto opts = {"single", "half", "auto"};
+        if ( end(opts) == std::find(begin(opts), end(opts), cfg_precision) ) {
+            printf("Unexpected option for --precision, expecting single/half/auto\n");
+            exit(EXIT_FAILURE);
+        }
     }
 #endif
 #endif

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -91,7 +91,8 @@ static void parse_commandline(int argc, char *argv[]) {
         ("full-tuner", "Try harder to find an optimal OpenCL tuning.")
         ("tune-only", "Tune OpenCL only and then exit.")
 #ifdef USE_HALF
-        ("precision", po::value<std::string>(), "Floating-point precision (single/half/auto)")
+        ("precision", po::value<std::string>(), "Floating-point precision (single/half/auto).\n"
+                                                "Default is to auto which automatically determines which one to use.")
 #endif
         ;
 #endif
@@ -324,9 +325,14 @@ static void parse_commandline(int argc, char *argv[]) {
 
 #ifdef USE_HALF
     if (vm.count("precision")) {
-        cfg_precision = vm["precision"].as<std::string>();
-        auto opts = {"single", "half", "auto"};
-        if ( end(opts) == std::find(begin(opts), end(opts), cfg_precision) ) {
+        auto precision = vm["precision"].as<std::string>();
+        if ("single" == precision) {
+            cfg_precision = precision_t::SINGLE;
+        } else if ("half" == precision) {
+            cfg_precision = precision_t::HALF;
+        } else if ("auto" == precision) {
+            cfg_precision = precision_t::AUTO;
+        } else {
             printf("Unexpected option for --precision, expecting single/half/auto\n");
             exit(EXIT_FAILURE);
         }

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -393,10 +393,12 @@ void Network::initialize(int playouts, const std::string & weightsfile) {
                 to_init.emplace_back(fp16net.get());
                 m_forward = std::make_unique<OpenCLScheduler<float>>();
             }
+            break;
             case precision_t::SINGLE: {
                 myprintf("Initializing OpenCL (single precision).\n");
                 m_forward = std::make_unique<OpenCLScheduler<float>>();
             }
+            break;
             case precision_t::HALF: {
                 myprintf("Initializing OpenCL (half precision).\n");
                 m_forward = std::make_unique<OpenCLScheduler<half_float::half>>();

--- a/src/Network.h
+++ b/src/Network.h
@@ -73,6 +73,8 @@ public:
     static constexpr auto OUTPUTS_VALUE = 1;
 
     void initialize(int playouts, const std::string & weightsfile);
+
+    float benchmark_time(int centiseconds);
     void benchmark(const GameState * const state,
                    const int iterations = 1600);
     static void show_heatmap(const FastState * const state,

--- a/src/config.h
+++ b/src/config.h
@@ -76,11 +76,11 @@
 
 /*
  * USE_HALF: Include the half-precision OpenCL implementation when building.
- * This does not enable half-precision by default, it just compiles
- * half-precision support.  You have to use the command line
- * argument --use-half explicitly to enable half-precision.
+ * The current implementation autodetects whether half-precision is better
+ * or single-precision is better (half precision is chosen if it's 5% faster)
  * Half-precision OpenCL gains performance on some GPUs while losing some
- * accuracy on the calculation, so please test strength before enabling it.
+ * accuracy on the calculation, but generally it is worth using half precision
+ * if it is at least 5% faster.
  */
 #define USE_HALF
 


### PR DESCRIPTION
Runs both precisions for 1 seconds, and if fp16 is faster than fp32 by more than 5%, fp16 is used.
removes --use-half, replaces it with --precision [auto|single|half] option, default auto