### PR TITLE
Use L2-norm in self check

### DIFF
--- a/src/Network.h
+++ b/src/Network.h
@@ -121,11 +121,6 @@ private:
     void compare_net_outputs(Netresult& data, Netresult& ref);
     std::unique_ptr<ForwardPipe> m_forward_cpu;
 
-    // Records the result of most recent selfchecks
-    std::deque<bool> m_selfcheck_fails;
-
-    // Mutex that protects m_selfcheck_fails
-    SMP::Mutex m_selfcheck_mutex;
 #endif
 
     NNCache m_nncache;


### PR DESCRIPTION
The previous method is too strict for fp16 compute. Since lower precision of fp16 is still good enough to play at the same strength as fp32 relax the self check.

Maximum L2-norm error in about 1000 checks for various options using 192x15 network:

| Precision    | Max error |
|--------------|-----------|
| fp32         | 5e-6      |
| fp16_storage | 0.015     |
| fp16_compute | 0.042     |

fp16_compute vs fp32 on Intel(R) HD Graphics Kabylake Desktop GT1.5 using 200 visits with the latest 192x15 network.

```
lz_fp32 v lz_fp16 (131/400 games)
board size: 19   komi: 7.5
          wins              black         white       avg cpu
lz_fp32     62 47.33%       29 43.94%     33 50.77%     93.83
lz_fp16     69 52.67%       32 49.23%     37 56.06%     92.28
                            61 46.56%     70 53.44%

```

These games were played with this pull request and there were no self-check failures.

<details>
<Summary>Ringmaster config</Summary>

```
competition_type = 'playoff'

description = """
fp16 vs fp32
"""

record_games = True
stderr_to_log = False

players = {
    'lz_fp32' : Player("../../leelaz -g -d -t 1 --noponder -v 200 -r 10 -w d351f06e446ba10697bfd2977b4be52c3de148032865eaaf9efc9796aea95a0c.gz --precision single", startup_gtp_commands=["time_settings 0 1 0"]),
    'lz_fp16' : Player("../../leelaz -g -d -t 1 --noponder -v 200 -r 10 -w d351f06e446ba10697bfd2977b4be52c3de148032865eaaf9efc9796aea95a0c.gz --precision half", startup_gtp_commands=["time_settings 0 1 0"]),
    }

board_size = 19
komi = 7.5

matchups = [
    Matchup('lz_fp32', 'lz_fp16',
            alternating=True,
            number_of_games=400),
    ]
```
</details>
