### PR TITLE
Allow unlimited thinking during opponent time

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -47,6 +47,7 @@ using namespace Utils;
 // Configuration flags
 bool cfg_gtp_mode;
 bool cfg_allow_pondering;
+bool cfg_deep_ponder;
 int cfg_num_threads;
 int cfg_max_threads;
 int cfg_max_playouts;

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -31,6 +31,7 @@
 
 extern bool cfg_gtp_mode;
 extern bool cfg_allow_pondering;
+extern bool cfg_deep_ponder;
 extern int cfg_num_threads;
 extern int cfg_max_threads;
 extern int cfg_max_playouts;

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -79,6 +79,7 @@ static void parse_commandline(int argc, char *argv[]) {
                        "fast = Same as on but always plays faster.\n"
                        "no_pruning = For self play training use.\n")
         ("noponder", "Disable thinking on opponent's time.")
+        ("deepponder", "Unlimited thinking on opponent's time.")
         ("benchmark", "Test network and exit. Default args:\n-v3200 --noponder "
                       "-m0 -t1 -s1.")
         ("cpu-only", "Use CPU-only implementation and do not use GPU.")
@@ -260,6 +261,16 @@ static void parse_commandline(int argc, char *argv[]) {
 
     if (vm.count("noponder")) {
         cfg_allow_pondering = false;
+    }
+
+    if (vm.count("deepponder")) {
+        cfg_deep_ponder = true;
+        if (vm.count("noponder")) {
+            printf("Nonsensical options: Deep pondering is requested but "
+                "thinking on the opponent's time is not allowed. "
+                "Remove --noponder to allow pondering.\n");
+            exit(EXIT_FAILURE);
+        }
     }
 
     if (vm.count("noise")) {

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -787,7 +787,7 @@ void UCTSearch::ponder() {
             }
         }
         keeprunning  = is_running();
-        keeprunning &= !stop_thinking(0, 1);
+        keeprunning &= (cfg_deep_ponder || !stop_thinking(0, 1));
     } while (!Utils::input_pending() && keeprunning);
 
     // stop the search


### PR DESCRIPTION
Add a new command line option --deepponder to allow unlimited thinking during opponent time even when --playouts or --visits are set.