### PR TITLE
Pondering revisited

### DIFF
--- a/src/GTP.h
+++ b/src/GTP.h
@@ -30,7 +30,7 @@
 #include "UCTSearch.h"
 
 extern bool cfg_gtp_mode;
-extern bool cfg_allow_pondering;
+extern int cfg_ponder;
 extern int cfg_num_threads;
 extern int cfg_max_threads;
 extern int cfg_max_playouts;

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -787,7 +787,7 @@ void UCTSearch::ponder() {
             }
         }
         keeprunning  = is_running();
-        keeprunning &= !stop_thinking(0, 1);
+        keeprunning &= (cfg_ponder == Pondering::UNLIMITED || !stop_thinking(0, 1));
     } while (!Utils::input_pending() && keeprunning);
 
     // stop the search

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -64,6 +64,12 @@ namespace TimeManagement {
     };
 };
 
+namespace Pondering {
+    enum enabled_t {
+        OFF = 0, ON = 1, UNLIMITED = 2
+    };
+};
+
 class UCTSearch {
 public:
     /*


### PR DESCRIPTION
Removed --noponder command line option and --playouts requiring
--noponder

Added --ponder [off|on|unlimited] command line option
off = similar to the old --noponder
on = similar to actual pondering (limited to --visits and --playouts)
unlimited = pondering without limitations

Added gtp command lz-ponder [off|on|unlimited]