### PR TITLE
Change policy vector to array.

### DIFF
--- a/src/NNCache.cpp
+++ b/src/NNCache.cpp
@@ -73,7 +73,7 @@ void NNCache::resize(int size) {
 void NNCache::set_size_from_playouts(int max_playouts) {
     // cache hits are generally from last several moves so setting cache
     // size based on playouts increases the hit rate while balancing memory
-    // usage for low playout instances. 150'000 cache entries is ~225 MB
+    // usage for low playout instances. 150'000 cache entries is ~208 MiB
     constexpr auto num_cache_moves = 3;
     auto max_playouts_per_move =
         std::min(max_playouts,

--- a/src/NNCache.h
+++ b/src/NNCache.h
@@ -21,17 +21,17 @@
 
 #include "config.h"
 
+#include <array>
 #include <deque>
 #include <memory>
 #include <mutex>
 #include <unordered_map>
-#include <vector>
 
 class NNCache {
 public:
     struct Netresult {
         // 19x19 board positions
-        std::vector<float> policy;
+        std::array<float, BOARD_SQUARES> policy;
 
         // pass
         float policy_pass;
@@ -39,10 +39,12 @@ public:
         // winrate
         float winrate;
 
-        Netresult() : policy(BOARD_SQUARES), policy_pass(0.0f), winrate(0.0f) {}
+        Netresult() : policy_pass(0.0f), winrate(0.0f) {
+            policy.fill(0.0f);
+        }
     };
 
-    NNCache(int size = 150000);  // ~ 225MB
+    NNCache(int size = 150000);  // ~ 208MiB
 
     // Set a reasonable size gives max number of playouts
     void set_size_from_playouts(int max_playouts);
@@ -77,7 +79,7 @@ private:
     struct Entry {
         Entry(const Netresult& r)
             : result(r) {}
-        Netresult result;  // ~ 1.5KB
+        Netresult result;  // ~ 1.4KiB
     };
 
     // Map from hash to {features, result}

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -610,10 +610,9 @@ bool Network::probe_cache(const GameState* const state,
             const auto hash = state->get_symmetry_hash(sym);
             if (m_nncache.lookup(hash, result)) {
                 decltype(result.policy) corrected_policy;
-                corrected_policy.reserve(BOARD_SQUARES);
                 for (auto idx = size_t{0}; idx < BOARD_SQUARES; ++idx) {
                     const auto sym_idx = symmetry_nn_idx_table[sym][idx];
-                    corrected_policy.emplace_back(result.policy[sym_idx]);
+                    corrected_policy[idx] = result.policy[sym_idx];
                 }
                 result.policy = std::move(corrected_policy);
                 return true;

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -78,8 +78,8 @@ public:
 
     /*
         Maximum size of the tree in memory. Nodes are about
-        48 bytes, so limit to ~1.2G on 32-bits and about 5.5G
-        on 64-bits.
+        56 bytes, so limit to ~1.3GiB on 32-bits and about
+        5.2GiB on 64-bits.
     */
     static constexpr auto MAX_TREE_SIZE =
         (sizeof(void*) == 4 ? 25'000'000 : 100'000'000);


### PR DESCRIPTION
Should save a tiny bit of memory.