### PR TITLE
Network initialization restructuring

### DIFF
--- a/src/OpenCL.cpp
+++ b/src/OpenCL.cpp
@@ -111,10 +111,8 @@ void OpenCL_Network<net_t>::add_weights(size_t layer,
         m_layers.push_back(Layer());
     }
 
-    auto converted_weights = std::vector<net_t>();
-    for (auto i = size_t{0}; i < size; i++) {
-        converted_weights.emplace_back(weights[i]);
-    }
+    auto converted_weights = std::vector<net_t>(size);
+    std::copy(weights, weights + size, begin(converted_weights));
 
     auto weightSize = size * sizeof(typename decltype(converted_weights)::value_type);
     m_layers.back().weights.emplace_back(


### PR DESCRIPTION
- Create one net at a time when doing fp16/fp32 autodetect.  Saves some GPU memory
- Create an internal lambda which initializes the nets
- Use std::copy to copy vectors to reduce runtime

Related to #1748 - possibly addresses concern, plus makes the code cleaner