### PR TITLE
ELF training

### DIFF
--- a/training/tf/chunkparser.py
+++ b/training/tf/chunkparser.py
@@ -212,6 +212,8 @@ class ChunkParser:
         winner = float(text_item[18])
         if not(winner == 1.0 or winner == -1.0):
             return False, None
+        if stm == 1
+            winner = -winner
         winner = int((winner + 1) / 2)
 
         version = struct.pack('i', 1)

--- a/training/tf/chunkparser.py
+++ b/training/tf/chunkparser.py
@@ -212,7 +212,7 @@ class ChunkParser:
         winner = float(text_item[18])
         if not(winner == 1.0 or winner == -1.0):
             return False, None
-        if stm == 1
+        if stm == 1:
             winner = -winner
         winner = int((winner + 1) / 2)
 


### PR DESCRIPTION
This is not intended to be merged for now but just to facilitate the training of ELF weights with LZ-produced data. Ideally the weights file should be read to determine whether it's v1 or v2 and apply the change in this commit if it's v2, but reading the network is in another py file IIUC. net2net should just work, so it may be a good idea to net2net to 256x40 (or 256x30 as some has suggested) and train with this modified code.
@Ttl Does this look working to you? I am worried that if we don't keep sampling 50% positions from black-won games and 50% from white-won games we may mess up the value head. https://github.com/pytorch/ELF/issues/74#issuecomment-409087307 How do you think we can achieve this?