### PR TITLE
Improve MTCS a bit

### DIFF
--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -273,6 +273,11 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
     for (auto& child : m_children) {
         if (!child.active()) {
             continue;
+        } else {
+            child.inflate();
+            if (child->m_is_expanding) {
+                continue;
+            }
         }
 
         auto winrate = fpu_eval;

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -271,12 +271,14 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
     auto best_value = std::numeric_limits<double>::lowest();
 
     for (auto& child : m_children) {
-        if (!child.active() || (child.is_inflated() && child->m_is_expanding)) {
+        if (!child.active()) {
             continue;
         }
 
         auto winrate = fpu_eval;
-        if (child.get_visits() > 0) {
+        if (child.is_inflated() && child->m_is_expanding) {
+            winrate = - fpu_reduction - 1.0;
+        } else if (child.get_visits() > 0) {
             winrate = child.get_eval(color);
         }
         auto psa = child.get_policy();

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -271,13 +271,8 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
     auto best_value = std::numeric_limits<double>::lowest();
 
     for (auto& child : m_children) {
-        if (!child.active()) {
+        if (!child.active() || (child.is_inflated() && child->m_is_expanding)) {
             continue;
-        } else {
-            child.inflate();
-            if (child->m_is_expanding) {
-                continue;
-            }
         }
 
         auto winrate = fpu_eval;


### PR DESCRIPTION
Search thread should explore other nodes in this case, this would save
the search from some useless searches.

It has benefit for batching support too. Before this change, all
threads could be busy waiting for the first node being expanded.