### PR TITLE
Network : remove unused residual tower weight values

### DIFF
--- a/src/CPUPipe.cpp
+++ b/src/CPUPipe.cpp
@@ -265,25 +265,25 @@ template <size_t spatial_size>
 void batchnorm(const size_t channels,
                std::vector<float>& data,
                const float* const means,
-               const float* const stddivs,
+               const float* const stddevs,
                const float* const eltwise = nullptr) {
     const auto lambda_ReLU = [](const auto val) { return (val > 0.0f) ?
                                                           val : 0.0f; };
     for (auto c = size_t{0}; c < channels; ++c) {
         const auto mean = means[c];
-        const auto scale_stddiv = stddivs[c];
+        const auto scale_stddev = stddevs[c];
         const auto arr = &data[c * spatial_size];
 
         if (eltwise == nullptr) {
             // Classical BN
             for (auto b = size_t{0}; b < spatial_size; b++) {
-                arr[b] = lambda_ReLU(scale_stddiv * (arr[b] - mean));
+                arr[b] = lambda_ReLU(scale_stddev * (arr[b] - mean));
             }
         } else {
             // BN + residual add
             const auto res = &eltwise[c * spatial_size];
             for (auto b = size_t{0}; b < spatial_size; b++) {
-                arr[b] = lambda_ReLU((scale_stddiv * (arr[b] - mean)) + res[b]);
+                arr[b] = lambda_ReLU((scale_stddev * (arr[b] - mean)) + res[b]);
             }
         }
     }
@@ -306,81 +306,47 @@ void CPUPipe::forward(const std::vector<float>& input,
     auto V = std::vector<float>(WINOGRAD_TILE * input_channels * P);
     auto M = std::vector<float>(WINOGRAD_TILE * output_channels * P);
 
-    winograd_convolve3(output_channels, input, m_conv_weights[0], V, M, conv_out);
+    winograd_convolve3(output_channels, input, m_weights->m_conv_weights[0], V, M, conv_out);
     batchnorm<NUM_INTERSECTIONS>(output_channels, conv_out,
-                                 m_batchnorm_means[0].data(),
-                                 m_batchnorm_stddivs[0].data());
+                                 m_weights->m_batchnorm_means[0].data(),
+                                 m_weights->m_batchnorm_stddevs[0].data());
 
     // Residual tower
     auto conv_in = std::vector<float>(output_channels * NUM_INTERSECTIONS);
     auto res = std::vector<float>(output_channels * NUM_INTERSECTIONS);
-    for (auto i = size_t{1}; i < m_conv_weights.size(); i += 2) {
+    for (auto i = size_t{1}; i < m_weights->m_conv_weights.size(); i += 2) {
         auto output_channels = m_input_channels;
         std::swap(conv_out, conv_in);
         winograd_convolve3(output_channels, conv_in,
-                           m_conv_weights[i], V, M, conv_out);
+                           m_weights->m_conv_weights[i], V, M, conv_out);
         batchnorm<NUM_INTERSECTIONS>(output_channels, conv_out,
-                                     m_batchnorm_means[i].data(),
-                                     m_batchnorm_stddivs[i].data());
+                                     m_weights->m_batchnorm_means[i].data(),
+                                     m_weights->m_batchnorm_stddevs[i].data());
 
         std::swap(conv_in, res);
         std::swap(conv_out, conv_in);
         winograd_convolve3(output_channels, conv_in,
-                           m_conv_weights[i + 1], V, M, conv_out);
+                           m_weights->m_conv_weights[i + 1], V, M, conv_out);
         batchnorm<NUM_INTERSECTIONS>(output_channels, conv_out,
-                                     m_batchnorm_means[i + 1].data(),
-                                     m_batchnorm_stddivs[i + 1].data(),
+                                     m_weights->m_batchnorm_means[i + 1].data(),
+                                     m_weights->m_batchnorm_stddevs[i + 1].data(),
                                      res.data());
     }
     convolve<1>(Network::OUTPUTS_POLICY, conv_out, m_conv_pol_w, m_conv_pol_b, output_pol);
     convolve<1>(Network::OUTPUTS_VALUE, conv_out, m_conv_val_w, m_conv_val_b, output_val);
 }
 
+void CPUPipe::push_weights(unsigned int /*filter_size*/,
+                           unsigned int /*channels*/,
+                           unsigned int outputs,
+                           std::shared_ptr<const ForwardPipeWeights> weights) {
 
-void CPUPipe::push_input_convolution(unsigned int /*filter_size*/,
-                                     unsigned int /*channels*/,
-                                     unsigned int /*outputs*/,
-                                     const std::vector<float>& weights,
-                                     const std::vector<float>& means,
-                                     const std::vector<float>& variances) {
-    m_conv_weights.push_back(weights);
-    m_batchnorm_means.push_back(means);
-    m_batchnorm_stddivs.push_back(variances);
+    m_weights = weights;
+
+    // Output head convolutions
+    m_conv_pol_w = weights->m_conv_pol_w;
+    m_conv_pol_b.resize(m_conv_pol_w.size() / outputs, 0.0f);
+    m_conv_val_w = weights->m_conv_val_w;
+    m_conv_val_b.resize(m_conv_val_w.size() / outputs, 0.0f);
 }
 
-void CPUPipe::push_residual(unsigned int /*filter_size*/,
-                            unsigned int /*channels*/,
-                            unsigned int /*outputs*/,
-                            const std::vector<float>& weights_1,
-                            const std::vector<float>& means_1,
-                            const std::vector<float>& variances_1,
-                            const std::vector<float>& weights_2,
-                            const std::vector<float>& means_2,
-                            const std::vector<float>& variances_2) {
-    m_conv_weights.push_back(weights_1);
-    m_batchnorm_means.push_back(means_1);
-    m_batchnorm_stddivs.push_back(variances_1);
-
-    m_conv_weights.push_back(weights_2);
-    m_batchnorm_means.push_back(means_2);
-    m_batchnorm_stddivs.push_back(variances_2);
-}
-
-void CPUPipe::push_convolve(unsigned int filter_size,
-                            unsigned int channels,
-                            unsigned int outputs,
-                            const std::vector<float>& weights) {
-    // currently we can only support the final convolve stages
-    (void)filter_size;
-    assert(filter_size == 1);
-
-    if (outputs == Network::OUTPUTS_POLICY) {
-        m_conv_pol_w = weights;
-        m_conv_pol_b.resize(m_conv_pol_w.size() / channels, 0.0f);
-    } else if (outputs == Network::OUTPUTS_VALUE) {
-        m_conv_val_w = weights;
-        m_conv_val_b.resize(m_conv_val_w.size() / channels, 0.0f);
-    } else {
-        assert(false);
-    }
-}

--- a/src/CPUPipe.h
+++ b/src/CPUPipe.h
@@ -32,28 +32,10 @@ public:
                          std::vector<float>& output_pol,
                          std::vector<float>& output_val);
 
-    virtual void push_input_convolution(unsigned int filter_size,
-                                        unsigned int channels,
-                                        unsigned int outputs,
-                                        const std::vector<float>& weights,
-                                        const std::vector<float>& means,
-                                        const std::vector<float>& variances);
-
-    virtual void push_residual(unsigned int filter_size,
-                               unsigned int channels,
-                               unsigned int outputs,
-                               const std::vector<float>& weights_1,
-                               const std::vector<float>& means_1,
-                               const std::vector<float>& variances_1,
-                               const std::vector<float>& weights_2,
-                               const std::vector<float>& means_2,
-                               const std::vector<float>& variances_2);
-
-    virtual void push_convolve(unsigned int filter_size,
-                               unsigned int channels,
-                               unsigned int outputs,
-                               const std::vector<float>& weights);
-
+    virtual void push_weights(unsigned int filter_size,
+                              unsigned int channels,
+                              unsigned int outputs,
+                              std::shared_ptr<const ForwardPipeWeights> weights);
 
 private:
     void winograd_transform_in(const std::vector<float>& in,
@@ -80,9 +62,7 @@ private:
     int m_input_channels;
 
     // Input + residual block tower
-    std::vector<std::vector<float>> m_conv_weights;
-    std::vector<std::vector<float>> m_batchnorm_means;
-    std::vector<std::vector<float>> m_batchnorm_stddivs;
+    std::shared_ptr<const ForwardPipeWeights> m_weights;
 
     std::vector<float> m_conv_pol_w;
     std::vector<float> m_conv_val_w;

--- a/src/ForwardPipe.h
+++ b/src/ForwardPipe.h
@@ -19,42 +19,39 @@
 #ifndef FORWARDPIPE_H_INCLUDED
 #define FORWARDPIPE_H_INCLUDED
 
+#include <memory>
 #include <vector>
 
 #include "config.h"
 
 class ForwardPipe {
 public:
+    class ForwardPipeWeights {
+    public:
+        // Input + residual block tower
+        std::vector<std::vector<float>> m_conv_weights;
+        std::vector<std::vector<float>> m_conv_biases;
+        std::vector<std::vector<float>> m_batchnorm_means;
+        std::vector<std::vector<float>> m_batchnorm_stddevs;
+
+        // Policy head
+        std::vector<float> m_conv_pol_w;
+        std::vector<float> m_conv_pol_b;
+
+        std::vector<float> m_conv_val_w;
+        std::vector<float> m_conv_val_b;
+    };
+
     virtual ~ForwardPipe() = default;
 
     virtual void initialize(const int channels) = 0;
     virtual void forward(const std::vector<float>& input,
                          std::vector<float>& output_pol,
                          std::vector<float>& output_val) = 0;
-
-    virtual void push_input_convolution(unsigned int filter_size,
-                                        unsigned int channels,
-                                        unsigned int outputs,
-                                        const std::vector<float>& weights,
-                                        const std::vector<float>& means,
-                                        const std::vector<float>& variances) = 0;
-
-    virtual void push_residual(unsigned int filter_size,
-                               unsigned int channels,
-                               unsigned int outputs,
-                               const std::vector<float>& weights_1,
-                               const std::vector<float>& means_1,
-                               const std::vector<float>& variances_1,
-                               const std::vector<float>& weights_2,
-                               const std::vector<float>& means_2,
-                               const std::vector<float>& variances_2) = 0;
-
-    virtual void push_convolve(unsigned int filter_size,
-                               unsigned int channels,
-                               unsigned int outputs,
-                               const std::vector<float>& weights) = 0;
-
-
+    virtual void push_weights(unsigned int filter_size,
+                              unsigned int channels,
+                              unsigned int outputs,
+                              std::shared_ptr<const ForwardPipeWeights> weights) = 0;
 };
 
 #endif

--- a/src/Network.h
+++ b/src/Network.h
@@ -53,6 +53,7 @@ constexpr auto WINOGRAD_P = WINOGRAD_WTILES * WINOGRAD_WTILES;
 constexpr auto SQ2 = 1.4142135623730951f; // Square root of 2
 
 class Network {
+    using ForwardPipeWeights = ForwardPipe::ForwardPipeWeights;
 public:
     static constexpr auto NUM_SYMMETRIES = 8;
     static constexpr auto IDENTITY_SYMMETRY = 0;
@@ -126,15 +127,8 @@ private:
 
     NNCache m_nncache;
 
-    // Input + residual block tower
-    std::vector<std::vector<float>> m_conv_weights;
-    std::vector<std::vector<float>> m_conv_biases;
-    std::vector<std::vector<float>> m_batchnorm_means;
-    std::vector<std::vector<float>> m_batchnorm_stddevs;
+    std::shared_ptr<ForwardPipeWeights> m_fwd_weights;
 
-    // Policy head
-    std::vector<float> m_conv_pol_w;
-    std::vector<float> m_conv_pol_b;
     std::array<float, OUTPUTS_POLICY> m_bn_pol_w1;
     std::array<float, OUTPUTS_POLICY> m_bn_pol_w2;
 
@@ -142,8 +136,6 @@ private:
     std::array<float, POTENTIAL_MOVES> m_ip_pol_b;
 
     // Value head
-    std::vector<float> m_conv_val_w;
-    std::vector<float> m_conv_val_b;
     std::array<float, OUTPUTS_VALUE> m_bn_val_w1;
     std::array<float, OUTPUTS_VALUE> m_bn_val_w2;
 

--- a/src/OpenCLScheduler.cpp
+++ b/src/OpenCLScheduler.cpp
@@ -179,6 +179,40 @@ void OpenCLScheduler<net_t>::push_convolve(unsigned int filter_size,
 }
 
 template <typename net_t>
+void OpenCLScheduler<net_t>::push_weights(unsigned int filter_size,
+                                          unsigned int channels,
+                                          unsigned int outputs,
+                                          std::shared_ptr<const ForwardPipeWeights> weights) {
+    auto weight_index = size_t{0};
+
+    // Winograd filter transformation changes filter size to 4x4
+    push_input_convolution(filter_size, channels, outputs,
+                           weights->m_conv_weights[weight_index],
+                           weights->m_batchnorm_means[weight_index],
+                           weights->m_batchnorm_stddevs[weight_index]);
+    weight_index++;
+
+    // residual blocks : except the first entry,
+    // the second ~ last entry is all on residual topwer
+    for (auto i = size_t{0}; i < weights->m_conv_weights.size()/2; i++) {
+        push_residual(filter_size, outputs, outputs,
+                      weights->m_conv_weights[weight_index],
+                      weights->m_batchnorm_means[weight_index],
+                      weights->m_batchnorm_stddevs[weight_index],
+                      weights->m_conv_weights[weight_index + 1],
+                      weights->m_batchnorm_means[weight_index + 1],
+                      weights->m_batchnorm_stddevs[weight_index + 1]);
+        weight_index += 2;
+    }
+
+    // Output head convolutions
+    push_convolve(1, outputs, Network::OUTPUTS_POLICY, weights->m_conv_pol_w);
+    push_convolve(1, outputs, Network::OUTPUTS_VALUE, weights->m_conv_val_w);
+}
+
+
+
+template <typename net_t>
 void OpenCLScheduler<net_t>::forward(const std::vector<float>& input,
                                      std::vector<float>& output_pol,
                                      std::vector<float>& output_val) {

--- a/src/OpenCLScheduler.h
+++ b/src/OpenCLScheduler.h
@@ -42,29 +42,10 @@ public:
     virtual void forward(const std::vector<float>& input,
                          std::vector<float>& output_pol,
                          std::vector<float>& output_val);
-
-    virtual void push_input_convolution(unsigned int filter_size,
-                                        unsigned int channels,
-                                        unsigned int outputs,
-                                        const std::vector<float>& weights,
-                                        const std::vector<float>& means,
-                                        const std::vector<float>& variances);
-
-    virtual void push_residual(unsigned int filter_size,
-                               unsigned int channels,
-                               unsigned int outputs,
-                               const std::vector<float>& weights_1,
-                               const std::vector<float>& means_1,
-                               const std::vector<float>& variances_1,
-                               const std::vector<float>& weights_2,
-                               const std::vector<float>& means_2,
-                               const std::vector<float>& variances_2);
-
-    virtual void push_convolve(unsigned int filter_size,
-                               unsigned int channels,
-                               unsigned int outputs,
-                               const std::vector<float>& weights);
-
+    virtual void push_weights(unsigned int filter_size,
+                              unsigned int channels,
+                              unsigned int outputs,
+                              std::shared_ptr<const ForwardPipeWeights> weights);
 private:
     std::vector<std::unique_ptr<OpenCL_Network<net_t>>> m_networks;
     std::vector<std::unique_ptr<OpenCL<net_t>>> m_opencl;
@@ -73,6 +54,28 @@ private:
     std::vector<ContextPoolQueue> m_context_pool;
 
     SMP::Mutex m_context_pool_mutex;
+
+    void push_input_convolution(unsigned int filter_size,
+                                unsigned int channels,
+                                unsigned int outputs,
+                                const std::vector<float>& weights,
+                                const std::vector<float>& means,
+                                const std::vector<float>& variances);
+
+    void push_residual(unsigned int filter_size,
+                       unsigned int channels,
+                       unsigned int outputs,
+                       const std::vector<float>& weights_1,
+                       const std::vector<float>& means_1,
+                       const std::vector<float>& variances_1,
+                       const std::vector<float>& weights_2,
+                       const std::vector<float>& means_2,
+                       const std::vector<float>& variances_2);
+
+    void push_convolve(unsigned int filter_size,
+                       unsigned int channels,
+                       unsigned int outputs,
+                       const std::vector<float>& weights);
 };
 
 #endif


### PR DESCRIPTION
We restructured the code ad moved everything to ForwardPipe.  No need to leave it in the memory anymore.  This saves about half a gigabyte of memory footprint on 20x256 nets
