### PR TITLE
Always expect 2 arguments after "play" command.

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -345,30 +345,22 @@ bool GTP::execute(GameState & game, std::string xinput) {
 
         return true;
     } else if (command.find("play") == 0) {
-        if (command.find("resign") != std::string::npos) {
-            game.play_move(FastBoard::RESIGN);
-            gtp_printf(id, "");
-        } else if (command.find("pass") != std::string::npos) {
-            game.play_move(FastBoard::PASS);
-            gtp_printf(id, "");
-        } else {
-            std::istringstream cmdstream(command);
-            std::string tmp;
-            std::string color, vertex;
+        std::istringstream cmdstream(command);
+        std::string tmp;
+        std::string color, vertex;
 
-            cmdstream >> tmp;   //eat play
-            cmdstream >> color;
-            cmdstream >> vertex;
+        cmdstream >> tmp;   //eat play
+        cmdstream >> color;
+        cmdstream >> vertex;
 
-            if (!cmdstream.fail()) {
-                if (!game.play_textmove(color, vertex)) {
-                    gtp_fail_printf(id, "illegal move");
-                } else {
-                    gtp_printf(id, "");
-                }
+        if (!cmdstream.fail()) {
+            if (!game.play_textmove(color, vertex)) {
+                gtp_fail_printf(id, "illegal move");
             } else {
-                gtp_fail_printf(id, "syntax not understood");
+                gtp_printf(id, "");
             }
+        } else {
+            gtp_fail_printf(id, "syntax not understood");
         }
         return true;
     } else if (command.find("genmove") == 0 || command.find("lz-genmove_analyze") == 0) {

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -99,9 +99,9 @@ void GameState::play_move(int color, int vertex) {
     game_history.emplace_back(std::make_shared<KoState>(*this));
 }
 
-bool GameState::play_textmove(const std::string& color,
-                              const std::string& vertex) {
+bool GameState::play_textmove(std::string color, const std::string& vertex) {
     int who;
+    transform(cbegin(color), cend(color), begin(color), tolower);
     if (color == "w" || color == "white") {
         who = FullBoard::WHITE;
     } else if (color == "b" || color == "black") {
@@ -111,7 +111,8 @@ bool GameState::play_textmove(const std::string& color,
     }
 
     const auto move = board.text_to_move(vertex);
-    if (board.get_state(move) != FastBoard::EMPTY) {
+    if (move == FastBoard::NO_VERTEX ||
+        (move != FastBoard::PASS && move != FastBoard::RESIGN && board.get_state(move) != FastBoard::EMPTY)) {
         return false;
     }
 

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -52,8 +52,7 @@ public:
 
     void play_move(int color, int vertex);
     void play_move(int vertex);
-    bool play_textmove(const std::string& color,
-                       const std::string& vertex);
+    bool play_textmove(std::string color, const std::string& vertex);
 
     void start_clock(int color);
     void stop_clock(int color);


### PR DESCRIPTION
As [demanded by GTP](https://www.lysator.liu.se/~gunnar/gtp/gtp2-spec-draft2/gtp2-spec.html#SECTION00073300000000000000), improving the input handling of `GameState::play_textmove` in the process (which now would crash if given a pass or resignation).