### PR TITLE
OpenCL : don't initialize weights using CL_MEM_COPY_HOST_PTR

### DIFF
--- a/src/OpenCL.cpp
+++ b/src/OpenCL.cpp
@@ -112,12 +112,16 @@ void OpenCL_Network<net_t>::add_weights(size_t layer,
     }
 
     auto weightSize = size * sizeof(net_t);
-    m_layers.back().weights.emplace_back(
+
+    auto queue = cl::CommandQueue(getOpenCL().m_context, getOpenCL().m_device);
+    auto buffer = cl::Buffer(
         m_opencl.m_context,
-        CL_MEM_COPY_HOST_PTR | CL_MEM_READ_ONLY,
+        CL_MEM_READ_ONLY,
         weightSize,
-        const_cast<net_t*>(weights)
+        nullptr
     );
+    queue.enqueueWriteBuffer(buffer, CL_TRUE, 0, weightSize, const_cast<net_t*>(weights));
+    m_layers.back().weights.push_back(std::move(buffer));
 }
 
 template <typename net_t>


### PR DESCRIPTION
On many OpenCL implementations, CL_MEM_COPY_HOST_PTR | CL_MEM_READ_ONLY keeps a backing store of the data.  Hence we need to keep two copies of the weight (one on host, one on GPU) spending more memory.

This was done so that the driver can swap in/swap out memory from GPU when GPU memory is in a pinch.  Based on how leela-zero works, I believe this behavior won't help much since we are re-scanning through all the weights every millisecond or so (it will add too much pressure to the PCI-e bus)

So, instead of using CL_MEM_COPY_HOST_PTR, just create a buffer and then copy the weights using enqueueWriteBuffer - saves about 300MB of host memory on a 256x40 weight.