### PR TITLE
Fixes assert failure on wait_expanded()

### DIFF
--- a/src/NNCache.cpp
+++ b/src/NNCache.cpp
@@ -26,6 +26,7 @@
 #include "GTP.h"
 
 const int NNCache::MAX_CACHE_COUNT;
+const int NNCache::MIN_CACHE_COUNT;
 const size_t NNCache::ENTRY_SIZE;
 
 NNCache::NNCache(int size) : m_size(size) {}

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -178,6 +178,11 @@ bool UCTNode::has_children() const {
 }
 
 bool UCTNode::expandable(const float min_psa_ratio) const {
+    if (m_min_psa_ratio_children == 0.0) {
+        // if we figured out that we are fully expandable
+        // it is impossible that we stay in INITIAL state
+        assert(m_expand_state.load() != ExpandState::INITIAL);
+    }
     return min_psa_ratio < m_min_psa_ratio_children;
 }
 
@@ -330,7 +335,9 @@ UCTNode& UCTNode::get_best_root_child(int color) {
 size_t UCTNode::count_nodes_and_clear_expand_state() {
     auto nodecount = size_t{0};
     nodecount += m_children.size();
-    m_expand_state = ExpandState::INITIAL;
+    if (expandable()) {
+        m_expand_state = ExpandState::INITIAL;
+    }
     for (auto& child : m_children) {
         if (child.is_inflated()) {
             nodecount += child->count_nodes_and_clear_expand_state();

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -527,6 +527,12 @@ std::string UCTSearch::get_pv(FastState & state, UCTNode& parent) {
         return std::string();
     }
 
+    if (parent.expandable()) {
+        // not fully expanded.  There may be race conditions so we won't
+        // go through the rabbit hole trying to print things from this node.
+        return std::string();
+    }
+
     auto& best_child = parent.get_best_root_child(state.get_to_move());
     if (best_child.first_visit()) {
         return std::string();


### PR DESCRIPTION
If a node is fully expanded but is reveretd to INITIAL state, there is no chance
it returns to EXPANDED state.  Don't revert nodes to INITIAL state if it is fully
expanded.

Addresses other smaller bugs too

May address #1849 