### PR TITLE
Update .gitignore to inclue ".vs/"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ leelaz-model*
 leelaz_opencl_tuning
 /build-autogtp-*
 /build-validation-*
+.vs/


### PR DESCRIPTION
When cloning and opening an .sln solution (such as the `/next/` branch) in Visual Studio 2017, the `.vs` folder is created at the base of the project to store temporary user-specific environment settings. By default, Visual Studio 2017's Github plugin instantly detects these as changed files which must be synced. In my case, three files are created:

`ProjectSettings.json - Contains user-set project config settings`
`slnx.sqlite - Contains directory information and other details specific to the user's machine`
`VSWorkspaceState.json - Tracks open files and expanded directory views in the user's workspace`

This minor addition to the base `.gitignore` file resolves this, and as far as I can tell does not ignore any MSVC/VS files which *should* be managed under our git source control.