### PR TITLE
Add side to move in lz-analyze command.

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -456,22 +456,43 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
     } else if (command.find("lz-analyze") == 0) {
         std::istringstream cmdstream(command);
         std::string tmp;
-        int interval;
+        auto who = game.board.get_to_move();
 
         cmdstream >> tmp; // eat lz-analyze
-        cmdstream >> interval;
+        cmdstream >> tmp; // eat side to move or interval
         if (!cmdstream.fail()) {
-            cfg_analyze_interval_centis = interval;
-        } else {
-            gtp_fail_printf(id, "syntax not understood");
-            return true;
+            if (tmp == "w" || tmp == "white") {
+                who = FastBoard::WHITE;
+            } else if (tmp == "b" || tmp == "black") {
+                who = FastBoard::BLACK;
+            } else {
+                // Not side to move, must be interval
+                try {
+                    cfg_analyze_interval_centis = std::stoi(tmp);
+                } catch(...) {
+                    gtp_fail_printf(id, "syntax not understood");
+                    return true;
+                }
+            }
+            if (tmp == "w" || tmp == "b" || tmp == "white" || tmp == "black") {
+                // We got a color, so the interval must come now.
+                int interval;
+                cmdstream >> interval;
+                if (!cmdstream.fail()) {
+                    cfg_analyze_interval_centis = interval;
+                } else {
+                    gtp_fail_printf(id, "syntax not understood");
+                    return true;
+                }
+            }
         }
-        // Start multi-line response
+        // Start multi-line response.
         if (id != -1) gtp_printf_raw("=%d\n", id);
         else gtp_printf_raw("=\n");
-        // now start pondering
+        // Now start pondering.
         if (!game.has_resigned()) {
             // Outputs winrate and pvs through gtp
+            game.set_to_move(who);
             search->ponder();
         }
         cfg_analyze_interval_centis = 0;


### PR DESCRIPTION
See discussion in pull request #1642.

This adds an optional side to move in the lz-analyze command, instead
of only a posting interval. This makes the format more consistent with
all other GTP commands.

We check the amount and format of the arguments so we are backwards
compatible with GUIs that send the old format, i.e. with only a posting
interval.