### PR TITLE
Autoselect half mode for fp16 compute.

### DIFF
--- a/src/ForwardPipe.h
+++ b/src/ForwardPipe.h
@@ -45,6 +45,7 @@ public:
     virtual ~ForwardPipe() = default;
 
     virtual void initialize(const int channels) = 0;
+    virtual bool needs_autodetect() { return false; };
     virtual void forward(const std::vector<float>& input,
                          std::vector<float>& output_pol,
                          std::vector<float>& output_val) = 0;

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -356,6 +356,7 @@ std::unique_ptr<ForwardPipe>&& Network::init_net(int channels,
     return std::move(pipe);
 }
 
+#ifdef USE_HALF
 void Network::select_precision(int channels) {
     if (cfg_precision == precision_t::AUTO) {
         auto score_fp16 = float{-1.0};
@@ -420,6 +421,7 @@ void Network::select_precision(int channels) {
         return;
     }
 }
+#endif
 
 void Network::initialize(int playouts, const std::string & weightsfile) {
 #ifdef USE_BLAS

--- a/src/Network.h
+++ b/src/Network.h
@@ -123,11 +123,15 @@ private:
                                       std::vector<float>::iterator white,
                                       const int symmetry);
     bool probe_cache(const GameState* const state, Network::Netresult& result);
+    std::unique_ptr<ForwardPipe>&& init_net(int channels,
+                                            std::unique_ptr<ForwardPipe>&& pipe);
+#ifdef USE_HALF
+    void select_precision(int channels);
+#endif
     std::unique_ptr<ForwardPipe> m_forward;
 #ifdef USE_OPENCL_SELFCHECK
     void compare_net_outputs(const Netresult& data, const Netresult& ref);
     std::unique_ptr<ForwardPipe> m_forward_cpu;
-
 #endif
 
     NNCache m_nncache;
@@ -141,14 +145,18 @@ private:
     std::array<float, OUTPUTS_POLICY> m_bn_pol_w1;
     std::array<float, OUTPUTS_POLICY> m_bn_pol_w2;
 
-    std::array<float, OUTPUTS_POLICY * NUM_INTERSECTIONS * POTENTIAL_MOVES> m_ip_pol_w;
+    std::array<float, OUTPUTS_POLICY
+                      * NUM_INTERSECTIONS
+                      * POTENTIAL_MOVES> m_ip_pol_w;
     std::array<float, POTENTIAL_MOVES> m_ip_pol_b;
 
     // Value head
     std::array<float, OUTPUTS_VALUE> m_bn_val_w1;
     std::array<float, OUTPUTS_VALUE> m_bn_val_w2;
 
-    std::array<float, OUTPUTS_VALUE * NUM_INTERSECTIONS * VALUE_LAYER> m_ip1_val_w;
+    std::array<float, OUTPUTS_VALUE
+                      * NUM_INTERSECTIONS
+                      * VALUE_LAYER> m_ip1_val_w;
     std::array<float, VALUE_LAYER> m_ip1_val_b;
 
     std::array<float, VALUE_LAYER> m_ip2_val_w;

--- a/src/OpenCL.cpp
+++ b/src/OpenCL.cpp
@@ -774,10 +774,11 @@ void OpenCL<net_t>::initialize(const int channels, int gpu, bool silent) {
     myprintf("Half precision compute support: ");
     if (m_device.getInfo<CL_DEVICE_EXTENSIONS>().find("cl_khr_fp16")
         != std::string::npos) {
-        myprintf("YES\n");
+        myprintf("Yes.\n");
+        m_fp16_compute = true;
         m_cl_args += " -DFP16_SUPPORT";
     } else {
-        myprintf("NO\n");
+        myprintf("No.\n");
     }
 
     auto t = Tuner<net_t>(*this, m_context, m_device);
@@ -828,6 +829,11 @@ void OpenCL<net_t>::initialize(const int channels, int gpu, bool silent) {
     myprintf("\n");
 
     m_init_ok = true;
+}
+
+template <typename net_t>
+bool OpenCL<net_t>::has_fp16_compute() {
+    return m_fp16_compute;
 }
 
 template <typename net_t>

--- a/src/OpenCL.h
+++ b/src/OpenCL.h
@@ -186,6 +186,7 @@ public:
     void initialize(const int channels, int gpu, bool silent = false);
     void ensure_context_initialized(OpenCLContext & opencl_context);
     std::string get_device_name();
+    bool has_fp16_compute();
 
     std::vector<size_t> get_sgemm_tuners();
 
@@ -207,6 +208,7 @@ private:
     size_t m_wavefront_size{0};
     size_t m_max_workgroup_size{0};
     std::vector<size_t> m_max_workgroup_dims;
+    bool m_fp16_compute{false};
     bool m_init_ok{false};
 };
 

--- a/src/OpenCLScheduler.h
+++ b/src/OpenCLScheduler.h
@@ -42,6 +42,7 @@ public:
     virtual void forward(const std::vector<float>& input,
                          std::vector<float>& output_pol,
                          std::vector<float>& output_val);
+    virtual bool needs_autodetect();
     virtual void push_weights(unsigned int filter_size,
                               unsigned int channels,
                               unsigned int outputs,


### PR DESCRIPTION
Rework the Network initialization to pull out the OpenCL benchmarking
for precision autodetection. Add support to ForwardPipe to report
whether it is necessary to run the benchmarks. If the answer is no, and
fp16 compute works, we assume that's what we want.

This avoids the benchmarking overhead on modern AMD cards and probably
on the latest ones from NVIDIA too.