### PR TITLE
Fix memory estimation for auto-detected gpu.

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -945,8 +945,8 @@ size_t GTP::get_base_memory() {
     // At the moment of writing the memory consumption is
     // roughly network size + 85 for one GPU and + 160 for two GPUs.
 #ifdef USE_OPENCL
-    return (size_t)(s_network->get_estimated_size()
-                    + 85 * MiB * cfg_gpus.size());
+    auto gpus = std::max(cfg_gpus.size(), size_t{1});
+    return s_network->get_estimated_size() + 85 * MiB * gpus;
 #else
     return s_network->get_estimated_size();
 #endif


### PR DESCRIPTION
Fixes a bug, when number of gpus used was taken from a configuration and 0 was used instead of 1 for auto-detected GPU.