### PR TITLE
Fix bug with precision autodetection using fp32 if fp16 was faster

### DIFF
--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -380,7 +380,17 @@ void Network::select_precision(int channels) {
 
         myprintf("Initializing OpenCL (autodetecting precision).\n");
 
-        // Start by setting up fp16.
+        // Start by setting up fp32.
+        try {
+            m_forward.reset();
+            m_forward = init_net(channels,
+                std::make_unique<OpenCLScheduler<float>>());
+            score_fp32 = benchmark_time(100);
+        } catch (...) {
+            // empty - if exception thrown just throw away fp32 net
+        }
+
+        // Now benchmark fp16.
         try {
             m_forward.reset();
             m_forward = init_net(channels,
@@ -394,16 +404,6 @@ void Network::select_precision(int channels) {
             score_fp16 = benchmark_time(100);
         } catch (...) {
             // empty - if exception thrown just throw away fp16 net
-        }
-
-        // Now benchmark fp32.
-        try {
-            m_forward.reset();
-            m_forward = init_net(channels,
-                std::make_unique<OpenCLScheduler<float>>());
-            score_fp32 = benchmark_time(100);
-        } catch (...) {
-            // empty - if exception thrown just throw away fp32 net
         }
 
         if (score_fp16 < 0.0f && score_fp32 < 0.0f) {


### PR DESCRIPTION
The logic later assumes that fp16 was benchmarked last. Even if fp16 compute is supported it now benchmarks fp32 first. I decided to optimize for the more common case without fp16 compute support and fp16 storage being faster and avoid reinitializing the fp16 network.

Fixes #1887 