### PR TITLE
A new appveyor job to auto-build leela-zero by msbuild

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,17 @@
 version: '{build}'
+image: Visual Studio 2017
 configuration: Release
 platform: x64
 environment:
   matrix:
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    features: USE_CPU_ONLY USE_BLAS
-    run_tests: 1
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+  - cmake_build: 1
+  - cmake_build: 1
     features: USE_CPU_ONLY
     run_tests: 1
+  - cmake_build: 1
+    features: USE_CPU_ONLY USE_BLAS
+    run_tests: 1
+  - msbuild: 1
 skip_commits:
   files:
     - '**/*.md'
@@ -19,29 +21,12 @@ skip_commits:
     - AUTHORS
     - COPYING
 install:
-- cmd: nuget restore msvc\VS2017 -PackagesDirectory pkgs
-cache: pkgs -> appveyor.yml
+- cmd: nuget restore msvc\VS2017 -PackagesDirectory msvc\packages
+cache: msvc\packages -> appveyor.yml
 build_script:
-- cmd: >-
-    set PKG_FOLDER="%cd%\pkgs"
-
-    git submodule update --init --recursive
-
-    mkdir build
-
-    cd build
-
-    set BLAS_HOME="..\pkgs\OpenBLAS.0.2.14.1\lib\native"
-
-    for /F %%f in ("%features%") do set DEFINES=%DEFINES% -D%%f=1
-
-    cmake -G "Visual Studio 15 2017 Win64" %DEFINES% -DCMAKE_PREFIX_PATH="%QTDIR%/lib/cmake/" -DBOOST_ROOT="C:/Libraries/boost_1_65_1" -DBOOST_LIBRARYDIR="C:/Libraries/boost_1_65_1/lib64-msvc-14.1" -DBoost_USE_STATIC_LIBS=ON -DZLIB_ROOT="%PKG_FOLDER%/zlib-msvc14-x64.1.2.11.7795/build/native" -DZLIB_LIBRARY="%PKG_FOLDER%/zlib-msvc14-x64.1.2.11.7795/build/native/zlib-msvc14-x64.targets" -DOpenCL_LIBRARY="%PKG_FOLDER%/opencl-nug.0.777.12/build/native/opencl-nug.targets" -DOpenCL_INCLUDE_DIR="%PKG_FOLDER%/opencl-nug.0.777.12/build/native/include" -DBLAS_LIBRARIES="%PKG_FOLDER%/OpenBLAS.0.2.14.1/build/native/openblas.targets" -Dgtest_force_shared_crt=ON ..
-
-    cmake --build . --config Release -- /maxcpucount:1
+- cmd: if "%cmake_build%"=="1" msvc\VS2017\cmake_build.bat
+- cmd: if "%msbuild%"=="1" git submodule update --init --recursive
+- cmd: if "%msbuild%"=="1" msbuild /t:build msvc\VS2017\leela-zero.vcxproj
 
 test_script:
-- cmd: >-
-
-    set PATH=Release;%PATH
-
-    if NOT "%run_tests%"=="" tests.exe
+- cmd: if "%run_tests%"=="1" cd build && Release\tests.exe

--- a/msvc/VS2017/cmake_build.bat
+++ b/msvc/VS2017/cmake_build.bat
@@ -1,0 +1,8 @@
+set PKG_FOLDER="%cd%\msvc\packages"
+git submodule update --init --recursive
+mkdir build
+cd build
+set BLAS_HOME="..\msvc\packages\OpenBLAS.0.2.14.1\lib\native"
+for /F %%f in ("%features%") do set DEFINES=%DEFINES% -D%%f=1
+cmake -G "Visual Studio 15 2017 Win64" %DEFINES% -DCMAKE_PREFIX_PATH="%QTDIR%/lib/cmake/" -DBOOST_ROOT="C:/Libraries/boost_1_65_1" -DBOOST_LIBRARYDIR="C:/Libraries/boost_1_65_1/lib64-msvc-14.1" -DBoost_USE_STATIC_LIBS=ON -DZLIB_ROOT="%PKG_FOLDER%/zlib-msvc14-x64.1.2.11.7795/build/native" -DZLIB_LIBRARY="%PKG_FOLDER%/zlib-msvc14-x64.1.2.11.7795/build/native/zlib-msvc14-x64.targets" -DOpenCL_LIBRARY="%PKG_FOLDER%/opencl-nug.0.777.12/build/native/opencl-nug.targets" -DOpenCL_INCLUDE_DIR="%PKG_FOLDER%/opencl-nug.0.777.12/build/native/include" -DBLAS_LIBRARIES="%PKG_FOLDER%/OpenBLAS.0.2.14.1/build/native/openblas.targets" -Dgtest_force_shared_crt=ON ..
+cmake --build . --config Release -- /maxcpucount:1


### PR DESCRIPTION
A new appveyor job is added to build leela-zero by msbuild.

In my appveyor test, there are totally four appveyor jobs that have been passed. The running time of these jobs are listed below:

1. `cmake_build=1`: 11 minutes and 13 seconds.
2. `cmake_build=1, features=USE_CPU_ONLY, run_tests=1`:  6 minutes and 51 seconds.
3. `cmake_build=1, features=USE_CPU_ONLY USE_BLAS, run_tests=1`: 6 minutes.
4. `msbuild=1`: 6 minutes and 42 seconds.

If `cmake_build=1`, appveyor will run a newly created `msvc/VS2017/cmake_build.bat` to build leela-zero by cmake. (Why do I create `cmake_build.bat`? Because it seems impossible to write a script in multiple-lines in `appveyor.yml` with the `IF` statement.)

If `msbuild=1`, appveyor will build leela-zero by msbuild. (Currently, I cannot find a way to build autogtp from `autogtp.vcxproj`. Making a job to auto-build autogtp can be one of the future works.)
