### PR TITLE
Added AppVeyor jobs to build leela-zero by cmake and msbuild in Visual Studio 2015 and 2017

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,21 @@
 version: '{build}'
+image:
+- Visual Studio 2015
+- Visual Studio 2017
 configuration: Release
 platform: x64
+matrix:
+  fast_finish: true
 environment:
   matrix:
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    features: USE_CPU_ONLY USE_BLAS
-    run_tests: 1
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+  - cmake_build: 1
+  - cmake_build: 1
     features: USE_CPU_ONLY
     run_tests: 1
+  - cmake_build: 1
+    features: USE_CPU_ONLY USE_BLAS
+    run_tests: 1
+  - msbuild: 1
 skip_commits:
   files:
     - '**/*.md'
@@ -18,30 +24,27 @@ skip_commits:
     - training/
     - AUTHORS
     - COPYING
-install:
-- cmd: nuget restore msvc\VS2017 -PackagesDirectory pkgs
-cache: pkgs -> appveyor.yml
+for:
+- matrix:
+    only:
+    - image: Visual Studio 2015
+  install:
+  - cmd: set MSVCDIR=msvc\VS2015
+  - cmd: echo %MSVCDIR%
+  - cmd: nuget restore %MSVCDIR% -PackagesDirectory msvc\packages
+- matrix:
+    only:
+    - image: Visual Studio 2017
+  install:
+  - cmd: set MSVCDIR=msvc\VS2017
+  - cmd: echo %MSVCDIR%
+  - cmd: nuget restore %MSVCDIR% -PackagesDirectory msvc\packages
 build_script:
-- cmd: >-
-    set PKG_FOLDER="%cd%\pkgs"
-
-    git submodule update --init --recursive
-
-    mkdir build
-
-    cd build
-
-    set BLAS_HOME="..\pkgs\OpenBLAS.0.2.14.1\lib\native"
-
-    for /F %%f in ("%features%") do set DEFINES=%DEFINES% -D%%f=1
-
-    cmake -G "Visual Studio 15 2017 Win64" %DEFINES% -DCMAKE_PREFIX_PATH="%QTDIR%/lib/cmake/" -DBOOST_ROOT="C:/Libraries/boost_1_65_1" -DBOOST_LIBRARYDIR="C:/Libraries/boost_1_65_1/lib64-msvc-14.1" -DBoost_USE_STATIC_LIBS=ON -DZLIB_ROOT="%PKG_FOLDER%/zlib-msvc14-x64.1.2.11.7795/build/native" -DZLIB_LIBRARY="%PKG_FOLDER%/zlib-msvc14-x64.1.2.11.7795/build/native/zlib-msvc14-x64.targets" -DOpenCL_LIBRARY="%PKG_FOLDER%/opencl-nug.0.777.12/build/native/opencl-nug.targets" -DOpenCL_INCLUDE_DIR="%PKG_FOLDER%/opencl-nug.0.777.12/build/native/include" -DBLAS_LIBRARIES="%PKG_FOLDER%/OpenBLAS.0.2.14.1/build/native/openblas.targets" -Dgtest_force_shared_crt=ON ..
-
-    cmake --build . --config Release -- /maxcpucount:1
+- cmd: if "%cmake_build%"=="1" %MSVCDIR%\cmake_build.bat
+- cmd: if "%msbuild%"=="1" git submodule update --init --recursive
+- cmd: if "%msbuild%"=="1" msbuild /t:build %MSVCDIR%\leela-zero.vcxproj
 
 test_script:
-- cmd: >-
+- cmd: if "%run_tests%"=="1" cd build && Release\tests.exe
 
-    set PATH=Release;%PATH
-
-    if NOT "%run_tests%"=="" tests.exe
+cache: msvc\packages -> appveyor.yml

--- a/msvc/VS2015/cmake_build.bat
+++ b/msvc/VS2015/cmake_build.bat
@@ -1,0 +1,18 @@
+set PKG_FOLDER="%cd%\msvc\packages"
+git submodule update --init --recursive
+mkdir build
+cd build
+set BLAS_HOME="..\msvc\packages\OpenBLAS.0.2.14.1\lib\native"
+for /F %%f in ("%features%") do set DEFINES=%DEFINES% -D%%f=1
+cmake -G "Visual Studio 14 2015 Win64" %DEFINES% ^
+      -DCMAKE_PREFIX_PATH="%QTDIR%/lib/cmake/"   ^
+      -DBOOST_ROOT="C:/Libraries/boost_1_65_1"   ^
+      -DBOOST_LIBRARYDIR="C:/Libraries/boost_1_65_1/lib64-msvc-14.1" ^
+      -DBoost_USE_STATIC_LIBS=ON                 ^
+      -DZLIB_ROOT="%PKG_FOLDER%/zlib-msvc14-x64.1.2.11.7795/build/native" ^
+      -DZLIB_LIBRARY="%PKG_FOLDER%/zlib-msvc14-x64.1.2.11.7795/build/native/zlib-msvc14-x64.targets" ^
+      -DOpenCL_LIBRARY="%PKG_FOLDER%/opencl-nug.0.777.12/build/native/opencl-nug.targets" ^
+      -DOpenCL_INCLUDE_DIR="%PKG_FOLDER%/opencl-nug.0.777.12/build/native/include" ^
+      -DBLAS_LIBRARIES="%PKG_FOLDER%/OpenBLAS.0.2.14.1/build/native/openblas.targets" ^
+      -Dgtest_force_shared_crt=ON ..
+cmake --build . --config Release -- /maxcpucount:1

--- a/msvc/VS2015/leela-zero.vcxproj
+++ b/msvc/VS2015/leela-zero.vcxproj
@@ -43,9 +43,11 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <TargetName>leelaz</TargetName>
+    <IncludePath>..\..\src\Eigen;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TargetName>leelaz</TargetName>
+    <IncludePath>..\..\src\Eigen;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -139,8 +141,9 @@
     <Import Project="..\packages\boost_system-vc140.1.65.1.0\build\native\boost_system-vc140.targets" Condition="Exists('..\packages\boost_system-vc140.1.65.1.0\build\native\boost_system-vc140.targets')" />
     <Import Project="..\packages\OpenBLAS.0.2.14.1\build\native\openblas.targets" Condition="Exists('..\packages\OpenBLAS.0.2.14.1\build\native\openblas.targets')" />
     <Import Project="..\packages\opencl-nug.0.777.12\build\native\opencl-nug.targets" Condition="Exists('..\packages\opencl-nug.0.777.12\build\native\opencl-nug.targets')" />
-    <Import Project="..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
+    <Import Project="..\packages\zlib-msvc14-x64.1.2.11.7795\build\native\zlib-msvc14-x64.targets" Condition="Exists('..\packages\zlib-msvc14-x64.1.2.11.7795\build\native\zlib-msvc14-x64.targets')" />
     <Import Project="..\packages\boost_program_options-vc140.1.65.1.0\build\native\boost_program_options-vc140.targets" Condition="Exists('..\packages\boost_program_options-vc140.1.65.1.0\build\native\boost_program_options-vc140.targets')" />
+    <Import Project="..\packages\boost_filesystem-vc140.1.65.1.0\build\native\boost_filesystem-vc140.targets" Condition="Exists('..\packages\boost_filesystem-vc140.1.65.1.0\build\native\boost_filesystem-vc140.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -150,7 +153,8 @@
     <Error Condition="!Exists('..\packages\boost_system-vc140.1.65.1.0\build\native\boost_system-vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost_system-vc140.1.65.1.0\build\native\boost_system-vc140.targets'))" />
     <Error Condition="!Exists('..\packages\OpenBLAS.0.2.14.1\build\native\openblas.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\OpenBLAS.0.2.14.1\build\native\openblas.targets'))" />
     <Error Condition="!Exists('..\packages\opencl-nug.0.777.12\build\native\opencl-nug.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\opencl-nug.0.777.12\build\native\opencl-nug.targets'))" />
-    <Error Condition="!Exists('..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
+    <Error Condition="!Exists('..\packages\zlib-msvc14-x64.1.2.11.7795\build\native\zlib-msvc14-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\zlib-msvc14-x64.1.2.11.7795\build\native\zlib-msvc14-x64.targets'))" />
     <Error Condition="!Exists('..\packages\boost_program_options-vc140.1.65.1.0\build\native\boost_program_options-vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost_program_options-vc140.1.65.1.0\build\native\boost_program_options-vc140.targets'))" />
+    <Error Condition="!Exists('..\packages\boost_filesystem-vc140.1.65.1.0\build\native\boost_filesystem-vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost_filesystem-vc140.1.65.1.0\build\native\boost_filesystem-vc140.targets'))" />
   </Target>
 </Project>

--- a/msvc/VS2015/packages.config
+++ b/msvc/VS2015/packages.config
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="boost" version="1.65.1.0" targetFramework="native" />
+  <package id="boost_filesystem-vc140" version="1.65.1.0" targetFramework="native" />
   <package id="boost_program_options-vc140" version="1.65.1.0" targetFramework="native" />
   <package id="boost_system-vc140" version="1.65.1.0" targetFramework="native" />
   <package id="OpenBLAS" version="0.2.14.1" targetFramework="native" />
   <package id="opencl-nug" version="0.777.12" targetFramework="native" />
-  <package id="zlib-msvc-x64" version="1.2.11.8900" targetFramework="native" />
+  <package id="zlib-msvc14-x64" version="1.2.11.7795" targetFramework="native" />
 </packages>

--- a/msvc/VS2017/cmake_build.bat
+++ b/msvc/VS2017/cmake_build.bat
@@ -1,0 +1,8 @@
+set PKG_FOLDER="%cd%\msvc\packages"
+git submodule update --init --recursive
+mkdir build
+cd build
+set BLAS_HOME="..\msvc\packages\OpenBLAS.0.2.14.1\lib\native"
+for /F %%f in ("%features%") do set DEFINES=%DEFINES% -D%%f=1
+cmake -G "Visual Studio 15 2017 Win64" %DEFINES% -DCMAKE_PREFIX_PATH="%QTDIR%/lib/cmake/" -DBOOST_ROOT="C:/Libraries/boost_1_65_1" -DBOOST_LIBRARYDIR="C:/Libraries/boost_1_65_1/lib64-msvc-14.1" -DBoost_USE_STATIC_LIBS=ON -DZLIB_ROOT="%PKG_FOLDER%/zlib-msvc14-x64.1.2.11.7795/build/native" -DZLIB_LIBRARY="%PKG_FOLDER%/zlib-msvc14-x64.1.2.11.7795/build/native/zlib-msvc14-x64.targets" -DOpenCL_LIBRARY="%PKG_FOLDER%/opencl-nug.0.777.12/build/native/opencl-nug.targets" -DOpenCL_INCLUDE_DIR="%PKG_FOLDER%/opencl-nug.0.777.12/build/native/include" -DBLAS_LIBRARIES="%PKG_FOLDER%/OpenBLAS.0.2.14.1/build/native/openblas.targets" -Dgtest_force_shared_crt=ON ..
+cmake --build . --config Release -- /maxcpucount:1

--- a/msvc/VS2017/leela-zero.vcxproj
+++ b/msvc/VS2017/leela-zero.vcxproj
@@ -134,7 +134,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <IncludePath>$(SolutionDir)\..\src\Eigen;$(IncludePath)</IncludePath>
+    <IncludePath>..\..\src\Eigen;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
@@ -143,7 +143,7 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>leelaz</TargetName>
     <IntDir>$(Platform)\$(Configuration)\leelaz\</IntDir>
-    <IncludePath>$(SolutionDir)\..\src\Eigen;$(IncludePath)</IncludePath>
+    <IncludePath>..\..\src\Eigen;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>


### PR DESCRIPTION
New AppVeyor jobs are added to build leela-zero by both of cmake and msbuild in Visual Studio 2015 and 2017.

In my local test, there are totally eight AppVeyor jobs that have been passed. The running time of these jobs are listed below:

1. `Image: Visual Studio 2015; Environment: cmake_build=1`: 3 minutes 47 seconds.
2. `Image: Visual Studio 2015; Environment: cmake_build=1, features=USE_CPU_ONLY, run_tests=1`:  3 minutes 17 seconds.
3. `Image: Visual Studio 2015; Environment: cmake_build=1, features=USE_CPU_ONLY USE_BLAS, run_tests=1`: 3 minutes 4 seconds.
4. `Image: Visual Studio 2015; Environment: msbuild=1`: 3 minutes and 26 seconds.
5. `Image: Visual Studio 2017; Environment: cmake_build=1`: 4 minutes and 55 seconds.
6. `Image: Visual Studio 2017; Environment: cmake_build=1, features=USE_CPU_ONLY, run_tests=1`: 4 minutes and 27 seconds.
7. `Image: Visual Studio 2017; Environment: cmake_build=1, features=USE_CPU_ONLY USE_BLAS, run_tests=1`: 4 minutes and 19 seconds.
8. `Image: Visual Studio 2017; Environment: msbuild=1`: 3 minutes and 27 seconds.

If `cmake_build=1`, appveyor will run a newly created `cmake_build.bat` to build leela-zero by cmake. (Why do I create `cmake_build.bat`? Because it seems impossible to write a script in multiple-lines in `appveyor.yml` with the `IF` statement.)

If `msbuild=1`, appveyor will build leela-zero by msbuild. (Currently, I cannot find a way to build autogtp from `autogtp.vcxproj`. Making a job to auto-build autogtp can be one of the future works.)