### PR TITLE
 Implement more options in lz-setoption.

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -232,9 +232,9 @@ std::string GTP::get_life_list(const GameState & game, bool live) {
 
     // remove multiple mentions of the same string
     // unique reorders and returns new iterator, erase actually deletes
-    std::sort(stringlist.begin(), stringlist.end());
-    stringlist.erase(std::unique(stringlist.begin(), stringlist.end()),
-                     stringlist.end());
+    std::sort(begin(stringlist), end(stringlist));
+    stringlist.erase(std::unique(begin(stringlist), end(stringlist)),
+                     end(stringlist));
 
     for (size_t i = 0; i < stringlist.size(); i++) {
         result += (i == 0 ? "" : "\n") + stringlist[i];

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -17,7 +17,6 @@
 */
 
 #include "config.h"
-#include "GTP.h"
 
 #include <algorithm>
 #include <cctype>
@@ -33,6 +32,7 @@
 #include <vector>
 #include <boost/algorithm/string.hpp>
 
+#include "GTP.h"
 #include "FastBoard.h"
 #include "FullBoard.h"
 #include "GameState.h"
@@ -200,9 +200,16 @@ const std::string GTP::s_commands[] = {
     ""
 };
 
+// Default/min/max could be moved into separate fields,
+// but for now we assume that the GUI will not send us invalid info.
 const std::string GTP::s_options[] = {
     "option name Maximum Memory Use (MiB) type spin default 2048 min 128 max 131072",
     "option name Percentage of memory for cache type spin default 10 min 1 max 99",
+    "option name Visits type spin default 0 min 0 max 1000000000",
+    "option name Playouts type spin default 0 min 0 max 1000000000",
+    "option name Lagbuffer type spin default 0 min 0 max 3000",
+    "option name Resign Percentage type spin default -1 min -1 max 30",
+    "option name Pondering type check default true",
     ""
 };
 
@@ -236,7 +243,7 @@ std::string GTP::get_life_list(const GameState & game, bool live) {
     return result;
 }
 
-bool GTP::execute(GameState & game, const std::string& xinput) {
+void GTP::execute(GameState & game, const std::string& xinput) {
     std::string input;
     static auto search = std::make_unique<UCTSearch>(game, *s_network);
 
@@ -276,11 +283,11 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
     int id = -1;
 
     if (input == "") {
-        return true;
+        return;
     } else if (input == "exit") {
         exit(EXIT_SUCCESS);
     } else if (input.find("#") == 0) {
-        return true;
+        return;
     } else if (std::isdigit(input[0])) {
         std::istringstream strm(input);
         char spacer;
@@ -294,13 +301,13 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
     /* process commands */
     if (command == "protocol_version") {
         gtp_printf(id, "%d", GTP_VERSION);
-        return true;
+        return;
     } else if (command == "name") {
         gtp_printf(id, PROGRAM_NAME);
-        return true;
+        return;
     } else if (command == "version") {
         gtp_printf(id, PROGRAM_VERSION);
-        return true;
+        return;
     } else if (command == "quit") {
         gtp_printf(id, "");
         exit(EXIT_SUCCESS);
@@ -314,19 +321,19 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
         for (int i = 0; s_commands[i].size() > 0; i++) {
             if (tmp == s_commands[i]) {
                 gtp_printf(id, "true");
-                return 1;
+                return;
             }
         }
 
         gtp_printf(id, "false");
-        return true;
+        return;
     } else if (command.find("list_commands") == 0) {
         std::string outtmp(s_commands[0]);
         for (int i = 1; s_commands[i].size() > 0; i++) {
             outtmp = outtmp + "\n" + s_commands[i];
         }
         gtp_printf(id, outtmp.c_str());
-        return true;
+        return;
     } else if (command.find("boardsize") == 0) {
         std::istringstream cmdstream(command);
         std::string stmp;
@@ -348,14 +355,14 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
             gtp_fail_printf(id, "syntax not understood");
         }
 
-        return true;
+        return;
     } else if (command.find("clear_board") == 0) {
         Training::clear_training();
         game.reset_game();
         search = std::make_unique<UCTSearch>(game, *s_network);
         assert(UCTNodePointer::get_tree_size() == 0);
         gtp_printf(id, "");
-        return true;
+        return;
     } else if (command.find("komi") == 0) {
         std::istringstream cmdstream(command);
         std::string tmp;
@@ -374,7 +381,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
             gtp_fail_printf(id, "syntax not understood");
         }
 
-        return true;
+        return;
     } else if (command.find("play") == 0) {
         std::istringstream cmdstream(command);
         std::string tmp;
@@ -393,7 +400,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
         } else {
             gtp_fail_printf(id, "syntax not understood");
         }
-        return true;
+        return;
     } else if (command.find("genmove") == 0
                || command.find("lz-genmove_analyze") == 0) {
         auto analysis_output = command.find("lz-genmove_analyze") == 0;
@@ -416,7 +423,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
                 who = FastBoard::BLACK;
             } else {
                 gtp_fail_printf(id, "syntax error");
-                return 1;
+                return;
             }
             if (analysis_output) {
                 // Start of multi-line response
@@ -453,7 +460,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
             gtp_fail_printf(id, "syntax not understood");
         }
         analysis_output = false;
-        return true;
+        return;
     } else if (command.find("lz-analyze") == 0) {
         std::istringstream cmdstream(command);
         std::string tmp;
@@ -472,7 +479,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
                     cfg_analyze_interval_centis = std::stoi(tmp);
                 } catch(...) {
                     gtp_fail_printf(id, "syntax not understood");
-                    return true;
+                    return;
                 }
             }
             if (tmp == "w" || tmp == "b" || tmp == "white" || tmp == "black") {
@@ -483,7 +490,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
                     cfg_analyze_interval_centis = interval;
                 } else {
                     gtp_fail_printf(id, "syntax not understood");
-                    return true;
+                    return;
                 }
             }
         }
@@ -499,7 +506,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
         cfg_analyze_interval_centis = 0;
         // Terminate multi-line response
         gtp_printf_raw("\n");
-        return true;
+        return;
     } else if (command.find("kgs-genmove_cleanup") == 0) {
         std::istringstream cmdstream(command);
         std::string tmp;
@@ -515,7 +522,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
                 who = FastBoard::BLACK;
             } else {
                 gtp_fail_printf(id, "syntax error");
-                return 1;
+                return;
             }
             game.set_passes(0);
             {
@@ -535,18 +542,18 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
         } else {
             gtp_fail_printf(id, "syntax not understood");
         }
-        return true;
+        return;
     } else if (command.find("undo") == 0) {
         if (game.undo_move()) {
             gtp_printf(id, "");
         } else {
             gtp_fail_printf(id, "cannot undo");
         }
-        return true;
+        return;
     } else if (command.find("showboard") == 0) {
         gtp_printf(id, "");
         game.display_state();
-        return true;
+        return;
     } else if (command.find("final_score") == 0) {
         float ftmp = game.final_score();
         /* white wins */
@@ -557,7 +564,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
         } else {
             gtp_printf(id, "0");
         }
-        return true;
+        return;
     } else if (command.find("final_status_list") == 0) {
         if (command.find("alive") != std::string::npos) {
             std::string livelist = get_life_list(game, true);
@@ -568,7 +575,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
         } else {
             gtp_printf(id, "");
         }
-        return true;
+        return;
     } else if (command.find("time_settings") == 0) {
         std::istringstream cmdstream(command);
         std::string tmp;
@@ -584,7 +591,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
         } else {
             gtp_fail_printf(id, "syntax not understood");
         }
-        return true;
+        return;
     } else if (command.find("time_left") == 0) {
         std::istringstream cmdstream(command);
         std::string tmp, color;
@@ -601,7 +608,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
                 icolor = FastBoard::BLACK;
             } else {
                 gtp_fail_printf(id, "Color in time adjust not understood.\n");
-                return 1;
+                return;
             }
 
             game.adjust_time(icolor, time * 100, stones);
@@ -618,7 +625,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
         } else {
             gtp_fail_printf(id, "syntax not understood");
         }
-        return true;
+        return;
     } else if (command.find("auto") == 0) {
         do {
             int move = search->think(game.get_to_move(), UCTSearch::NORMAL);
@@ -627,14 +634,14 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
 
         } while (game.get_passes() < 2 && !game.has_resigned());
 
-        return true;
+        return;
     } else if (command.find("go") == 0) {
         int move = search->think(game.get_to_move());
         game.play_move(move);
 
         std::string vertex = game.move_to_text(move);
         myprintf("%s\n", vertex.c_str());
-        return true;
+        return;
     } else if (command.find("heatmap") == 0) {
         std::istringstream cmdstream(command);
         std::string tmp;
@@ -669,7 +676,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
         }
 
         gtp_printf(id, "");
-        return true;
+        return;
     } else if (command.find("fixed_handicap") == 0) {
         std::istringstream cmdstream(command);
         std::string tmp;
@@ -684,7 +691,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
         } else {
             gtp_fail_printf(id, "Not a valid number of handicap stones");
         }
-        return true;
+        return;
     } else if (command.find("place_free_handicap") == 0) {
         std::istringstream cmdstream(command);
         std::string tmp;
@@ -701,7 +708,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
             gtp_fail_printf(id, "Not a valid number of handicap stones");
         }
 
-        return true;
+        return;
     } else if (command.find("set_free_handicap") == 0) {
         std::istringstream cmdstream(command);
         std::string tmp;
@@ -725,7 +732,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
         std::string stonestring = game.board.get_stone_list();
         gtp_printf(id, "%s", stonestring.c_str());
 
-        return true;
+        return;
     } else if (command.find("loadsgf") == 0) {
         std::istringstream cmdstream(command);
         std::string tmp, filename;
@@ -742,7 +749,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
             }
         } else {
             gtp_fail_printf(id, "Missing filename.");
-            return true;
+            return;
         }
 
         auto sgftree = std::make_unique<SGFTree>();
@@ -754,7 +761,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
         } catch (const std::exception&) {
             gtp_fail_printf(id, "cannot load file");
         }
-        return true;
+        return;
     } else if (command.find("kgs-chat") == 0) {
         // kgs-chat (game|private) Name Message
         std::istringstream cmdstream(command);
@@ -768,11 +775,11 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
         } while (!cmdstream.fail());
 
         gtp_fail_printf(id, "I'm a go bot, not a chat bot.");
-        return true;
+        return;
     } else if (command.find("kgs-game_over") == 0) {
         // Do nothing. Particularly, don't ponder.
         gtp_printf(id, "");
-        return true;
+        return;
     } else if (command.find("kgs-time_settings") == 0) {
         // none, absolute, byoyomi, or canadian
         std::istringstream cmdstream(command);
@@ -798,7 +805,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
             game.set_timecontrol(maintime * 100, byotime * 100, 0, byoperiods);
         } else {
             gtp_fail_printf(id, "syntax not understood");
-            return true;
+            return;
         }
 
         if (!cmdstream.fail()) {
@@ -806,7 +813,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
         } else {
             gtp_fail_printf(id, "syntax not understood");
         }
-        return true;
+        return;
     } else if (command.find("netbench") == 0) {
         std::istringstream cmdstream(command);
         std::string tmp;
@@ -821,7 +828,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
             s_network->benchmark(&game);
         }
         gtp_printf(id, "");
-        return true;
+        return;
 
     } else if (command.find("printsgf") == 0) {
         std::istringstream cmdstream(command);
@@ -844,7 +851,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
             gtp_printf(id, "");
         }
 
-        return true;
+        return;
     } else if (command.find("load_training") == 0) {
         std::istringstream cmdstream(command);
         std::string tmp, filename;
@@ -860,7 +867,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
             gtp_fail_printf(id, "syntax not understood");
         }
 
-        return true;
+        return;
     } else if (command.find("save_training") == 0) {
         std::istringstream cmdstream(command);
         std::string tmp, filename;
@@ -876,7 +883,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
             gtp_fail_printf(id, "syntax not understood");
         }
 
-        return true;
+        return;
     } else if (command.find("dump_training") == 0) {
         std::istringstream cmdstream(command);
         std::string tmp, winner_color, filename;
@@ -891,7 +898,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
             who_won = FullBoard::BLACK;
         } else {
             gtp_fail_printf(id, "syntax not understood");
-            return true;
+            return;
         }
 
         Training::dump_training(who_won, filename);
@@ -902,7 +909,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
             gtp_fail_printf(id, "syntax not understood");
         }
 
-        return true;
+        return;
     } else if (command.find("dump_debug") == 0) {
         std::istringstream cmdstream(command);
         std::string tmp, filename;
@@ -918,7 +925,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
             gtp_fail_printf(id, "syntax not understood");
         }
 
-        return true;
+        return;
     } else if (command.find("dump_supervised") == 0) {
         std::istringstream cmdstream(command);
         std::string tmp, sgfname, outname;
@@ -933,7 +940,7 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
         } else {
             gtp_fail_printf(id, "syntax not understood");
         }
-        return true;
+        return;
     } else if (command.find("lz-memory_report") == 0) {
         auto base_memory = get_base_memory();
         auto tree_size = add_overhead(UCTNodePointer::get_tree_size());
@@ -944,12 +951,12 @@ bool GTP::execute(GameState & game, const std::string& xinput) {
             "Estimated total memory consumption: %d MiB.\n"
             "Network with overhead: %d MiB / Search tree: %d MiB / Network cache: %d\n",
             total / MiB, base_memory / MiB, tree_size / MiB, cache_size / MiB);
-        return true;
+        return;
     } else if (command.find("lz-setoption") == 0) {
-        return execute_setoption(id, command);
+        return execute_setoption(*search.get(), id, command);
     }
     gtp_fail_printf(id, "unknown command");
-    return true;
+    return;
 }
 
 std::pair<std::string, std::string> GTP::parse_option(std::istringstream& is) {
@@ -1026,7 +1033,8 @@ std::pair<bool, std::string> GTP::set_max_memory(size_t max_memory,
         " MiB.");
 }
 
-bool GTP::execute_setoption(int id, const std::string &command) {
+void GTP::execute_setoption(UCTSearch & search,
+                            int id, const std::string &command) {
     std::istringstream cmdstream(command);
     std::string tmp, name_token;
 
@@ -1040,12 +1048,12 @@ bool GTP::execute_setoption(int id, const std::string &command) {
             options_out_tmp = options_out_tmp + "\n" + s_options[i];
         }
         gtp_printf(id, options_out_tmp.c_str());
-        return true;
+        return;
     }
 
     if (name_token.find("name") != 0) {
         gtp_fail_printf(id, "incorrect syntax for lz-setoption");
-        return true;
+        return;
     }
 
     std::string name, value;
@@ -1058,7 +1066,7 @@ bool GTP::execute_setoption(int id, const std::string &command) {
         if (!valuestream.fail()) {
             if (max_memory_in_mib < 128 || max_memory_in_mib > 131072) {
                 gtp_fail_printf(id, "incorrect value");
-                return true;
+                return;
             }
             bool result;
             std::string reason;
@@ -1069,10 +1077,10 @@ bool GTP::execute_setoption(int id, const std::string &command) {
             } else {
                 gtp_fail_printf(id, reason.c_str());
             }
-            return true;
+            return;
         } else {
             gtp_fail_printf(id, "incorrect value");
-            return true;
+            return;
         }
     } else if (name == "percentage of memory for cache") {
         std::istringstream valuestream(value);
@@ -1080,7 +1088,7 @@ bool GTP::execute_setoption(int id, const std::string &command) {
         valuestream >> cache_size_ratio_percent;
         if (cache_size_ratio_percent < 1 || cache_size_ratio_percent > 99) {
             gtp_fail_printf(id, "incorrect value");
-            return true;
+            return;
         }
         bool result;
         std::string reason;
@@ -1091,9 +1099,69 @@ bool GTP::execute_setoption(int id, const std::string &command) {
         } else {
             gtp_fail_printf(id, reason.c_str());
         }
-        return true;
+        return;
+    } else if (name == "visits") {
+        std::istringstream valuestream(value);
+        int visits;
+        valuestream >> visits;
+        cfg_max_visits = visits;
+
+        // 0 may be specified to mean "no limit"
+        if (cfg_max_visits == 0) {
+            cfg_max_visits = UCTSearch::UNLIMITED_PLAYOUTS;
+        }
+        // Note that if the visits are changed but no
+        // explicit command to set memory usage is given,
+        // we will stick with the initial guess we made on startup.
+        search.set_visit_limit(cfg_max_visits);
+    } else if (name == "playouts") {
+        std::istringstream valuestream(value);
+        int playouts;
+        valuestream >> playouts;
+        cfg_max_playouts = playouts;
+
+        // 0 may be specified to mean "no limit"
+        if (cfg_max_playouts == 0) {
+            cfg_max_playouts = UCTSearch::UNLIMITED_PLAYOUTS;
+        } else if (cfg_allow_pondering) {
+            // Limiting playouts while pondering is still enabled
+            // makes no sense.
+            gtp_fail_printf(id, "incorrect value");
+            return;
+        }
+
+        // Note that if the playouts are changed but no
+        // explicit command to set memory usage is given,
+        // we will stick with the initial guess we made on startup.
+        search.set_playout_limit(cfg_max_visits);
+    } else if (name == "lagbuffer") {
+        std::istringstream valuestream(value);
+        int lagbuffer;
+        valuestream >> lagbuffer;
+        cfg_lagbuffer_cs = lagbuffer;
+    } else if (name == "pondering") {
+        std::istringstream valuestream(value);
+        std::string toggle;
+        valuestream >> toggle;
+        if (toggle == "true") {
+            if (cfg_max_playouts != UCTSearch::UNLIMITED_PLAYOUTS) {
+                gtp_fail_printf(id, "incorrect value");
+                return;
+            }
+            cfg_allow_pondering = true;
+        } else if (toggle == "false") {
+            cfg_allow_pondering = false;
+        } else {
+            gtp_fail_printf(id, "incorrect value");
+            return;
+        }
+    } else if (name == "resign percentage") {
+        std::istringstream valuestream(value);
+        int resignpct;
+        valuestream >> resignpct;
+        cfg_resignpct = resignpct;
     } else {
         gtp_fail_printf(id, "Unknown option");
     }
-    return true;
+    return;
 }

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -81,8 +81,7 @@ class GTP {
 public:
     static std::unique_ptr<Network> s_network;
     static void initialize(std::unique_ptr<Network>&& network);
-    static bool execute(GameState & game, const std::string& xinput);
-    static bool execute_setoption(int id, const std::string& command);
+    static void execute(GameState & game, const std::string& xinput);
     static void setup_default_parameters();
 private:
     static constexpr int GTP_VERSION = 2;
@@ -94,6 +93,8 @@ private:
         std::istringstream& is);
     static std::pair<bool, std::string> set_max_memory(
         size_t max_memory, int cache_size_ratio_percent);
+    static void execute_setoption(UCTSearch& search,
+                                  int id, const std::string& command);
 
     // Memory estimation helpers
     static size_t get_base_memory();

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -209,7 +209,8 @@ static void parse_commandline(int argc, char *argv[]) {
 #ifdef USE_OPENCL
     if (vm.count("gpu")) {
         cfg_gpus = vm["gpu"].as<std::vector<int> >();
-        // if we use OpenCL, we probably need more threads for the max so that we can saturate the GPU.
+        // if we use OpenCL, we probably need more threads for the max
+        // so that we can saturate the GPU.
         cfg_max_threads *= cfg_gpus.size();
         // we can't exceed MAX_CPUS
         cfg_max_threads = std::min(cfg_max_threads, MAX_CPUS);
@@ -340,7 +341,8 @@ static void parse_commandline(int argc, char *argv[]) {
     if (vm.count("lagbuffer")) {
         int lagbuffer = vm["lagbuffer"].as<int>();
         if (lagbuffer != cfg_lagbuffer_cs) {
-            myprintf("Using per-move time margin of %.2fs.\n", lagbuffer/100.0f);
+            myprintf("Using per-move time margin of %.2fs.\n",
+                     lagbuffer/100.0f);
             cfg_lagbuffer_cs = lagbuffer;
         }
     }

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -462,7 +462,10 @@ void Network::initialize(int playouts, const std::string & weightsfile) {
 
     m_fwd_weights = std::make_shared<ForwardPipeWeights>();
 
+    // Make a guess at a good size as long as the user doesn't
+    // explicitly set a maximum memory usage.
     m_nncache.set_size_from_playouts(playouts);
+
     // Prepare symmetry table
     for (auto s = 0; s < NUM_SYMMETRIES; ++s) {
         for (auto v = 0; v < NUM_INTERSECTIONS; ++v) {

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -40,6 +40,7 @@
 using namespace Utils;
 
 constexpr int UCTSearch::UNLIMITED_PLAYOUTS;
+
 class OutputAnalysisData {
 public:
     OutputAnalysisData(const std::string& move, int visits,


### PR DESCRIPTION
Implement more options in lz-setoption.

Implement a few more parameters that can be set via lz-setoption,
specifically visits, playouts, pondering, resign threshold and the lag
buffer.

We currently don't check the provided values against the reported
min/max values but rely on the UI not to mess up. This could be
addressed in a refactoring. Similarly, commandline and setoption values
should probably treated in a unified way.

Remove the bogus boolean return value from GTP processing functions.