### PR TITLE
Report tuner errors to stderr

### DIFF
--- a/src/Tuner.cpp
+++ b/src/Tuner.cpp
@@ -468,16 +468,16 @@ std::string Tuner<net_t>::tune_sgemm(const int m, const int n, const int k,
     }
     if (best_time == 0) {
         if (failed_compile > 0) {
-            printf("Failed to compile: %d kernels.\n", failed_compile);
+            myprintf_error("Failed to compile: %d kernels.\n", failed_compile);
         }
         if (failed_enqueue > 0) {
-            printf("Failed to enqueue: %d kernels\n", failed_enqueue);
+            myprintf_error("Failed to enqueue: %d kernels\n", failed_enqueue);
         }
         if (failed_error > 0) {
-            printf("Too high error: %d kernels\n", failed_error);
+            myprintf_error("Too high error: %d kernels\n", failed_error);
         }
-        printf("Failed to find a working configuration.\nCheck your OpenCL drivers.\n");
-        printf("Minimum error: %f. Error bound: %f\n", min_error, getTunerMaxError<net_t>());
+        myprintf_error("Failed to find a working configuration.\nCheck your OpenCL drivers.\n");
+        myprintf_error("Minimum error: %f. Error bound: %f\n", min_error, getTunerMaxError<net_t>());
         throw std::runtime_error("Tuner failed to find working configuration.");
     }
     return best_params;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -82,21 +82,35 @@ bool Utils::input_pending() {
 
 static std::mutex IOmutex;
 
+static void myprintf_base(const char *fmt, va_list ap) {
+    va_list ap2;
+    va_copy(ap2, ap);
+
+    vfprintf(stderr, fmt, ap);
+
+    if (cfg_logfile_handle) {
+        std::lock_guard<std::mutex> lock(IOmutex);
+        vfprintf(cfg_logfile_handle, fmt, ap2);
+    }
+    va_end(ap2);
+}
+
 void Utils::myprintf(const char *fmt, ...) {
     if (cfg_quiet) {
         return;
     }
+
     va_list ap;
     va_start(ap, fmt);
-    vfprintf(stderr, fmt, ap);
+    myprintf_base(fmt, ap);
     va_end(ap);
+}
 
-    if (cfg_logfile_handle) {
-        std::lock_guard<std::mutex> lock(IOmutex);
-        va_start(ap, fmt);
-        vfprintf(cfg_logfile_handle, fmt, ap);
-        va_end(ap);
-    }
+void Utils::myprintf_error(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    myprintf_base(fmt, ap);
+    va_end(ap);
 }
 
 static void gtp_fprintf(FILE* file, const std::string& prefix,

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -30,6 +30,7 @@
 extern Utils::ThreadPool thread_pool;
 
 namespace Utils {
+    void myprintf_error(const char *fmt, ...);
     void myprintf(const char *fmt, ...);
     void gtp_printf(int id, const char *fmt, ...);
     void gtp_printf_raw(const char *fmt, ...);


### PR DESCRIPTION
If tuner failed during precision autodetection error output in stdout was read as a GTP message. Hopefully fixes #1932.