### PR TITLE
Simple ladder detector

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -58,6 +58,7 @@ int cfg_max_cache_ratio_percent;
 TimeManagement::enabled_t cfg_timemanage;
 int cfg_lagbuffer_cs;
 int cfg_resignpct;
+int cfg_ladder_len;
 int cfg_noise;
 int cfg_random_cnt;
 int cfg_random_min_visits;
@@ -138,6 +139,7 @@ void GTP::setup_default_parameters() {
     cfg_fpu_reduction = 0.25f;
     // see UCTSearch::should_resign
     cfg_resignpct = -1;
+    cfg_ladder_len = 0;
     cfg_noise = false;
     cfg_random_cnt = 0;
     cfg_random_min_visits = 1;
@@ -1160,6 +1162,12 @@ void GTP::execute_setoption(UCTSearch & search,
         int resignpct;
         valuestream >> resignpct;
         cfg_resignpct = resignpct;
+    } else if (name == "ladder detection length") {
+        std::istringstream valuestream(value);
+        int ladder_len;
+        valuestream >> ladder_len;
+        cfg_ladder_len = ladder_len;
+        gtp_printf(id, "");
     } else {
         gtp_fail_printf(id, "Unknown option");
     }

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -41,6 +41,7 @@ extern int cfg_max_cache_ratio_percent;
 extern TimeManagement::enabled_t cfg_timemanage;
 extern int cfg_lagbuffer_cs;
 extern int cfg_resignpct;
+extern int cfg_ladder_len;
 extern int cfg_noise;
 extern int cfg_random_cnt;
 extern int cfg_random_min_visits;

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -301,3 +301,22 @@ const FullBoard& GameState::get_past_board(int moves_ago) const {
     assert(m_movenum + 1 <= game_history.size());
     return game_history[m_movenum - moves_ago]->board;
 }
+
+int GameState::get_past_move(int moves_ago) const {
+    return game_history[m_movenum - moves_ago]->get_last_move();
+}
+
+bool GameState::is_ladder(int ladder_len) const {
+    // bogus ladder detector that detects any repeated patterns actually
+    const auto PERIOD = 4;
+    if (ladder_len < 2 || m_movenum < (unsigned) ladder_len + PERIOD) {
+        return false;
+    }
+    const auto delta = get_past_move(0) - get_past_move(PERIOD);
+    for (auto i = 1; i < ladder_len; i++) {
+        if (get_past_move(i) - get_past_move(i + PERIOD) != delta) {
+            return false;
+        }
+    }
+    return true;
+}

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -65,8 +65,11 @@ public:
     bool has_resigned() const;
     int who_resigned() const;
 
+    bool is_ladder(int ladder_len) const;
+
 private:
     bool valid_handicap(int stones);
+    int get_past_move(int moves_ago) const;
 
     std::vector<std::shared_ptr<const KoState>> game_history;
     TimeControl m_timecontrol;

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -83,6 +83,8 @@ static void parse_commandline(int argc, char *argv[]) {
         ("benchmark", "Test network and exit. Default args:\n-v3200 --noponder "
                       "-m0 -t1 -s1.")
         ("cpu-only", "Use CPU-only implementation and do not use GPU.")
+        ("ladderlen", po::value<int>()->default_value(cfg_ladder_len),
+                      "Length of repeated moves for ladder detection. (0 = off)")
         ;
 #ifdef USE_OPENCL
     po::options_description gpu_desc("GPU options");
@@ -302,6 +304,10 @@ static void parse_commandline(int argc, char *argv[]) {
 
     if (vm.count("resignpct")) {
         cfg_resignpct = vm["resignpct"].as<int>();
+    }
+
+    if (vm.count("ladderlen")) {
+        cfg_ladder_len = vm["ladderlen"].as<int>();
     }
 
     if (vm.count("randomcnt")) {

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -219,7 +219,7 @@ SearchResult UCTSearch::play_simulation(GameState & currstate,
                 node->create_children(m_network, m_nodes, currstate, eval,
                                       get_min_psa_ratio());
             if (!had_children && success &&
-                !currstate.is_ladder(3)) {
+                !currstate.is_ladder(cfg_ladder_len)) {
                 result = SearchResult::from_eval(eval);
             }
         }

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -218,7 +218,8 @@ SearchResult UCTSearch::play_simulation(GameState & currstate,
             const auto success =
                 node->create_children(m_network, m_nodes, currstate, eval,
                                       get_min_psa_ratio());
-            if (!had_children && success) {
+            if (!had_children && success &&
+                !currstate.is_ladder(3)) {
                 result = SearchResult::from_eval(eval);
             }
         }


### PR DESCRIPTION
This small PR (about 10 lines essentially) adds a ladder detector to leelaz. I know that it is out of the scope of this project (#1447, #1754, #1779). But it practically benefits cpu-only users without large change of existing code. It is not for making leelaz stronger but for comfortable analysis of human games by Lizzie, Go Review Partner, etc. The detector is turned off by default.

Example 1 (ref. https://github.com/gcp/leela-zero/issues/1754#issuecomment-414805195)

    (;B[dd];W[pp];B[pd];W[dp];B[cq];W[cp];B[dq];W[ep];B[fr];W[qf];B[qq];W[qp];B[pq];W[op];B[oq];W[np];B[nq];W[nc];B[nd];W[md];B[ne];W[pc];B[mc];W[oc];B[ld])

The network 182 (68d7c8fc) finds ladder escaping from Example 1 within 500 playouts with the following option.

    leelaz --ladderlen 3 ...

Here, "3" is the length of moves for ladder detection. It takes more than 1000 playouts without this option.

Actually, this PR does not check ladders seriously for simplicity. It only detects any repeated patterns of every 4 moves and calls play_simulation() recursively as long as the same pattern continues. This can cause false positive. For example, repeated pushes from the following Example 2 are regarded as "ladder". But it seems harmless because the pattern is soon broken naturally.

Example 2

    (;B[pp];W[pd];B[dp];W[cd];B[ec];W[dc];B[ed];W[cf];B[nc];W[qf];B[pc];W[qc];B[qb];W[oc];B[pb];W[od];B[qd];W[ob];B[qe];W[pf];B[jc];W[qn];B[rf];W[rg];B[re];W[oh];B[pn];W[pm];B[on];W[ro];B[qq];W[jq];B[hq];W[mq];B[nl];W[ok];B[nr];W[om];B[nm];W[nn];B[no])
