### PR TITLE
Add a feature to exclude moves from the search.

### DIFF
--- a/src/FastState.cpp
+++ b/src/FastState.cpp
@@ -77,7 +77,19 @@ bool FastState::is_move_legal(int color, int vertex) const {
            vertex == FastBoard::RESIGN ||
            (vertex != m_komove &&
                 board.get_state(vertex) == FastBoard::EMPTY &&
+                !is_to_avoid(color, vertex, m_movenum) &&
                 !board.is_suicide(vertex, color));
+}
+
+bool FastState::is_to_avoid(int color, int vertex, size_t movenum) const {
+    for (auto& move : m_moves_to_avoid) {
+        if (color == move.color &&
+                vertex == move.vertex &&
+                movenum >= move.from_move &&
+                movenum <= move.to_move)
+            return true;
+    }
+    return false;
 }
 
 void FastState::play_move(int vertex) {
@@ -130,6 +142,15 @@ void FastState::set_passes(int val) {
 void FastState::increment_passes() {
     m_passes++;
     if (m_passes > 4) m_passes = 4;
+}
+
+void FastState::add_move_to_avoid(int color, int vertex, size_t from_move, size_t to_move) {
+    MoveToAvoid item;
+    item.color = color;
+    item.vertex = vertex;
+    item.from_move = from_move;
+    item.to_move = to_move;
+    m_moves_to_avoid.push_back(item);
 }
 
 int FastState::get_to_move() const {

--- a/src/FastState.cpp
+++ b/src/FastState.cpp
@@ -73,12 +73,12 @@ void FastState::reset_board() {
 }
 
 bool FastState::is_move_legal(int color, int vertex) const {
-    return vertex == FastBoard::PASS ||
-           vertex == FastBoard::RESIGN ||
-           (vertex != m_komove &&
-                board.get_state(vertex) == FastBoard::EMPTY &&
-                !is_to_avoid(color, vertex, m_movenum) &&
-                !board.is_suicide(vertex, color));
+    return !is_to_avoid(color, vertex, m_movenum) && (
+              vertex == FastBoard::PASS ||
+                 vertex == FastBoard::RESIGN ||
+                 (vertex != m_komove &&
+                      board.get_state(vertex) == FastBoard::EMPTY &&
+                      !board.is_suicide(vertex, color)));
 }
 
 bool FastState::is_to_avoid(int color, int vertex, size_t movenum) const {

--- a/src/FastState.cpp
+++ b/src/FastState.cpp
@@ -84,19 +84,14 @@ bool FastState::is_move_legal(int color, int vertex) const {
 
 bool FastState::is_to_avoid(int color, int vertex, size_t movenum) const {
     for (auto& move : cfg_analyze_tags.m_moves_to_avoid) {
-        if (color == move.color &&
-                vertex == move.vertex &&
-                movenum >= move.from_move &&
-                movenum <= move.to_move) {
+        if (color == move.color && vertex == move.vertex && movenum <= move.until_move) {
             return true;
         }
     }
     if (vertex != FastBoard::PASS && vertex != FastBoard::RESIGN) {
         bool active_allow = false;
         for (auto& move : cfg_analyze_tags.m_moves_to_allow) {
-            if (color == move.color &&
-                    movenum >= move.from_move &&
-                    movenum <= move.to_move) {
+            if (color == move.color && movenum <= move.until_move) {
                 active_allow = true;
                 if (vertex == move.vertex) {
                     return false;

--- a/src/FastState.cpp
+++ b/src/FastState.cpp
@@ -91,6 +91,18 @@ bool FastState::is_to_avoid(int color, int vertex, size_t movenum) const {
             return true;
         }
     }
+    if (!cfg_analyze_tags.m_moves_to_allow.empty()
+            && vertex != FastBoard::PASS && vertex != FastBoard::RESIGN) {
+        for (auto& move : cfg_analyze_tags.m_moves_to_allow) {
+            if (color == move.color &&
+                    vertex == move.vertex &&
+                    movenum >= move.from_move &&
+                    movenum <= move.to_move) {
+                return false;
+            }
+        }
+        return true;
+    }
     return false;
 }
 

--- a/src/FastState.cpp
+++ b/src/FastState.cpp
@@ -74,35 +74,12 @@ void FastState::reset_board() {
 }
 
 bool FastState::is_move_legal(int color, int vertex) const {
-    return !is_to_avoid(color, vertex, m_movenum) && (
+    return !cfg_analyze_tags.is_to_avoid(color, vertex, m_movenum) && (
               vertex == FastBoard::PASS ||
                  vertex == FastBoard::RESIGN ||
                  (vertex != m_komove &&
                       board.get_state(vertex) == FastBoard::EMPTY &&
                       !board.is_suicide(vertex, color)));
-}
-
-bool FastState::is_to_avoid(int color, int vertex, size_t movenum) const {
-    for (auto& move : cfg_analyze_tags.m_moves_to_avoid) {
-        if (color == move.color && vertex == move.vertex && movenum <= move.until_move) {
-            return true;
-        }
-    }
-    if (vertex != FastBoard::PASS && vertex != FastBoard::RESIGN) {
-        bool active_allow = false;
-        for (auto& move : cfg_analyze_tags.m_moves_to_allow) {
-            if (color == move.color && movenum <= move.until_move) {
-                active_allow = true;
-                if (vertex == move.vertex) {
-                    return false;
-                }
-            }
-        }
-        if (active_allow) {
-            return true;
-        }
-    }
-    return false;
 }
 
 void FastState::play_move(int vertex) {

--- a/src/FastState.cpp
+++ b/src/FastState.cpp
@@ -37,6 +37,7 @@
 #include "FastBoard.h"
 #include "Utils.h"
 #include "Zobrist.h"
+#include "GTP.h"
 
 using namespace Utils;
 
@@ -82,7 +83,7 @@ bool FastState::is_move_legal(int color, int vertex) const {
 }
 
 bool FastState::is_to_avoid(int color, int vertex, size_t movenum) const {
-    for (auto& move : m_moves_to_avoid) {
+    for (auto& move : cfg_analyze_tags.m_moves_to_avoid) {
         if (color == move.color &&
                 vertex == move.vertex &&
                 movenum >= move.from_move &&
@@ -143,14 +144,6 @@ void FastState::set_passes(int val) {
 void FastState::increment_passes() {
     m_passes++;
     if (m_passes > 4) m_passes = 4;
-}
-
-void FastState::add_move_to_avoid(int color, int vertex, size_t from_move, size_t to_move) {
-    m_moves_to_avoid.emplace_back(color, from_move, to_move, vertex);
-}
-
-void FastState::clear_moves_to_avoid() {
-    m_moves_to_avoid.clear();
 }
 
 int FastState::get_to_move() const {

--- a/src/FastState.cpp
+++ b/src/FastState.cpp
@@ -86,8 +86,9 @@ bool FastState::is_to_avoid(int color, int vertex, size_t movenum) const {
         if (color == move.color &&
                 vertex == move.vertex &&
                 movenum >= move.from_move &&
-                movenum <= move.to_move)
+                movenum <= move.to_move) {
             return true;
+        }
     }
     return false;
 }
@@ -145,12 +146,11 @@ void FastState::increment_passes() {
 }
 
 void FastState::add_move_to_avoid(int color, int vertex, size_t from_move, size_t to_move) {
-    MoveToAvoid item;
-    item.color = color;
-    item.vertex = vertex;
-    item.from_move = from_move;
-    item.to_move = to_move;
-    m_moves_to_avoid.push_back(item);
+    m_moves_to_avoid.emplace_back(color, from_move, to_move, vertex);
+}
+
+void FastState::clear_moves_to_avoid() {
+    m_moves_to_avoid.clear();
 }
 
 int FastState::get_to_move() const {

--- a/src/FastState.cpp
+++ b/src/FastState.cpp
@@ -91,17 +91,21 @@ bool FastState::is_to_avoid(int color, int vertex, size_t movenum) const {
             return true;
         }
     }
-    if (!cfg_analyze_tags.m_moves_to_allow.empty()
-            && vertex != FastBoard::PASS && vertex != FastBoard::RESIGN) {
+    if (vertex != FastBoard::PASS && vertex != FastBoard::RESIGN) {
+        bool active_allow = false;
         for (auto& move : cfg_analyze_tags.m_moves_to_allow) {
             if (color == move.color &&
-                    vertex == move.vertex &&
                     movenum >= move.from_move &&
                     movenum <= move.to_move) {
-                return false;
+                active_allow = true;
+                if (vertex == move.vertex) {
+                    return false;
+                }
             }
         }
-        return true;
+        if (active_allow) {
+            return true;
+        }
     }
     return false;
 }

--- a/src/FastState.h
+++ b/src/FastState.h
@@ -37,21 +37,6 @@
 
 #include "FullBoard.h"
 
-struct MoveToAvoid {
-    int color;
-    size_t from_move, to_move;
-    int vertex;
-
-    MoveToAvoid(int color, size_t from_move, size_t to_move, int vertex)
-        : color(color), from_move(from_move), to_move(to_move), vertex(vertex)
-    {}
-
-    bool operator==(const MoveToAvoid other) const {
-        return color == other.color && from_move == other.from_move &&
-            to_move == other.to_move && vertex == other.vertex;
-    }
-};
-
 class FastState {
 public:
     void init_game(int size, float komi);
@@ -71,8 +56,6 @@ public:
     void set_to_move(int tomove);
     void set_passes(int val);
     void increment_passes();
-    void add_move_to_avoid(int color, int vertex, size_t from_move, size_t to_move);
-    void clear_moves_to_avoid();
 
     float final_score() const;
     std::uint64_t get_symmetry_hash(int symmetry) const;
@@ -90,7 +73,6 @@ public:
     int m_komove;
     size_t m_movenum;
     int m_lastmove;
-    std::vector<MoveToAvoid> m_moves_to_avoid;
 
 protected:
     void play_move(int color, int vertex);

--- a/src/FastState.h
+++ b/src/FastState.h
@@ -42,6 +42,10 @@ struct MoveToAvoid {
     size_t from_move, to_move;
     int vertex;
 
+    MoveToAvoid(int color, size_t from_move, size_t to_move, int vertex)
+        : color(color), from_move(from_move), to_move(to_move), vertex(vertex)
+    {}
+
     bool operator==(const MoveToAvoid other) const {
         return color == other.color && from_move == other.from_move &&
             to_move == other.to_move && vertex == other.vertex;
@@ -68,6 +72,7 @@ public:
     void set_passes(int val);
     void increment_passes();
     void add_move_to_avoid(int color, int vertex, size_t from_move, size_t to_move);
+    void clear_moves_to_avoid();
 
     float final_score() const;
     std::uint64_t get_symmetry_hash(int symmetry) const;

--- a/src/FastState.h
+++ b/src/FastState.h
@@ -45,7 +45,6 @@ public:
 
     void play_move(int vertex);
     bool is_move_legal(int color, int vertex) const;
-    bool is_to_avoid(int color, int vertex, size_t movenum) const;
 
     void set_komi(float komi);
     float get_komi() const;

--- a/src/FastState.h
+++ b/src/FastState.h
@@ -37,6 +37,17 @@
 
 #include "FullBoard.h"
 
+struct MoveToAvoid {
+    int color;
+    size_t from_move, to_move;
+    int vertex;
+
+    bool operator==(const MoveToAvoid other) const {
+        return color == other.color && from_move == other.from_move &&
+            to_move == other.to_move && vertex == other.vertex;
+    }
+};
+
 class FastState {
 public:
     void init_game(int size, float komi);
@@ -45,6 +56,7 @@ public:
 
     void play_move(int vertex);
     bool is_move_legal(int color, int vertex) const;
+    bool is_to_avoid(int color, int vertex, size_t movenum) const;
 
     void set_komi(float komi);
     float get_komi() const;
@@ -55,6 +67,7 @@ public:
     void set_to_move(int tomove);
     void set_passes(int val);
     void increment_passes();
+    void add_move_to_avoid(int color, int vertex, size_t from_move, size_t to_move);
 
     float final_score() const;
     std::uint64_t get_symmetry_hash(int symmetry) const;
@@ -72,6 +85,7 @@ public:
     int m_komove;
     size_t m_movenum;
     int m_lastmove;
+    std::vector<MoveToAvoid> m_moves_to_avoid;
 
 protected:
     void play_move(int color, int vertex);

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -284,10 +284,10 @@ AnalyzeTags GTP::parse_analyze_tags(std::istringstream & cmdstream, const GameSt
 
         if (tag == "avoid" || tag == "allow") {
             std::string textcolor, textmoves;
-            size_t to_movenum;
+            size_t until_movenum;
             cmdstream >> textcolor;
             cmdstream >> textmoves;
-            cmdstream >> to_movenum;
+            cmdstream >> until_movenum;
             if (cmdstream.fail()) {
                 break;
             }
@@ -317,14 +317,14 @@ AnalyzeTags GTP::parse_analyze_tags(std::istringstream & cmdstream, const GameSt
                 break;
             }
 
-            if (to_movenum < 1) {
+            if (until_movenum < 1) {
                 break;
             }
-            to_movenum += game.get_movenum() - 1;
+            until_movenum += game.get_movenum() - 1;
 
             for (auto move : moves) {
                 if (tag == "avoid") {
-                    tags.add_move_to_avoid(color, move, game.get_movenum(), to_movenum);
+                    tags.add_move_to_avoid(color, move, until_movenum);
                     if (move != FastBoard::PASS && move != FastBoard::RESIGN) {
                         if (color == FastBoard::BLACK) {
                             avoid_not_pass_resign_b = true;
@@ -333,7 +333,7 @@ AnalyzeTags GTP::parse_analyze_tags(std::istringstream & cmdstream, const GameSt
                         }
                     }
                 } else {
-                    tags.add_move_to_allow(color, move, game.get_movenum(), to_movenum);
+                    tags.add_move_to_allow(color, move, until_movenum);
                     if (color == FastBoard::BLACK) {
                         allow_b = true;
                     } else {

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -213,7 +213,7 @@ const std::string GTP::s_commands[] = {
     "lz-genmove_analyze",
     "lz-memory_report",
     "lz-setoption",
-    "avoid",
+    "lz-avoid",
     ""
 };
 
@@ -969,12 +969,16 @@ void GTP::execute(GameState & game, const std::string& xinput) {
             "Network with overhead: %d MiB / Search tree: %d MiB / Network cache: %d\n",
             total / MiB, base_memory / MiB, tree_size / MiB, cache_size / MiB);
         return;
-    } else if (command.find("avoid") == 0) {
+    } else if (command.find("lz-avoid clear") == 0) {
+        game.clear_moves_to_avoid();
+        gtp_printf(id, "cleared the list of moves to avoid");
+        return;
+    } else if (command.find("lz-avoid") == 0) {
         std::istringstream cmdstream(command);
         std::string tmp;
         std::string textcolor, textmove, text_to_movenum;
 
-        cmdstream >> tmp;   // eat avoid
+        cmdstream >> tmp;   // eat lz-avoid
         cmdstream >> textcolor;
         cmdstream >> textmove;
         cmdstream >> text_to_movenum;
@@ -999,12 +1003,13 @@ void GTP::execute(GameState & game, const std::string& xinput) {
 
         std::stringstream movenumstream(text_to_movenum);
         movenumstream >> to_movenum;
-        if (text_to_movenum[0] == '+')
+        if (text_to_movenum[0] == '+') {
             to_movenum += game.get_movenum();
+        }
 
         game.add_move_to_avoid(color, move, game.get_movenum(), to_movenum);
 
-        gtp_printf(id, "added to lists of moves to avoid");
+        gtp_printf(id, "added to list of moves to avoid");
         return;
     } else if (command.find("lz-setoption") == 0) {
         return execute_setoption(*search.get(), id, command);

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -58,7 +58,7 @@ struct MoveToAvoid {
 class AnalyzeTags {
 public:
     bool m_invalid;
-    std::vector<MoveToAvoid> m_moves_to_avoid;
+    std::vector<MoveToAvoid> m_moves_to_avoid, m_moves_to_allow;
     int m_interval_centis;
     int m_who;
 
@@ -69,12 +69,17 @@ public:
     void clear() {
         m_invalid = true;
         m_moves_to_avoid.clear();
+        m_moves_to_allow.clear();
         m_interval_centis = 0;
         m_who = FastBoard::INVAL;
     }
 
     void add_move_to_avoid(int color, int vertex, size_t from_move, size_t to_move) {
         m_moves_to_avoid.emplace_back(color, from_move, to_move, vertex);
+    }
+
+    void add_move_to_allow(int color, int vertex, size_t from_move, size_t to_move) {
+        m_moves_to_allow.emplace_back(color, from_move, to_move, vertex);
     }
 };
 

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -42,16 +42,16 @@
 
 struct MoveToAvoid {
     int color;
-    size_t from_move, to_move;
+    size_t until_move;
     int vertex;
 
-    MoveToAvoid(int color, size_t from_move, size_t to_move, int vertex)
-        : color(color), from_move(from_move), to_move(to_move), vertex(vertex)
+    MoveToAvoid(int color, size_t until_move, int vertex)
+        : color(color), until_move(until_move), vertex(vertex)
     {}
 
     bool operator==(const MoveToAvoid other) const {
-        return color == other.color && from_move == other.from_move &&
-            to_move == other.to_move && vertex == other.vertex;
+        return color == other.color &&
+            until_move == other.until_move && vertex == other.vertex;
     }
 };
 
@@ -74,12 +74,12 @@ public:
         m_who = FastBoard::INVAL;
     }
 
-    void add_move_to_avoid(int color, int vertex, size_t from_move, size_t to_move) {
-        m_moves_to_avoid.emplace_back(color, from_move, to_move, vertex);
+    void add_move_to_avoid(int color, int vertex, size_t until_move) {
+        m_moves_to_avoid.emplace_back(color, until_move, vertex);
     }
 
-    void add_move_to_allow(int color, int vertex, size_t from_move, size_t to_move) {
-        m_moves_to_allow.emplace_back(color, from_move, to_move, vertex);
+    void add_move_to_allow(int color, int vertex, size_t until_move) {
+        m_moves_to_allow.emplace_back(color, until_move, vertex);
     }
 };
 

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -40,6 +40,36 @@
 #include "GameState.h"
 #include "UCTSearch.h"
 
+struct MoveToAvoid {
+    int color;
+    size_t from_move, to_move;
+    int vertex;
+
+    MoveToAvoid(int color, size_t from_move, size_t to_move, int vertex)
+        : color(color), from_move(from_move), to_move(to_move), vertex(vertex)
+    {}
+
+    bool operator==(const MoveToAvoid other) const {
+        return color == other.color && from_move == other.from_move &&
+            to_move == other.to_move && vertex == other.vertex;
+    }
+};
+
+class AnalyzeTags {
+public:
+    std::vector<MoveToAvoid> m_moves_to_avoid;
+
+    AnalyzeTags() {}
+
+    void clear() {
+        m_moves_to_avoid.clear();
+    }
+
+    void add_move_to_avoid(int color, int vertex, size_t from_move, size_t to_move) {
+        m_moves_to_avoid.emplace_back(color, from_move, to_move, vertex);
+    }
+};
+
 extern bool cfg_gtp_mode;
 extern bool cfg_allow_pondering;
 extern int cfg_num_threads;
@@ -83,6 +113,7 @@ extern std::string cfg_options_str;
 extern bool cfg_benchmark;
 extern bool cfg_cpu_only;
 extern int cfg_analyze_interval_centis;
+extern AnalyzeTags cfg_analyze_tags;
 
 static constexpr size_t MiB = 1024LL * 1024LL;
 
@@ -100,6 +131,7 @@ public:
 private:
     static constexpr int GTP_VERSION = 2;
 
+    static bool process_analyze_tags(int id, std::istringstream & cmdstream, const GameState & game);
     static std::string get_life_list(const GameState & game, bool live);
     static const std::string s_commands[];
     static const std::string s_options[];

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -57,12 +57,20 @@ struct MoveToAvoid {
 
 class AnalyzeTags {
 public:
+    bool m_invalid;
     std::vector<MoveToAvoid> m_moves_to_avoid;
+    int m_interval_centis;
+    int m_who;
 
-    AnalyzeTags() {}
+    AnalyzeTags() {
+        clear();
+    }
 
     void clear() {
+        m_invalid = true;
         m_moves_to_avoid.clear();
+        m_interval_centis = 0;
+        m_who = FastBoard::INVAL;
     }
 
     void add_move_to_avoid(int color, int vertex, size_t from_move, size_t to_move) {
@@ -112,7 +120,6 @@ extern bool cfg_quiet;
 extern std::string cfg_options_str;
 extern bool cfg_benchmark;
 extern bool cfg_cpu_only;
-extern int cfg_analyze_interval_centis;
 extern AnalyzeTags cfg_analyze_tags;
 
 static constexpr size_t MiB = 1024LL * 1024LL;
@@ -128,10 +135,10 @@ public:
     static void initialize(std::unique_ptr<Network>&& network);
     static void execute(GameState & game, const std::string& xinput);
     static void setup_default_parameters();
+    static AnalyzeTags parse_analyze_tags(std::istringstream & cmdstream, const GameState & game);
 private:
     static constexpr int GTP_VERSION = 2;
 
-    static bool process_analyze_tags(int id, std::istringstream & cmdstream, const GameState & game);
     static std::string get_life_list(const GameState & game, bool live);
     static const std::string s_commands[];
     static const std::string s_options[];

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -56,31 +56,25 @@ struct MoveToAvoid {
 };
 
 class AnalyzeTags {
+    friend class LeelaTest;
+
 public:
-    bool m_invalid;
+    AnalyzeTags() = default;
+    AnalyzeTags(std::istringstream& cmdstream, const GameState& game);
+
+    void add_move_to_avoid(int color, int vertex, size_t until_move);
+    void add_move_to_allow(int color, int vertex, size_t until_move);
+    int interval_centis() const;
+    int invalid() const;
+    int who() const;
+    bool is_to_avoid(int color, int vertex, size_t movenum) const;
+    bool has_move_restrictions() const;
+
+private:
+    bool m_invalid{true};
     std::vector<MoveToAvoid> m_moves_to_avoid, m_moves_to_allow;
-    int m_interval_centis;
-    int m_who;
-
-    AnalyzeTags() {
-        clear();
-    }
-
-    void clear() {
-        m_invalid = true;
-        m_moves_to_avoid.clear();
-        m_moves_to_allow.clear();
-        m_interval_centis = 0;
-        m_who = FastBoard::INVAL;
-    }
-
-    void add_move_to_avoid(int color, int vertex, size_t until_move) {
-        m_moves_to_avoid.emplace_back(color, until_move, vertex);
-    }
-
-    void add_move_to_allow(int color, int vertex, size_t until_move) {
-        m_moves_to_allow.emplace_back(color, until_move, vertex);
-    }
+    int m_interval_centis{0};
+    int m_who{FastBoard::INVAL};
 };
 
 extern bool cfg_gtp_mode;
@@ -140,7 +134,6 @@ public:
     static void initialize(std::unique_ptr<Network>&& network);
     static void execute(GameState & game, const std::string& xinput);
     static void setup_default_parameters();
-    static AnalyzeTags parse_analyze_tags(std::istringstream & cmdstream, const GameState & game);
 private:
     static constexpr int GTP_VERSION = 2;
 

--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -106,7 +106,7 @@ private:
                        float min_psa_ratio);
     double get_blackevals() const;
     void accumulate_eval(float eval);
-    void kill_superkos(const KoState& state);
+    void kill_superkos(const GameState& state);
     void dirichlet_noise(float epsilon, float alpha);
 
     // Note : This class is very size-sensitive as we are going to create

--- a/src/UCTNodeRoot.cpp
+++ b/src/UCTNodeRoot.cpp
@@ -61,7 +61,7 @@ UCTNode* UCTNode::get_first_child() const {
 
 void UCTNode::kill_superkos(const GameState& state) {
     UCTNodePointer *pass_child = nullptr;
-    size_t valid_count = m_children.size();
+    size_t valid_count = 0;
 
     for (auto& child : m_children) {
         auto move = child->get_move();
@@ -72,10 +72,12 @@ void UCTNode::kill_superkos(const GameState& state) {
             if (mystate.superko()) {
                 // Don't delete nodes for now, just mark them invalid.
                 child->invalidate();
-                valid_count--;
             }
         } else {
             pass_child = &child;
+        }
+        if (child->valid()) {
+            valid_count++;
         }
     }
 

--- a/src/UCTNodeRoot.cpp
+++ b/src/UCTNodeRoot.cpp
@@ -59,7 +59,10 @@ UCTNode* UCTNode::get_first_child() const {
     return m_children.front().get();
 }
 
-void UCTNode::kill_superkos(const KoState& state) {
+void UCTNode::kill_superkos(const GameState& state) {
+    UCTNodePointer *pass_child = nullptr;
+    size_t valid_count = m_children.size();
+
     for (auto& child : m_children) {
         auto move = child->get_move();
         if (move != FastBoard::PASS) {
@@ -69,8 +72,18 @@ void UCTNode::kill_superkos(const KoState& state) {
             if (mystate.superko()) {
                 // Don't delete nodes for now, just mark them invalid.
                 child->invalidate();
+                valid_count--;
             }
+        } else {
+            pass_child = &child;
         }
+    }
+
+    if (valid_count > 1 && pass_child &&
+            !state.is_move_legal(state.get_to_move(), FastBoard::PASS)) {
+        // Remove the PASS node according to "avoid" -- but only if there are
+        // other valid nodes left.
+        (*pass_child)->invalidate();
     }
 
     // Now do the actual deletion.

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -422,6 +422,10 @@ bool UCTSearch::should_resign(passflag_t passflag, float besteval) {
         }
     }
 
+    if (!m_rootstate.is_move_legal(color, FastBoard::RESIGN)) {
+        return false;
+    }
+
     return true;
 }
 
@@ -523,8 +527,10 @@ int UCTSearch::get_best_move(passflag_t passflag) {
             // We didn't consider passing. Should we have and
             // end the game immediately?
 
+            if (!m_rootstate.is_move_legal(color, FastBoard::PASS)) {
+                myprintf("Passing is forbidden, I'll play on.\n");
             // do we lose by passing?
-            if (relative_score < 0.0f) {
+            } else if (relative_score < 0.0f) {
                 myprintf("Passing loses, I'll play on.\n");
             } else if (relative_score > 0.0f) {
                 myprintf("Passing wins, I'll pass out.\n");

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -800,7 +800,8 @@ int UCTSearch::think(int color, passflag_t passflag) {
 }
 
 void UCTSearch::ponder() {
-    auto disable_reuse = !cfg_analyze_tags.m_moves_to_avoid.empty();
+    auto disable_reuse = !cfg_analyze_tags.m_moves_to_avoid.empty() ||
+                         !cfg_analyze_tags.m_moves_to_allow.empty();
     if (disable_reuse) {
         m_last_rootstate.reset(nullptr);
     }

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -744,8 +744,8 @@ int UCTSearch::think(int color, passflag_t passflag) {
         Time elapsed;
         int elapsed_centis = Time::timediff_centis(start, elapsed);
 
-        if (cfg_analyze_interval_centis &&
-            elapsed_centis - last_output > cfg_analyze_interval_centis) {
+        if (cfg_analyze_tags.m_interval_centis &&
+            elapsed_centis - last_output > cfg_analyze_tags.m_interval_centis) {
             last_output = elapsed_centis;
             output_analysis(m_rootstate, *m_root);
         }
@@ -800,7 +800,7 @@ int UCTSearch::think(int color, passflag_t passflag) {
 }
 
 void UCTSearch::ponder() {
-    bool disable_reuse = !cfg_analyze_tags.m_moves_to_avoid.empty();
+    auto disable_reuse = !cfg_analyze_tags.m_moves_to_avoid.empty();
     if (disable_reuse) {
         m_last_rootstate.reset(nullptr);
     }
@@ -824,10 +824,10 @@ void UCTSearch::ponder() {
         if (result.valid()) {
             increment_playouts();
         }
-        if (cfg_analyze_interval_centis) {
+        if (cfg_analyze_tags.m_interval_centis) {
             Time elapsed;
             int elapsed_centis = Time::timediff_centis(start, elapsed);
-            if (elapsed_centis - last_output > cfg_analyze_interval_centis) {
+            if (elapsed_centis - last_output > cfg_analyze_tags.m_interval_centis) {
                 last_output = elapsed_centis;
                 output_analysis(m_rootstate, *m_root);
             }

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -762,7 +762,7 @@ int UCTSearch::think(int color, passflag_t passflag) {
     } while (keeprunning);
 
     // Make sure to post at least once.
-    if (cfg_analyze_interval_centis && last_output == 0) {
+    if (cfg_analyze_tags.interval_centis() && last_output == 0) {
         output_analysis(m_rootstate, *m_root);
     }
 
@@ -837,7 +837,7 @@ void UCTSearch::ponder() {
     } while (!Utils::input_pending() && keeprunning);
 
     // Make sure to post at least once.
-    if (cfg_analyze_interval_centis && last_output == 0) {
+    if (cfg_analyze_tags.interval_centis() && last_output == 0) {
         output_analysis(m_rootstate, *m_root);
     }
 

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -744,8 +744,8 @@ int UCTSearch::think(int color, passflag_t passflag) {
         Time elapsed;
         int elapsed_centis = Time::timediff_centis(start, elapsed);
 
-        if (cfg_analyze_tags.m_interval_centis &&
-            elapsed_centis - last_output > cfg_analyze_tags.m_interval_centis) {
+        if (cfg_analyze_tags.interval_centis() &&
+            elapsed_centis - last_output > cfg_analyze_tags.interval_centis()) {
             last_output = elapsed_centis;
             output_analysis(m_rootstate, *m_root);
         }
@@ -800,8 +800,7 @@ int UCTSearch::think(int color, passflag_t passflag) {
 }
 
 void UCTSearch::ponder() {
-    auto disable_reuse = !cfg_analyze_tags.m_moves_to_avoid.empty() ||
-                         !cfg_analyze_tags.m_moves_to_allow.empty();
+    auto disable_reuse = cfg_analyze_tags.has_move_restrictions();
     if (disable_reuse) {
         m_last_rootstate.reset(nullptr);
     }
@@ -825,10 +824,10 @@ void UCTSearch::ponder() {
         if (result.valid()) {
             increment_playouts();
         }
-        if (cfg_analyze_tags.m_interval_centis) {
+        if (cfg_analyze_tags.interval_centis()) {
             Time elapsed;
             int elapsed_centis = Time::timediff_centis(start, elapsed);
-            if (elapsed_centis - last_output > cfg_analyze_tags.m_interval_centis) {
+            if (elapsed_centis - last_output > cfg_analyze_tags.interval_centis()) {
                 last_output = elapsed_centis;
                 output_analysis(m_rootstate, *m_root);
             }

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -108,6 +108,10 @@ bool UCTSearch::advance_to_new_rootstate() {
         return false;
     }
 
+    if (m_rootstate.m_moves_to_avoid != m_last_rootstate->m_moves_to_avoid) {
+        return false;
+    }
+
     auto depth =
         int(m_rootstate.get_movenum() - m_last_rootstate->get_movenum());
 

--- a/src/tests/gtests.cpp
+++ b/src/tests/gtests.cpp
@@ -272,7 +272,7 @@ void LeelaTest::test_analyze_cmd(std::string cmd, bool valid, int who, int inter
     // avoid_until checks against the absolute game move number, indexed from 0
     std::istringstream cmdstream(cmd);
     auto maingame = get_gamestate();
-    auto result = GTP::parse_analyze_tags(cmdstream, maingame);
+    AnalyzeTags result{cmdstream, maingame};
     EXPECT_EQ(result.m_invalid, !valid);
     if (!valid) return;
     EXPECT_EQ(result.m_who, who);

--- a/src/tests/gtests.cpp
+++ b/src/tests/gtests.cpp
@@ -330,4 +330,14 @@ TEST_F(LeelaTest, AnalyzeParse) {
             true, FastBoard::WHITE, 100, 2, FastBoard::BLACK, 2, 9);
     test_analyze_cmd("avoid b k10 8 w avoid b pass 17",
             true, FastBoard::WHITE, 0, 2, FastBoard::BLACK, 2, 9);
+
+    gtp_execute("clear_board");
+    test_analyze_cmd("b avoid b a1 10 allow b t1 1",
+            false, -1, -1, -1, -1, -1, -1);
+    test_analyze_cmd("b avoid w a1 10 allow b t1 1",
+            true, FastBoard::BLACK, 0, 1, FastBoard::WHITE, 0, 9);
+    test_analyze_cmd("b avoid b pass 10 allow b t1 1",
+            true, FastBoard::BLACK, 0, 1, FastBoard::BLACK, 0, 9);
+    test_analyze_cmd("b avoid b resign 10 allow b t1 1",
+            true, FastBoard::BLACK, 0, 1, FastBoard::BLACK, 0, 9);
 }

--- a/src/tests/gtests.cpp
+++ b/src/tests/gtests.cpp
@@ -340,4 +340,8 @@ TEST_F(LeelaTest, AnalyzeParse) {
             true, FastBoard::BLACK, 0, 1, FastBoard::BLACK, 0, 9);
     test_analyze_cmd("b avoid b resign 10 allow b t1 1",
             true, FastBoard::BLACK, 0, 1, FastBoard::BLACK, 0, 9);
+    test_analyze_cmd("b avoid w c3,c4,d3,d4 2 avoid b pass 50",
+            true, FastBoard::BLACK, 0, 5, FastBoard::WHITE, 0, 1);
+    test_analyze_cmd("b avoid w c3,c4,d3,d4, 2 avoid b pass 50",
+            false, -1, -1, -1, -1, -1, -1);
 }

--- a/src/tests/gtests.cpp
+++ b/src/tests/gtests.cpp
@@ -269,6 +269,7 @@ TEST_F(LeelaTest, TimeControl2) {
 void LeelaTest::test_analyze_cmd(std::string cmd, bool valid, int who, int interval,
         int avoidlen, int avoidcolor, int avoiduntil) {
     // std::cout << "testing " << cmd << std::endl;
+    // avoid_until checks against the absolute game move number, indexed from 0
     std::istringstream cmdstream(cmd);
     auto maingame = get_gamestate();
     auto result = GTP::parse_analyze_tags(cmdstream, maingame);
@@ -343,4 +344,34 @@ TEST_F(LeelaTest, AnalyzeParse) {
             true, FastBoard::BLACK, 0, 5, FastBoard::WHITE, 1);
     test_analyze_cmd("b avoid w c3,c4,d3,d4, 2 avoid b pass 50",
             false, -1, -1, -1, -1, -1);
+
+    gtp_execute("clear_board");
+    test_analyze_cmd("b avoid b q16 1",
+            true, FastBoard::BLACK, 0, 1, FastBoard::BLACK, 0);
+    test_analyze_cmd("b avoid b : 1",
+            false, -1, -1, -1, -1, -1);
+    test_analyze_cmd("b avoid b d4: 1",
+            false, -1, -1, -1, -1, -1);
+    test_analyze_cmd("b avoid b d14: 1",
+            false, -1, -1, -1, -1, -1);
+    test_analyze_cmd("b avoid b :e3 1",
+            false, -1, -1, -1, -1, -1);
+    test_analyze_cmd("b avoid b d:e3 1",
+            false, -1, -1, -1, -1, -1);
+    test_analyze_cmd("b avoid b q16:q16 20",
+            true, FastBoard::BLACK, 0, 1, FastBoard::BLACK, 19);
+    test_analyze_cmd("b avoid b q16:t19 1",
+            true, FastBoard::BLACK, 0, 16, FastBoard::BLACK, 0);
+    test_analyze_cmd("b avoid b t19:q16 1",
+            true, FastBoard::BLACK, 0, 16, FastBoard::BLACK, 0);
+    test_analyze_cmd("b avoid b t16:q19 1",
+            true, FastBoard::BLACK, 0, 16, FastBoard::BLACK, 0);
+    test_analyze_cmd("b avoid b q19:t16 1",
+            true, FastBoard::BLACK, 0, 16, FastBoard::BLACK, 0);
+    test_analyze_cmd("b avoid b a1:t19 1",
+            true, FastBoard::BLACK, 0, 361, FastBoard::BLACK, 0);
+    test_analyze_cmd("b avoid b a1:t19 1 avoid w pass 1 avoid w resign 1",
+            true, FastBoard::BLACK, 0, 363, FastBoard::BLACK, 0);
+    test_analyze_cmd("b avoid b a1:t19,pass,resign 1",
+            true, FastBoard::BLACK, 0, 363, FastBoard::BLACK, 0);
 }

--- a/src/tests/gtests.cpp
+++ b/src/tests/gtests.cpp
@@ -115,7 +115,7 @@ public:
                               testing::internal::GetCapturedStderr());
     }
     void test_analyze_cmd(std::string cmd, bool valid, int who, int interval,
-            int avoidlen, int avoidcolor, int avoidfrom, int avoidto);
+            int avoidlen, int avoidcolor, int avoiduntil);
 
 private:
     std::unique_ptr<GameState> m_gamestate;
@@ -267,7 +267,7 @@ TEST_F(LeelaTest, TimeControl2) {
 }
 
 void LeelaTest::test_analyze_cmd(std::string cmd, bool valid, int who, int interval,
-        int avoidlen, int avoidcolor, int avoidfrom, int avoidto) {
+        int avoidlen, int avoidcolor, int avoiduntil) {
     // std::cout << "testing " << cmd << std::endl;
     std::istringstream cmdstream(cmd);
     auto maingame = get_gamestate();
@@ -279,8 +279,7 @@ void LeelaTest::test_analyze_cmd(std::string cmd, bool valid, int who, int inter
     EXPECT_EQ(result.m_moves_to_avoid.size(), avoidlen);
     if (avoidlen) {
         EXPECT_EQ(result.m_moves_to_avoid[0].color, avoidcolor);
-        EXPECT_EQ(result.m_moves_to_avoid[0].from_move, avoidfrom);
-        EXPECT_EQ(result.m_moves_to_avoid[0].to_move, avoidto);
+        EXPECT_EQ(result.m_moves_to_avoid[0].until_move, avoiduntil);
     }
 }
 
@@ -289,59 +288,59 @@ TEST_F(LeelaTest, AnalyzeParse) {
     gtp_execute("clear_board");
 
     test_analyze_cmd("b 50",
-            true, FastBoard::BLACK, 50, 0, -1, -1, -1);
+            true, FastBoard::BLACK, 50, 0, -1, -1);
     test_analyze_cmd("50 b",
-            true, FastBoard::BLACK, 50, 0, -1, -1, -1);
+            true, FastBoard::BLACK, 50, 0, -1, -1);
     test_analyze_cmd("b interval 50",
-            true, FastBoard::BLACK, 50, 0, -1, -1, -1);
+            true, FastBoard::BLACK, 50, 0, -1, -1);
     test_analyze_cmd("interval 50 b",
-            true, FastBoard::BLACK, 50, 0, -1, -1, -1);
+            true, FastBoard::BLACK, 50, 0, -1, -1);
     test_analyze_cmd("b interval",
-            false, -1, -1, -1, -1, -1, -1);
+            false, -1, -1, -1, -1, -1);
     test_analyze_cmd("42 w",
-            true, FastBoard::WHITE, 42, 0, -1, -1, -1);
+            true, FastBoard::WHITE, 42, 0, -1, -1);
     test_analyze_cmd("1234",
-            true, FastBoard::BLACK, 1234, 0, -1, -1, -1);
+            true, FastBoard::BLACK, 1234, 0, -1, -1);
     gtp_execute("play b q16");
     test_analyze_cmd("1234",
-            true, FastBoard::WHITE, 1234, 0, -1, -1, -1);
+            true, FastBoard::WHITE, 1234, 0, -1, -1);
     test_analyze_cmd("b 100 avoid b k10 1",
-            true, FastBoard::BLACK, 100, 1, FastBoard::BLACK, 1, 1);
+            true, FastBoard::BLACK, 100, 1, FastBoard::BLACK, 1);
     test_analyze_cmd("b 100 avoid b k10 1 avoid b a1 1",
-            true, FastBoard::BLACK, 100, 2, FastBoard::BLACK, 1, 1);
+            true, FastBoard::BLACK, 100, 2, FastBoard::BLACK, 1);
     test_analyze_cmd("b 100 avoid w k10 8",
-            true, FastBoard::BLACK, 100, 1, FastBoard::WHITE, 1, 8);
+            true, FastBoard::BLACK, 100, 1, FastBoard::WHITE, 8);
     gtp_execute("play w q4");
     test_analyze_cmd("b 100 avoid b k10 8",
-            true, FastBoard::BLACK, 100, 1, FastBoard::BLACK, 2, 9);
+            true, FastBoard::BLACK, 100, 1, FastBoard::BLACK, 9);
     test_analyze_cmd("100 b avoid b k10 8",
-            true, FastBoard::BLACK, 100, 1, FastBoard::BLACK, 2, 9);
+            true, FastBoard::BLACK, 100, 1, FastBoard::BLACK, 9);
     test_analyze_cmd("b avoid b k10 8 100",
-            true, FastBoard::BLACK, 100, 1, FastBoard::BLACK, 2, 9);
+            true, FastBoard::BLACK, 100, 1, FastBoard::BLACK, 9);
     test_analyze_cmd("avoid b k10 8 100 b",
-            true, FastBoard::BLACK, 100, 1, FastBoard::BLACK, 2, 9);
+            true, FastBoard::BLACK, 100, 1, FastBoard::BLACK, 9);
     test_analyze_cmd("avoid b k10 8 100 w",
-            true, FastBoard::WHITE, 100, 1, FastBoard::BLACK, 2, 9);
+            true, FastBoard::WHITE, 100, 1, FastBoard::BLACK, 9);
     test_analyze_cmd("avoid b z10 8 100 w",
-            false, -1, -1, -1, -1, -1, -1);
+            false, -1, -1, -1, -1, -1);
     test_analyze_cmd("avoid b k10 8 100 w bogus",
-            false, -1, -1, -1, -1, -1, -1);
+            false, -1, -1, -1, -1, -1);
     test_analyze_cmd("avoid b k10 8 100 w avoid b pass 17",
-            true, FastBoard::WHITE, 100, 2, FastBoard::BLACK, 2, 9);
+            true, FastBoard::WHITE, 100, 2, FastBoard::BLACK, 9);
     test_analyze_cmd("avoid b k10 8 w avoid b pass 17",
-            true, FastBoard::WHITE, 0, 2, FastBoard::BLACK, 2, 9);
+            true, FastBoard::WHITE, 0, 2, FastBoard::BLACK, 9);
 
     gtp_execute("clear_board");
     test_analyze_cmd("b avoid b a1 10 allow b t1 1",
-            false, -1, -1, -1, -1, -1, -1);
+            false, -1, -1, -1, -1, -1);
     test_analyze_cmd("b avoid w a1 10 allow b t1 1",
-            true, FastBoard::BLACK, 0, 1, FastBoard::WHITE, 0, 9);
+            true, FastBoard::BLACK, 0, 1, FastBoard::WHITE, 9);
     test_analyze_cmd("b avoid b pass 10 allow b t1 1",
-            true, FastBoard::BLACK, 0, 1, FastBoard::BLACK, 0, 9);
+            true, FastBoard::BLACK, 0, 1, FastBoard::BLACK, 9);
     test_analyze_cmd("b avoid b resign 10 allow b t1 1",
-            true, FastBoard::BLACK, 0, 1, FastBoard::BLACK, 0, 9);
+            true, FastBoard::BLACK, 0, 1, FastBoard::BLACK, 9);
     test_analyze_cmd("b avoid w c3,c4,d3,d4 2 avoid b pass 50",
-            true, FastBoard::BLACK, 0, 5, FastBoard::WHITE, 0, 1);
+            true, FastBoard::BLACK, 0, 5, FastBoard::WHITE, 1);
     test_analyze_cmd("b avoid w c3,c4,d3,d4, 2 avoid b pass 50",
-            false, -1, -1, -1, -1, -1, -1);
+            false, -1, -1, -1, -1, -1);
 }


### PR DESCRIPTION
(These instructions have been updated to match the current version.)

The new GTP feature "avoid" specifies moves to avoid. It is implemented as a new argument for the `lz-analyze` and `lz-genmove_analyze` commands.
Syntax is `lz-analyze ARGS [avoid <color> <coords> <number_of_moves>] [avoid ...]` (same for `lz-genmove_analyze`).
The specified coords will not be considered for this color starting from the current move for the next `number_of_moves` of moves. Instead of coordinates, `pass` or `resign` may also be specified.

Example: `lz-analyze 100 avoid b q16,q4,d16,d4 1 avoid w k10 2` forbids Black to play a Hoshi and White to play Tengen for the next move.

An additional form is `allow`. "Allow"ing a list of moves is equivalent to "avoid"ing all other moves, except pass or resign:
`lz-analyze 100 allow b r16,r17,q16 1` would force Black to play in the upper-right corner.
`lz-analyze 100 allow b r16,r17,q16 1 avoid b pass,resign 1` would do the same and forbid pass and resign at the same time. Note that `pass` and `resign` are the only possible `avoid` moves that can be specified together with `allow`.

This addresses issue https://github.com/gcp/leela-zero/issues/1675