### PR TITLE
Option to start out with visits for each move.

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -58,6 +58,7 @@ int cfg_max_cache_ratio_percent;
 TimeManagement::enabled_t cfg_timemanage;
 int cfg_lagbuffer_cs;
 int cfg_resignpct;
+int cfg_starting_root_child_visits;
 int cfg_noise;
 int cfg_random_cnt;
 int cfg_random_min_visits;
@@ -139,6 +140,7 @@ void GTP::setup_default_parameters() {
     cfg_fpu_reduction = 0.25f;
     // see UCTSearch::should_resign
     cfg_resignpct = -1;
+    cfg_starting_root_child_visits = 0;
     cfg_noise = false;
     cfg_fpu_root_reduction = cfg_fpu_reduction;
     cfg_random_cnt = 0;
@@ -1168,6 +1170,12 @@ void GTP::execute_setoption(UCTSearch & search,
         int resignpct;
         valuestream >> resignpct;
         cfg_resignpct = resignpct;
+        gtp_printf(id, "");
+    } else if (name == "starting visits for each root move") {
+        std::istringstream valuestream(value);
+        int starting_root_child_visits;
+        valuestream >> starting_root_child_visits;
+        cfg_starting_root_child_visits = starting_root_child_visits;
         gtp_printf(id, "");
     } else {
         gtp_fail_printf(id, "Unknown option");

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -75,6 +75,7 @@ precision_t cfg_precision;
 float cfg_puct;
 float cfg_softmax_temp;
 float cfg_fpu_reduction;
+float cfg_fpu_root_reduction;
 std::string cfg_weightsfile;
 std::string cfg_logfile;
 FILE* cfg_logfile_handle;
@@ -139,6 +140,7 @@ void GTP::setup_default_parameters() {
     // see UCTSearch::should_resign
     cfg_resignpct = -1;
     cfg_noise = false;
+    cfg_fpu_root_reduction = cfg_fpu_reduction;
     cfg_random_cnt = 0;
     cfg_random_min_visits = 1;
     cfg_random_temp = 1.0f;

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -41,6 +41,7 @@ extern int cfg_max_cache_ratio_percent;
 extern TimeManagement::enabled_t cfg_timemanage;
 extern int cfg_lagbuffer_cs;
 extern int cfg_resignpct;
+extern int cfg_starting_root_child_visits;
 extern int cfg_noise;
 extern int cfg_random_cnt;
 extern int cfg_random_min_visits;

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -61,6 +61,7 @@ extern precision_t cfg_precision;
 extern float cfg_puct;
 extern float cfg_softmax_temp;
 extern float cfg_fpu_reduction;
+extern float cfg_fpu_root_reduction;
 extern std::string cfg_logfile;
 extern std::string cfg_weightsfile;
 extern FILE* cfg_logfile_handle;

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -118,7 +118,6 @@ static void parse_commandline(int argc, char *argv[]) {
         ("puct", po::value<float>())
         ("softmax_temp", po::value<float>())
         ("fpu_reduction", po::value<float>())
-        ("fpu_root_reduction", po::value<float>())
         ;
 #endif
     // These won't be shown, we use them to catch incorrect usage of the
@@ -366,11 +365,6 @@ static void parse_commandline(int argc, char *argv[]) {
     // Do not lower the expected eval for root moves that are likely not
     // the best if we have introduced noise there exactly to explore more.
     cfg_fpu_root_reduction = cfg_noise ? 0.0f : cfg_fpu_reduction;
-#ifdef USE_TUNER
-    if (vm.count("fpu_root_reduction")) {
-        cfg_fpu_root_reduction = vm["fpu_root_reduction"].as<float>();
-    }
-#endif
 
     auto out = std::stringstream{};
     for (auto i = 1; i < argc; i++) {

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -118,6 +118,7 @@ static void parse_commandline(int argc, char *argv[]) {
         ("puct", po::value<float>())
         ("softmax_temp", po::value<float>())
         ("fpu_reduction", po::value<float>())
+        ("fpu_root_reduction", po::value<float>())
         ;
 #endif
     // These won't be shown, we use them to catch incorrect usage of the
@@ -362,6 +363,14 @@ static void parse_commandline(int argc, char *argv[]) {
         }
     }
 
+    // Do not lower the expected eval for root moves that are likely not
+    // the best if we have introduced noise there exactly to explore more.
+    cfg_fpu_root_reduction = cfg_noise ? 0.0f : cfg_fpu_reduction;
+#ifdef USE_TUNER
+    if (vm.count("fpu_root_reduction")) {
+        cfg_fpu_root_reduction = vm["fpu_root_reduction"].as<float>();
+    }
+#endif
 
     auto out = std::stringstream{};
     for (auto i = 1; i < argc; i++) {

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -251,16 +251,10 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
         }
     }
 
-    auto numerator = std::sqrt(double(parentvisits));
-    auto fpu_reduction = 0.0f;
-    // Lower the expected eval for moves that are likely not the best.
-    // Do not do this if we have introduced noise at this node exactly
-    // to explore more.
-    if (!is_root || !cfg_noise) {
-        fpu_reduction = cfg_fpu_reduction * std::sqrt(total_visited_policy);
-    }
+    const auto numerator = std::sqrt(double(parentvisits));
+    const auto fpu_reduction = (is_root ? cfg_fpu_root_reduction : cfg_fpu_reduction) * std::sqrt(total_visited_policy);
     // Estimated eval for unknown nodes = original parent NN eval - reduction
-    auto fpu_eval = get_net_eval(color) - fpu_reduction;
+    const auto fpu_eval = get_net_eval(color) - fpu_reduction;
 
     auto best = static_cast<UCTNodePointer*>(nullptr);
     auto best_value = std::numeric_limits<double>::lowest();
@@ -278,10 +272,10 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
         } else if (child.get_visits() > 0) {
             winrate = child.get_eval(color);
         }
-        auto psa = child.get_policy();
-        auto denom = 1.0 + child.get_visits();
-        auto puct = cfg_puct * psa * (numerator / denom);
-        auto value = winrate + puct;
+        const auto psa = child.get_policy();
+        const auto denom = 1.0 + child.get_visits();
+        const auto puct = cfg_puct * psa * (numerator / denom);
+        const auto value = winrate + puct;
         assert(value > std::numeric_limits<double>::lowest());
 
         if (value > best_value) {


### PR DESCRIPTION
This introduces an option to force a full-width search with a given number of visits (as requested in featurecat/lizzie#321 and obviously improving on what was originally in #1891). Note that such behavior cannot be replicated by changing c<sub>puct</sub>, even if only for the root.