### PR TITLE
Correct initialize different size sgf

### DIFF
--- a/src/SGFTree.cpp
+++ b/src/SGFTree.cpp
@@ -44,7 +44,7 @@ void SGFTree::init_state() {
     // Initialize with defaults.
     // The SGF might be missing boardsize or komi
     // which means we'll never initialize properly.
-    m_state.init_game(19, 7.5f);
+    m_state.init_game(BOARD_SIZE, 7.5f);
 }
 
 KoState * SGFTree::get_state() {

--- a/src/SGFTree.cpp
+++ b/src/SGFTree.cpp
@@ -44,7 +44,7 @@ void SGFTree::init_state() {
     // Initialize with defaults.
     // The SGF might be missing boardsize or komi
     // which means we'll never initialize properly.
-    m_state.init_game(BOARD_SIZE, 7.5f);
+    m_state.init_game(std::min(BOARD_SIZE, 19), 7.5f);
 }
 
 KoState * SGFTree::get_state() {


### PR DESCRIPTION
The sgf size initialized should be same as leelazero program's size settings, so leelazero can open size 9 , size 7 sgf file corretly.