### PR TITLE
Clearer and more intuitive README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ It will connect to the server automatically and do its work in the background, u
 after each game. You can just close the autogtp window to stop it.
 
 - More complicated way (not recommended, if you know what you're doing) :
-but if you want to manually compile your own leela-zero version, read [the main instructions there](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now), then follow [the instructions for windows to compile](https://github.com/wonderingabout/leela-zero#example-of-compiling-and-running---windows) there. You can also read these [AutoGTP details there](autogtp/README.md)
+but if you want to manually compile your own leela-zero version, read [the main instructions there](https://github.com/wonderingabout/leela-zero#i-want-to-run-leela-zero-now-main-instructions), then follow [the instructions for windows to compile](https://github.com/wonderingabout/leela-zero#example-of-compiling-and-running---windows) there. You can also read these [AutoGTP details there](autogtp/README.md)
 
 ### macOS and Linux (Ubuntu and similar, etc)
 
-Read [the main instructions below](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now), then follow instructions to compile leelaz and autogtp binaries in build subdirectory, [for macOS](https://github.com/wonderingabout/leela-zero#how-to-compile-and-run-autogtp-andor-leelaz---macos), or [for linux (Ubuntu and similar, etc)](https://github.com/wonderingabout/leela-zero#how-to-compile-and-run-autogtp-andor-leelaz---linux-ubuntu-and-similar-etc).
+Read [the main instructions below](https://github.com/wonderingabout/leela-zero#i-want-to-run-leela-zero-now-main-instructions), then follow instructions to compile leelaz and autogtp binaries in build subdirectory, [for macOS](https://github.com/wonderingabout/leela-zero#how-to-compile-and-run-autogtp-andor-leelaz---macos), or [for linux (Ubuntu and similar, etc)](https://github.com/wonderingabout/leela-zero#how-to-compile-and-run-autogtp-andor-leelaz---linux-ubuntu-and-similar-etc).
 
 Then, if you want to contribute, don't run leelaz, but instead copy autogtp and leelaz binaries from the build subdirectory to the autogtp subdirectory, then run autogtp as explained in the main instructions below. You can also read these [AutoGTP details there](autogtp/README.md). Contributing will start when you run autogtp.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ a good network (which you can feed into this program, suddenly making it strong)
 
 # I want to help
 
-To contribute to leela-zero, you need to run autogtp binary.
+To contribute to leela-zero, you need to run the autogtp binary.
 
 ## Using your own hardware
 
@@ -52,7 +52,7 @@ It will connect to the server automatically and do its work in the background, u
 after each game. You can just close the autogtp window to stop it.
 
 - More complicated way (not recommended, if you know what you're doing) :
-but if you want to manually compile your own leela-zero version, read [the main instructions there](https://github.com/wonderingabout/leela-zero#i-want-to-run-leela-zero-now-main-instructions), then follow [the instructions to compile for windows](https://github.com/wonderingabout/leela-zero#example-of-compiling-and-running---windows) there.
+else if you want to manually compile your own leela-zero version, read [the main instructions there](https://github.com/wonderingabout/leela-zero#i-want-to-run-leela-zero-now-main-instructions), then follow [the instructions to compile for windows](https://github.com/wonderingabout/leela-zero#example-of-compiling-and-running---windows) there.
 
 ### macOS and Linux (Ubuntu and similar, etc)
 
@@ -62,7 +62,7 @@ Then,
 
 - if you want to contribute, don't run leelaz, but instead copy autogtp and leelaz binaries from the build subdirectory to the autogtp subdirectory, then run autogtp as explained in the main instructions below. You can also read these [AutoGTP details there](autogtp/README.md). Contributing will start when you run autogtp.
 
-- Else, if you want to play only, run instead leelaz as explained in the main instructions below for macOS or linux.
+- Else, if you want to play only, run leelaz instead as explained in the main instructions below for macOS or linux.
 
 
 ## Using a Cloud provider
@@ -76,7 +76,7 @@ There are community maintained instructions available here:
 
 # I want to run leela-zero now (main instructions)
 
-As said earlier, to use leela-zero, you have to run autogtp and/or leelaz. The easiest way is to download an official tested release (for windows only) [as explained here](https://github.com/wonderingabout/leela-zero/blob/master/README.md#windows) which avoids to manually compile your own build of leela-zero.
+As said earlier, to use leela-zero, you have to run autogtp and/or leelaz. The easiest way is to download an official tested release (for windows only) [as explained here](https://github.com/wonderingabout/leela-zero/blob/master/README.md#windows) which avoids the need of manually compiling your own build of leela-zero.
 
 Else, you need to compile leelaz and autogtp binaries from leela-zero sources. The steps to compile leelaz and autogtp are explained [below](https://github.com/wonderingabout/leela-zero#compiling-autogtp-andor-leelaz).
 
@@ -135,7 +135,7 @@ by adding -DUSE_CPU_ONLY=1 to the cmake command line.
     curl -O https://zero.sjeng.org/best-network
     ./leelaz --weights best-network
     
-### Else, if you want to help (to contribute), run instead autogtp :
+### Else, if you want to help (to contribute), run autogtp instead :
 
     # Copy autogtp and leelaz binaries from build subdirectory to autogtp subdirectory
     cd ../autogtp
@@ -172,7 +172,7 @@ by adding -DUSE_CPU_ONLY=1 to the cmake command line.
     curl -O https://zero.sjeng.org/best-network
     ./leelaz --weights best-network
     
-### Else, if you want to help (to contribute), run instead autogtp :
+### Else, if you want to help (to contribute), run autogtp instead :
 
     # Copy autogtp and leelaz binaries from build subdirectory to autogtp subdirectory
     cd ../autogtp

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ after each game. You can just close the autogtp window to stop it.
 
 ### macOS and Linux
 
-Follow the instructions below to compile the leelaz and autogtp binaries in build subdirectory.
+Follow the main instructions below to compile the leelaz and autogtp binaries in build subdirectory.
 
 Then, if you want to contribute, don't run leelaz, but instead copy autogtp and leelaz binaries from the build subdirectory to the autogtp subdirectory, then run autogtp as shown in the commands below.
 
-You can read [AutoGTP details there](autogtp/README.md). Contributing will start when you run autogtp.
+You can also read these [AutoGTP details there](autogtp/README.md). Contributing will start when you run autogtp.
 
 Else, if you want to play only, run instead leelaz as shown below .
 
@@ -69,16 +69,19 @@ There are community maintained instructions available here:
 [Running Leela Zero client on a Tesla V100 GPU for free (Google Cloud Free Trial, Microsoft Azure, Oracle cloud, etc)](https://docs.google.com/document/d/1P_c-RbeLKjv1umc4rMEgvIVrUUZSeY0WAtYHjaxjD64/edit?usp=sharing)
 
 
-# I just want to play right now
+# I just want to run leela-zero right now
 
-Download the best known network weights file from: https://zero.sjeng.org/best-network
 To play, only leelaz is needed (and not AutoGTP).
 
+Download the best known network weights file from: https://zero.sjeng.org/best-network
 And head to the [Usage](#usage) section of this README.
 
 If you prefer a more human style, a network trained from human games is available here: https://sjeng.org/zero/best_v1.txt.zip.
 
-# Compiling
+To contribute, you need to run autogtp instead.
+
+
+# Compiling autogtp and/or leelaz
 
 ## Requirements
 
@@ -119,13 +122,13 @@ by adding -DUSE_CPU_ONLY=1 to the cmake command line.
     # Optionnal : if you want to test if your build has no issue
     ./tests
 
-### Then, if you want to play only (not contribute), run leelaz :
+### Then, if you just want to play right now (not contribute), run leelaz :
 
     # Use the command below to download leelaz and run leelaz in play mode
     curl -O https://zero.sjeng.org/best-network
     ./leelaz --weights best-network
     
-### Else, if you want to contribute, run instead AutoGTP (to contribute) :
+### Else, if you want to help (to contribute), run autogtp :
 
     # Copy autogtp and leelaz binaries from build subdirectory to autogtp subdirectory
     cd ../autogtp
@@ -155,13 +158,13 @@ by adding -DUSE_CPU_ONLY=1 to the cmake command line.
     # Optionnal : if you want to test if your build has no issue
     ./tests
 
-### Then, if you want to play only (not contribute), run leelaz :
+### Then, if you just want to play right now (not contribute), run leelaz :
 
     # Use the command below to download leelaz and run leelaz in play mode
     curl -O https://zero.sjeng.org/best-network
     ./leelaz --weights best-network
     
-### Else, if you want to contribute, run instead AutoGTP (to contribute) :
+### Else, if you want to help (to contribute), run autogtp :
 
     # Copy autogtp and leelaz binaries from build subdirectory to autogtp subdirectory
     cd ../autogtp

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Then, if you want to contribute, don't run leelaz, but instead copy autogtp and 
 
 Else, if you want to play only, run instead leelaz as explained in the main instructions below for macOS or linux.
 
+The steps to compile leelaz and autogtp are [below](https://github.com/wonderingabout/leela-zero#compiling-autogtp-andor-leelaz)
+
 
 ## Using a Cloud provider
 
@@ -74,7 +76,7 @@ There are community maintained instructions available here:
 
 As said earlier, to use leela-zero, you have to run autogtp and/or leelaz. The easiest way is to download an official tested release (for windows only) [as explained here](https://github.com/gcp/leela-zero/releases) which avoids to manually compile your own build of leela-zero.
 
-Else, you need to compile leelaz and autogtp binaries from leela-zero sources. The steps to compile are explained below.
+Else, you need to compile leelaz and autogtp binaries from leela-zero sources. The steps to compile leelaz and autogtp are explained [below](https://github.com/wonderingabout/leela-zero#compiling-autogtp-andor-leelaz).
 
 - To play, only leelaz is needed (and not AutoGTP).
 

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ Easiest way : If you want to run the latest stable version ("master" branch), he
 It will connect to the server automatically and do its work in the background, uploading results
 after each game. You can just close the autogtp window to stop it.
 
-More complicated way : but if you want to manually compile your own leela-zero version, read [the main instructions there](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now), then follow [the windows instructions to compile](https://github.com/wonderingabout/leela-zero#example-of-compiling-and-running---windows) there. You can also read these [AutoGTP details there](autogtp/README.md)
+More complicated way : but if you want to manually compile your own leela-zero version, read [the main instructions there](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now), then follow [the instructions for windows to compile](https://github.com/wonderingabout/leela-zero#example-of-compiling-and-running---windows) there. You can also read these [AutoGTP details there](autogtp/README.md)
 
 ### macOS and Linux (Ubuntu and similar, etc)
 
-Read [the main instructions below](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now), then follow instructions to compile  leelaz and autogtp binaries in build subdirectory, [for macOS](https://github.com/wonderingabout/leela-zero#how-to-compile-and-run-autogtp-andor-leelaz---macos), or [for linux (Ubuntu and similar, etc)](https://github.com/wonderingabout/leela-zero#how-to-compile-and-run-autogtp-andor-leelaz---linux-ubuntu-and-similar-etc).
+Read [the main instructions below](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now), then follow instructions to compile leelaz and autogtp binaries in build subdirectory, [for macOS](https://github.com/wonderingabout/leela-zero#how-to-compile-and-run-autogtp-andor-leelaz---macos), or [for linux (Ubuntu and similar, etc)](https://github.com/wonderingabout/leela-zero#how-to-compile-and-run-autogtp-andor-leelaz---linux-ubuntu-and-similar-etc).
 
 Then, if you want to contribute, don't run leelaz, but instead copy autogtp and leelaz binaries from the build subdirectory to the autogtp subdirectory, then run autogtp as explained in the main instructions below. You can also read these [AutoGTP details there](autogtp/README.md). Contributing will start when you run autogtp.
 

--- a/README.md
+++ b/README.md
@@ -44,32 +44,32 @@ the distributed effort. But you can still play, especially if you are patient.
 
 ### Windows
 
-Easiest way : If you want to run the latest stable version ("master" branch), head to the Github releases page at https://github.com/gcp/leela-zero/releases, download the latest release, unzip, and launch autogtp.exe.
+Easiest way : If you want to run the latest stable version ("master" branch), head to the Github releases page at https://github.com/gcp/leela-zero/releases, download the latest release for windows, unzip, and launch autogtp.exe.
 It will connect to the server automatically and do its work in the background, uploading results
 after each game. You can just close the autogtp window to stop it.
 
-More complicated way : but if you want to manually compile your own leela-zero version, either stable "master" branch or test branch "next", read [the main instructions there](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now), then follow [the instructions for windows](https://github.com/wonderingabout/leela-zero#example-of-compiling-and-running---windows) there . You can also read these [AutoGTP details there](autogtp/README.md)
+More complicated way : but if you want to manually compile your own leela-zero version, read [the main instructions there](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now), then follow [the windows instructions to compile](https://github.com/wonderingabout/leela-zero#example-of-compiling-and-running---windows) there. You can also read these [AutoGTP details there](autogtp/README.md)
 
 ### macOS
 
-Read [the main instructions below](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now), then follow [the instructions to compile](https://github.com/wonderingabout/leela-zero#how-to-compile-and-run-autogtp-andor-leelaz---macos) leelaz and autogtp binaries in build subdirectory.
+Read [the main instructions below](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now), then follow [the macOS instructions to compile](https://github.com/wonderingabout/leela-zero#how-to-compile-and-run-autogtp-andor-leelaz---macos) leelaz and autogtp binaries in build subdirectory.
 
 Then, [if you want to contribute](https://github.com/wonderingabout/leela-zero#else-if-you-want-to-help-to-contribute-run-autogtp--1), don't run leelaz, but instead copy autogtp and leelaz binaries from the build subdirectory to the autogtp subdirectory, then run autogtp as explained in the main instructions below.
 
 You can also read these [AutoGTP details there](autogtp/README.md). Contributing will start when you run autogtp.
 
-Else, if you want to play only, run instead leelaz as explained in the main instructions below .
+Else, [if you want to play only](https://github.com/wonderingabout/leela-zero#then-if-you-just-want-to-play-right-now-not-contribute-run-leelaz-), run instead leelaz as explained in the main instructions below .
 
 
 ### Linux (Ubuntu and similar, etc)
 
-Read [the main instructions below](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now), then follow [the instructions to compile](https://github.com/wonderingabout/leela-zero#how-to-compile-and-run-autogtp-andor-leelaz---ubuntu--similar) leelaz and autogtp binaries in build subdirectory.
+Read [the main instructions below](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now) for linux, then follow [the linux instructions to compile](https://github.com/wonderingabout/leela-zero#how-to-compile-and-run-autogtp-andor-leelaz---macos) leelaz and autogtp binaries in build subdirectory.
 
 Then, [if you want to contribute](https://github.com/wonderingabout/leela-zero#else-if-you-want-to-help-to-contribute-run-autogtp--1), don't run leelaz, but instead copy autogtp and leelaz binaries from the build subdirectory to the autogtp subdirectory, then run autogtp as explained in the main instructions below.
 
 You can also read these [AutoGTP details there](autogtp/README.md). Contributing will start when you run autogtp.
 
-Else, if you want to play only, run instead leelaz as explained in the main instructions below .
+Else, [if you want to play only](https://github.com/wonderingabout/leela-zero#then-if-you-just-want-to-play-right-now-not-contribute-run-leelaz-), run instead leelaz as explained in the main instructions below .
 
 
 ## Using a Cloud provider

--- a/README.md
+++ b/README.md
@@ -50,22 +50,13 @@ after each game. You can just close the autogtp window to stop it.
 
 More complicated way : but if you want to manually compile your own leela-zero version, read [the main instructions there](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now), then follow [the windows instructions to compile](https://github.com/wonderingabout/leela-zero#example-of-compiling-and-running---windows) there. You can also read these [AutoGTP details there](autogtp/README.md)
 
-### macOS
+### macOS and Linux (Ubuntu and similar, etc)
 
-Read [the main instructions below](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now), then follow [the macOS instructions to compile](https://github.com/wonderingabout/leela-zero#how-to-compile-and-run-autogtp-andor-leelaz---macos) leelaz and autogtp binaries in build subdirectory.
+Read [the main instructions below](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now), then follow instructions to compile  leelaz and autogtp binaries in build subdirectory, [for macOS](https://github.com/wonderingabout/leela-zero#how-to-compile-and-run-autogtp-andor-leelaz---macos), or [for linux (Ubuntu and similar, etc)](https://github.com/wonderingabout/leela-zero#how-to-compile-and-run-autogtp-andor-leelaz---linux-ubuntu-and-similar-etc).
 
-Then, [if you want to contribute](https://github.com/wonderingabout/leela-zero#else-if-you-want-to-help-to-contribute-run-autogtp--1), don't run leelaz, but instead copy autogtp and leelaz binaries from the build subdirectory to the autogtp subdirectory, then run autogtp as explained in the main instructions below. You can also read these [AutoGTP details there](autogtp/README.md). Contributing will start when you run autogtp.
+Then, if you want to contribute, don't run leelaz, but instead copy autogtp and leelaz binaries from the build subdirectory to the autogtp subdirectory, then run autogtp as explained in the main instructions below. You can also read these [AutoGTP details there](autogtp/README.md). Contributing will start when you run autogtp.
 
-Else, [if you want to play only](https://github.com/wonderingabout/leela-zero#then-if-you-just-want-to-play-right-now-not-contribute-run-leelaz-), run instead leelaz as explained in the main instructions below .
-
-
-### Linux (Ubuntu and similar, etc)
-
-Read [the main instructions below](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now), then follow [the linux instructions to compile](https://github.com/wonderingabout/leela-zero#how-to-compile-and-run-autogtp-andor-leelaz---macos) leelaz and autogtp binaries in build subdirectory.
-
-Then, [if you want to contribute](https://github.com/wonderingabout/leela-zero#else-if-you-want-to-help-to-contribute-run-autogtp--1), don't run leelaz, but instead copy autogtp and leelaz binaries from the build subdirectory to the autogtp subdirectory, then run autogtp as explained in the main instructions below. You can also read these [AutoGTP details there](autogtp/README.md). Contributing will start when you run autogtp.
-
-Else, [if you want to play only](https://github.com/wonderingabout/leela-zero#then-if-you-just-want-to-play-right-now-not-contribute-run-leelaz-), run instead leelaz as explained in the main instructions below .
+Else, if you want to play only, run instead leelaz as explained in the main instructions below for macOS or linux.
 
 
 ## Using a Cloud provider

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ lower. If your CPU is not *very* recent (Haswell or newer, Ryzen or newer),
 performance will be outright bad, and it's probably of no use trying to join
 the distributed effort. But you can still play, especially if you are patient.
 
+To contribute, you need to run AutoGTP.
+
 ### Windows
 
 Head to the Github releases page at https://github.com/gcp/leela-zero/releases,
@@ -51,10 +53,14 @@ after each game. You can just close the autogtp window to stop it.
 
 ### macOS and Linux
 
-Follow the instructions below to compile the leelaz binary, then go into
-the autogtp subdirectory and follow [the instructions there](autogtp/README.md)
-to build the autogtp binary. Copy the leelaz binary into the autogtp dir, and
-launch autogtp.
+Follow the instructions below to compile the leelaz and autogtp binaries .
+
+Then, if you want to contribute, don't run leelaz, but instead copy and run autogtp and leelaz into the autogtp subdirectory as shown in the commands below.
+You can read [AutoGTP information there](autogtp/README.md)
+Then, contributing will start when you run autogtp.
+
+Else, if you want to play only, run instead leelaz as shown below .
+
 
 ## Using a Cloud provider
 
@@ -68,6 +74,7 @@ There are community maintained instructions available here:
 # I just want to play right now
 
 Download the best known network weights file from: https://zero.sjeng.org/best-network
+To play, only leelaz is needed (and not AutoGTP).
 
 And head to the [Usage](#usage) section of this README.
 
@@ -90,7 +97,8 @@ by adding -DUSE_CPU_ONLY=1 to the cmake command line.
 * Optional: BLAS Library: OpenBLAS (libopenblas-dev) or Intel MKL
 * The program has been tested on Windows, Linux and macOS.
 
-## Example of compiling and running - Ubuntu & similar
+## How to compile and run AutoGTP and/or leelaz - Ubuntu & similar
+
 
     # Test for OpenCL support & compatibility
     sudo apt install clinfo && clinfo
@@ -103,15 +111,33 @@ by adding -DUSE_CPU_ONLY=1 to the cmake command line.
     # Install build depedencies
     sudo apt install libboost-dev libboost-program-options-dev libboost-filesystem-dev opencl-headers ocl-icd-libopencl1 ocl-icd-opencl-dev zlib1g-dev
 
-    # Use stand alone directory to keep source dir clean
+    # Use a stand alone build directory to keep source dir clean
     mkdir build && cd build
+    # Compile leelaz and autogtp in build subdirectory with cmake
     cmake ..
     cmake --build .
+    
+    # Optionnal : if you want to test if your build has no issue
     ./tests
+
+### Then, if you want to play only (not contribute), run leelaz :
+
+    # Use the command below to download leelaz and run leelaz in play mode
     curl -O https://zero.sjeng.org/best-network
     ./leelaz --weights best-network
+    
+### Else, if you want to contribute, run instead AutoGTP (to contribute) :
 
-## Example of compiling and running - macOS
+    # Copy AutoGTP and leelaz binaries from build subdirectory to autogtp subdirectory
+    cd ../autogtp
+    cp ../build/autogtp/autogtp .
+    cp ../build/leelaz .
+    
+    # Run AutoGTP to start contributing : 
+    ./autogtp
+
+
+## How to compile and run AutoGTP and/or leelaz - macOS
 
     # Clone github repo
     git clone https://github.com/gcp/leela-zero
@@ -121,13 +147,31 @@ by adding -DUSE_CPU_ONLY=1 to the cmake command line.
     # Install build depedencies
     brew install boost cmake
 
-    # Use stand alone directory to keep source dir clean
+    # Use a stand alone build directory to keep source dir clean
     mkdir build && cd build
+    # Compile leelaz and autogtp in build subdirectory with cmake
     cmake ..
     cmake --build .
+
+    # Optionnal : if you want to test if your build has no issue
     ./tests
+
+### Then, if you want to play only (not contribute), run leelaz :
+
+    # Use the command below to download leelaz and run leelaz in play mode
     curl -O https://zero.sjeng.org/best-network
     ./leelaz --weights best-network
+    
+### Else, if you want to contribute, run instead AutoGTP (to contribute) :
+
+    # Copy AutoGTP and leelaz binaries from build subdirectory to autogtp subdirectory
+    cd ../autogtp
+    cp ../build/autogtp/autogtp .
+    cp ../build/leelaz .
+    
+    # Run AutoGTP to start contributing : 
+    ./autogtp
+
 
 ## Example of compiling and running - Windows
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Else, [if you want to play only](https://github.com/wonderingabout/leela-zero#th
 
 ### Linux (Ubuntu and similar, etc)
 
-Read [the main instructions below](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now) for linux, then follow [the linux instructions to compile](https://github.com/wonderingabout/leela-zero#how-to-compile-and-run-autogtp-andor-leelaz---macos) leelaz and autogtp binaries in build subdirectory.
+Read [the main instructions below](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now), then follow [the linux instructions to compile](https://github.com/wonderingabout/leela-zero#how-to-compile-and-run-autogtp-andor-leelaz---macos) leelaz and autogtp binaries in build subdirectory.
 
 Then, [if you want to contribute](https://github.com/wonderingabout/leela-zero#else-if-you-want-to-help-to-contribute-run-autogtp--1), don't run leelaz, but instead copy autogtp and leelaz binaries from the build subdirectory to the autogtp subdirectory, then run autogtp as explained in the main instructions below.
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ by adding -DUSE_CPU_ONLY=1 to the cmake command line.
 
     # Use a stand alone build directory to keep source dir clean
     mkdir build && cd build
+    
     # Compile leelaz and autogtp in build subdirectory with cmake
     cmake ..
     cmake --build .

--- a/README.md
+++ b/README.md
@@ -53,12 +53,11 @@ after each game. You can just close the autogtp window to stop it.
 
 ### macOS and Linux
 
-Follow the instructions below to compile the leelaz and autogtp binaries .
+Follow the instructions below to compile the leelaz and autogtp binaries in build subdirectory.
 
-Then, if you want to contribute, don't run leelaz, but instead copy and run autogtp and leelaz into the autogtp subdirectory as shown in the commands below.
-You can read [AutoGTP information there](autogtp/README.md).
+Then, if you want to contribute, don't run leelaz, but instead copy autogtp and leelaz binaries from the build subdirectory to the autogtp subdirectory, then run autogtp as shown in the commands below.
 
-Then, contributing will start when you run autogtp.
+You can read [AutoGTP details there](autogtp/README.md). Contributing will start when you run autogtp.
 
 Else, if you want to play only, run instead leelaz as shown below .
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ a good network (which you can feed into this program, suddenly making it strong)
 
 # I want to help
 
-To help, you need to run autogtp binary.
+To contribute to leela-zero, you need to run autogtp binary.
 
 ## Using your own hardware
 

--- a/README.md
+++ b/README.md
@@ -44,11 +44,13 @@ the distributed effort. But you can still play, especially if you are patient.
 
 ### Windows
 
-Easiest way : If you want to run the latest stable version ("master" branch), head to the Github releases page at https://github.com/gcp/leela-zero/releases, download the latest release for windows, unzip, and launch autogtp.exe.
+- Easiest way (recommended) : 
+If you want to run the latest stable version ("master" branch), head to the Github releases page at https://github.com/gcp/leela-zero/releases, download the latest release for windows, unzip, and launch autogtp.exe.
 It will connect to the server automatically and do its work in the background, uploading results
 after each game. You can just close the autogtp window to stop it.
 
-More complicated way : but if you want to manually compile your own leela-zero version, read [the main instructions there](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now), then follow [the instructions for windows to compile](https://github.com/wonderingabout/leela-zero#example-of-compiling-and-running---windows) there. You can also read these [AutoGTP details there](autogtp/README.md)
+- More complicated way (not recommended, if you know what you're doing) :
+but if you want to manually compile your own leela-zero version, read [the main instructions there](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now), then follow [the instructions for windows to compile](https://github.com/wonderingabout/leela-zero#example-of-compiling-and-running---windows) there. You can also read these [AutoGTP details there](autogtp/README.md)
 
 ### macOS and Linux (Ubuntu and similar, etc)
 
@@ -68,16 +70,18 @@ There are community maintained instructions available here:
 [Running Leela Zero client on a Tesla V100 GPU for free (Google Cloud Free Trial, Microsoft Azure, Oracle cloud, etc)](https://docs.google.com/document/d/1P_c-RbeLKjv1umc4rMEgvIVrUUZSeY0WAtYHjaxjD64/edit?usp=sharing)
 
 
-# I just want to run leela-zero right now (main instructions)
+# I want to run leela-zero now (main instructions)
 
-To play, only leelaz is needed (and not AutoGTP).
+As said earlier, to use leela-zero, you have to run autogtp and/or leelaz. The easiest way is to download an official tested release (for windows only) [as explained here](https://github.com/gcp/leela-zero/releases) which avoids to manually compile your own build of leela-zero.
+
+Else, you need to compile leelaz and autogtp binaries from leela-zero sources. The steps to compile are explained below.
+
+- To play, only leelaz is needed (and not AutoGTP).
 
 Download the best known network weights file from: https://zero.sjeng.org/best-network
-And head to the [Usage](#usage) section of this README.
+And head to the [Usage](#usage) section of this README. If you prefer a more human style, a network trained from human games is available here: https://sjeng.org/zero/best_v1.txt.zip.
 
-If you prefer a more human style, a network trained from human games is available here: https://sjeng.org/zero/best_v1.txt.zip.
-
-To contribute, you need to run autogtp instead.
+- To contribute, you need to run autogtp instead.
 
 
 # Compiling autogtp and/or leelaz
@@ -127,7 +131,7 @@ by adding -DUSE_CPU_ONLY=1 to the cmake command line.
     curl -O https://zero.sjeng.org/best-network
     ./leelaz --weights best-network
     
-### Else, if you want to help (to contribute), run autogtp :
+### Else, if you want to help (to contribute), run instead autogtp :
 
     # Copy autogtp and leelaz binaries from build subdirectory to autogtp subdirectory
     cd ../autogtp
@@ -164,7 +168,7 @@ by adding -DUSE_CPU_ONLY=1 to the cmake command line.
     curl -O https://zero.sjeng.org/best-network
     ./leelaz --weights best-network
     
-### Else, if you want to help (to contribute), run autogtp :
+### Else, if you want to help (to contribute), run instead autogtp :
 
     # Copy autogtp and leelaz binaries from build subdirectory to autogtp subdirectory
     cd ../autogtp
@@ -177,6 +181,13 @@ by adding -DUSE_CPU_ONLY=1 to the cmake command line.
 
 ## Example of compiling and running - Windows
 
+- recommended : As said earlier in [i want to help instructions for windows](https://github.com/wonderingabout/leela-zero#windows), the easiest way (recommended) is to download already compiled and tested releases for windows here : https://github.com/gcp/leela-zero/releases , you can run leelaz to play, and/or contribute with autogtp.exe that is provided in the release, ready to use
+
+- not recommended, do only if you know what you're doing : however, if you want to manually compile your own windows build, you can follow the command instructions below.
+For AutoGTP compile details, see AutoGTP information page : [AutoGTP information there](autogtp/README.md).  
+
+-- NOTE TO GCP : i'm not familiar with compiling on windows, these may be outdated, didnt try them, didnt modify or improve them --
+
     # Clone github repo
     git clone https://github.com/gcp/leela-zero
     cd leela-zero
@@ -188,7 +199,7 @@ by adding -DUSE_CPU_ONLY=1 to the cmake command line.
     # Download <https://zero.sjeng.org/best-network> to msvc\x64\Release
     msvc\x64\Release\leelaz.exe --weights best-network
     
-For AutoGTP compile details, see AutoGTP information page : [AutoGTP information there](autogtp/README.md).    
+  
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -54,9 +54,7 @@ More complicated way : but if you want to manually compile your own leela-zero v
 
 Read [the main instructions below](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now), then follow [the macOS instructions to compile](https://github.com/wonderingabout/leela-zero#how-to-compile-and-run-autogtp-andor-leelaz---macos) leelaz and autogtp binaries in build subdirectory.
 
-Then, [if you want to contribute](https://github.com/wonderingabout/leela-zero#else-if-you-want-to-help-to-contribute-run-autogtp--1), don't run leelaz, but instead copy autogtp and leelaz binaries from the build subdirectory to the autogtp subdirectory, then run autogtp as explained in the main instructions below.
-
-You can also read these [AutoGTP details there](autogtp/README.md). Contributing will start when you run autogtp.
+Then, [if you want to contribute](https://github.com/wonderingabout/leela-zero#else-if-you-want-to-help-to-contribute-run-autogtp--1), don't run leelaz, but instead copy autogtp and leelaz binaries from the build subdirectory to the autogtp subdirectory, then run autogtp as explained in the main instructions below. You can also read these [AutoGTP details there](autogtp/README.md). Contributing will start when you run autogtp.
 
 Else, [if you want to play only](https://github.com/wonderingabout/leela-zero#then-if-you-just-want-to-play-right-now-not-contribute-run-leelaz-), run instead leelaz as explained in the main instructions below .
 
@@ -65,9 +63,7 @@ Else, [if you want to play only](https://github.com/wonderingabout/leela-zero#th
 
 Read [the main instructions below](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now), then follow [the linux instructions to compile](https://github.com/wonderingabout/leela-zero#how-to-compile-and-run-autogtp-andor-leelaz---macos) leelaz and autogtp binaries in build subdirectory.
 
-Then, [if you want to contribute](https://github.com/wonderingabout/leela-zero#else-if-you-want-to-help-to-contribute-run-autogtp--1), don't run leelaz, but instead copy autogtp and leelaz binaries from the build subdirectory to the autogtp subdirectory, then run autogtp as explained in the main instructions below.
-
-You can also read these [AutoGTP details there](autogtp/README.md). Contributing will start when you run autogtp.
+Then, [if you want to contribute](https://github.com/wonderingabout/leela-zero#else-if-you-want-to-help-to-contribute-run-autogtp--1), don't run leelaz, but instead copy autogtp and leelaz binaries from the build subdirectory to the autogtp subdirectory, then run autogtp as explained in the main instructions below. You can also read these [AutoGTP details there](autogtp/README.md). Contributing will start when you run autogtp.
 
 Else, [if you want to play only](https://github.com/wonderingabout/leela-zero#then-if-you-just-want-to-play-right-now-not-contribute-run-leelaz-), run instead leelaz as explained in the main instructions below .
 

--- a/README.md
+++ b/README.md
@@ -50,11 +50,22 @@ after each game. You can just close the autogtp window to stop it.
 
 More complicated way : but if you want to manually compile your own leela-zero version, either stable "master" branch or test branch "next", read [the main instructions there](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now), then follow [the instructions for windows](https://github.com/wonderingabout/leela-zero#example-of-compiling-and-running---windows) there . You can also read these [AutoGTP details there](autogtp/README.md)
 
-### macOS and Linux
+### macOS
 
-Follow [the main instructions below](https://github.com/wonderingabout/leela-zero#else-if-you-want-to-help-to-contribute-run-autogtp-) to compile the leelaz and autogtp binaries in build subdirectory.
+Read [the main instructions below](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now), then follow [the instructions to compile](https://github.com/wonderingabout/leela-zero#how-to-compile-and-run-autogtp-andor-leelaz---macos) leelaz and autogtp binaries in build subdirectory.
 
-Then, if you want to contribute, don't run leelaz, but instead copy autogtp and leelaz binaries from the build subdirectory to the autogtp subdirectory, then run autogtp as explained in the main instructions below.
+Then, [if you want to contribute](https://github.com/wonderingabout/leela-zero#else-if-you-want-to-help-to-contribute-run-autogtp--1), don't run leelaz, but instead copy autogtp and leelaz binaries from the build subdirectory to the autogtp subdirectory, then run autogtp as explained in the main instructions below.
+
+You can also read these [AutoGTP details there](autogtp/README.md). Contributing will start when you run autogtp.
+
+Else, if you want to play only, run instead leelaz as explained in the main instructions below .
+
+
+### Linux (Ubuntu and similar, etc)
+
+Read [the main instructions below](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now), then follow [the instructions to compile](https://github.com/wonderingabout/leela-zero#how-to-compile-and-run-autogtp-andor-leelaz---ubuntu--similar) leelaz and autogtp binaries in build subdirectory.
+
+Then, [if you want to contribute](https://github.com/wonderingabout/leela-zero#else-if-you-want-to-help-to-contribute-run-autogtp--1), don't run leelaz, but instead copy autogtp and leelaz binaries from the build subdirectory to the autogtp subdirectory, then run autogtp as explained in the main instructions below.
 
 You can also read these [AutoGTP details there](autogtp/README.md). Contributing will start when you run autogtp.
 
@@ -99,7 +110,7 @@ by adding -DUSE_CPU_ONLY=1 to the cmake command line.
 * Optional: BLAS Library: OpenBLAS (libopenblas-dev) or Intel MKL
 * The program has been tested on Windows, Linux and macOS.
 
-## How to compile and run AutoGTP and/or leelaz - Ubuntu & similar
+## How to compile and run AutoGTP and/or leelaz - Linux (Ubuntu and similar, etc)
 
 
     # Test for OpenCL support & compatibility

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ a good network (which you can feed into this program, suddenly making it strong)
 
 # I want to help
 
+To help, you need to run autogtp binary.
+
 ## Using your own hardware
 
 You need a PC with a GPU, i.e. a discrete graphics card made by NVIDIA or AMD,
@@ -50,17 +52,17 @@ It will connect to the server automatically and do its work in the background, u
 after each game. You can just close the autogtp window to stop it.
 
 - More complicated way (not recommended, if you know what you're doing) :
-but if you want to manually compile your own leela-zero version, read [the main instructions there](https://github.com/wonderingabout/leela-zero#i-want-to-run-leela-zero-now-main-instructions), then follow [the instructions for windows to compile](https://github.com/wonderingabout/leela-zero#example-of-compiling-and-running---windows) there. You can also read these [AutoGTP details there](autogtp/README.md)
+but if you want to manually compile your own leela-zero version, read [the main instructions there](https://github.com/wonderingabout/leela-zero#i-want-to-run-leela-zero-now-main-instructions), then follow [the instructions for windows to compile](https://github.com/wonderingabout/leela-zero#example-of-compiling-and-running---windows) there.
 
 ### macOS and Linux (Ubuntu and similar, etc)
 
 Read [the main instructions below](https://github.com/wonderingabout/leela-zero#i-want-to-run-leela-zero-now-main-instructions), then follow instructions to compile leelaz and autogtp binaries in build subdirectory, [for macOS](https://github.com/wonderingabout/leela-zero#how-to-compile-and-run-autogtp-andor-leelaz---macos), or [for linux (Ubuntu and similar, etc)](https://github.com/wonderingabout/leela-zero#how-to-compile-and-run-autogtp-andor-leelaz---linux-ubuntu-and-similar-etc).
 
-Then, if you want to contribute, don't run leelaz, but instead copy autogtp and leelaz binaries from the build subdirectory to the autogtp subdirectory, then run autogtp as explained in the main instructions below. You can also read these [AutoGTP details there](autogtp/README.md). Contributing will start when you run autogtp.
+Then, 
 
-Else, if you want to play only, run instead leelaz as explained in the main instructions below for macOS or linux.
+- if you want to contribute, don't run leelaz, but instead copy autogtp and leelaz binaries from the build subdirectory to the autogtp subdirectory, then run autogtp as explained in the main instructions below. You can also read these [AutoGTP details there](autogtp/README.md). Contributing will start when you run autogtp.
 
-The steps to compile leelaz and autogtp are [below](https://github.com/wonderingabout/leela-zero#compiling-autogtp-andor-leelaz)
+- Else, if you want to play only, run instead leelaz as explained in the main instructions below for macOS or linux.
 
 
 ## Using a Cloud provider
@@ -74,7 +76,7 @@ There are community maintained instructions available here:
 
 # I want to run leela-zero now (main instructions)
 
-As said earlier, to use leela-zero, you have to run autogtp and/or leelaz. The easiest way is to download an official tested release (for windows only) [as explained here](https://github.com/gcp/leela-zero/releases) which avoids to manually compile your own build of leela-zero.
+As said earlier, to use leela-zero, you have to run autogtp and/or leelaz. The easiest way is to download an official tested release (for windows only) [as explained here](https://github.com/wonderingabout/leela-zero/blob/master/README.md#windows) which avoids to manually compile your own build of leela-zero.
 
 Else, you need to compile leelaz and autogtp binaries from leela-zero sources. The steps to compile leelaz and autogtp are explained [below](https://github.com/wonderingabout/leela-zero#compiling-autogtp-andor-leelaz).
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ lower. If your CPU is not *very* recent (Haswell or newer, Ryzen or newer),
 performance will be outright bad, and it's probably of no use trying to join
 the distributed effort. But you can still play, especially if you are patient.
 
-To contribute, you need to run AutoGTP.
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -44,20 +44,21 @@ the distributed effort. But you can still play, especially if you are patient.
 
 ### Windows
 
-Head to the Github releases page at https://github.com/gcp/leela-zero/releases,
-download the latest release, unzip, and launch autogtp.exe. It will connect to
-the server automatically and do its work in the background, uploading results
+Easiest way : If you want to run the latest stable version ("master" branch), head to the Github releases page at https://github.com/gcp/leela-zero/releases, download the latest release, unzip, and launch autogtp.exe.
+It will connect to the server automatically and do its work in the background, uploading results
 after each game. You can just close the autogtp window to stop it.
+
+More complicated way : but if you want to manually compile your own leela-zero version, either stable "master" branch or test branch "next", read [the main instructions there](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now), then follow [the instructions for windows](https://github.com/wonderingabout/leela-zero#example-of-compiling-and-running---windows) there . You can also read these [AutoGTP details there](autogtp/README.md)
 
 ### macOS and Linux
 
-Follow the main instructions below to compile the leelaz and autogtp binaries in build subdirectory.
+Follow [the main instructions below](https://github.com/wonderingabout/leela-zero#else-if-you-want-to-help-to-contribute-run-autogtp-) to compile the leelaz and autogtp binaries in build subdirectory.
 
-Then, if you want to contribute, don't run leelaz, but instead copy autogtp and leelaz binaries from the build subdirectory to the autogtp subdirectory, then run autogtp as shown in the commands below.
+Then, if you want to contribute, don't run leelaz, but instead copy autogtp and leelaz binaries from the build subdirectory to the autogtp subdirectory, then run autogtp as explained in the main instructions below.
 
 You can also read these [AutoGTP details there](autogtp/README.md). Contributing will start when you run autogtp.
 
-Else, if you want to play only, run instead leelaz as shown below .
+Else, if you want to play only, run instead leelaz as explained in the main instructions below .
 
 
 ## Using a Cloud provider
@@ -69,7 +70,7 @@ There are community maintained instructions available here:
 [Running Leela Zero client on a Tesla V100 GPU for free (Google Cloud Free Trial, Microsoft Azure, Oracle cloud, etc)](https://docs.google.com/document/d/1P_c-RbeLKjv1umc4rMEgvIVrUUZSeY0WAtYHjaxjD64/edit?usp=sharing)
 
 
-# I just want to run leela-zero right now
+# I just want to run leela-zero right now (main instructions)
 
 To play, only leelaz is needed (and not AutoGTP).
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ lower. If your CPU is not *very* recent (Haswell or newer, Ryzen or newer),
 performance will be outright bad, and it's probably of no use trying to join
 the distributed effort. But you can still play, especially if you are patient.
 
-
 ### Windows
 
 Head to the Github releases page at https://github.com/gcp/leela-zero/releases,

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ after each game. You can just close the autogtp window to stop it.
 Follow the instructions below to compile the leelaz and autogtp binaries .
 
 Then, if you want to contribute, don't run leelaz, but instead copy and run autogtp and leelaz into the autogtp subdirectory as shown in the commands below.
-You can read [AutoGTP information there](autogtp/README.md)
+You can read [AutoGTP information there](autogtp/README.md).
+
 Then, contributing will start when you run autogtp.
 
 Else, if you want to play only, run instead leelaz as shown below .

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ by adding -DUSE_CPU_ONLY=1 to the cmake command line.
 
     # Use a stand alone build directory to keep source dir clean
     mkdir build && cd build
+    
     # Compile leelaz and autogtp in build subdirectory with cmake
     cmake ..
     cmake --build .
@@ -129,7 +130,7 @@ by adding -DUSE_CPU_ONLY=1 to the cmake command line.
     
 ### Else, if you want to contribute, run instead AutoGTP (to contribute) :
 
-    # Copy AutoGTP and leelaz binaries from build subdirectory to autogtp subdirectory
+    # Copy autogtp and leelaz binaries from build subdirectory to autogtp subdirectory
     cd ../autogtp
     cp ../build/autogtp/autogtp .
     cp ../build/leelaz .
@@ -165,7 +166,7 @@ by adding -DUSE_CPU_ONLY=1 to the cmake command line.
     
 ### Else, if you want to contribute, run instead AutoGTP (to contribute) :
 
-    # Copy AutoGTP and leelaz binaries from build subdirectory to autogtp subdirectory
+    # Copy autogtp and leelaz binaries from build subdirectory to autogtp subdirectory
     cd ../autogtp
     cp ../build/autogtp/autogtp .
     cp ../build/leelaz .
@@ -186,6 +187,8 @@ by adding -DUSE_CPU_ONLY=1 to the cmake command line.
     # Build from Visual Studio 2015 or 2017
     # Download <https://zero.sjeng.org/best-network> to msvc\x64\Release
     msvc\x64\Release\leelaz.exe --weights best-network
+    
+For AutoGTP compile details, see AutoGTP information page : [AutoGTP information there](autogtp/README.md).    
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ It will connect to the server automatically and do its work in the background, u
 after each game. You can just close the autogtp window to stop it.
 
 - More complicated way (not recommended, if you know what you're doing) :
-but if you want to manually compile your own leela-zero version, read [the main instructions there](https://github.com/wonderingabout/leela-zero#i-want-to-run-leela-zero-now-main-instructions), then follow [the instructions for windows to compile](https://github.com/wonderingabout/leela-zero#example-of-compiling-and-running---windows) there.
+but if you want to manually compile your own leela-zero version, read [the main instructions there](https://github.com/wonderingabout/leela-zero#i-want-to-run-leela-zero-now-main-instructions), then follow [the instructions to compile for windows](https://github.com/wonderingabout/leela-zero#example-of-compiling-and-running---windows) there.
 
 ### macOS and Linux (Ubuntu and similar, etc)
 

--- a/autogtp/README.md
+++ b/autogtp/README.md
@@ -6,18 +6,19 @@ the SGF and training data at the end of the game.
 
 # Requirements
 
-* Qt 5.3 or later with qmake
+* cmake
 * C++14 capable compiler
 * curl
 * gzip and gunzip
 
-## Example of compiling - Ubuntu
+## How to compile AutoGTP - Ubuntu and macOS
 
-    sudo apt install qt5-default qt5-qmake curl
-    qmake -qt5
-    make
+Just follow main instructions : cmake will compile both autogtp and leelaz binaries in build subdirectory.
 
-## Compiling under Visual Studio - Windows
+You don't need to do anything else.
+
+
+## How to compile AutoGTP using Visual Studio - Windows
 
 You have to download and install Qt and Qt VS Tools. You only need QtCore to
 run. Locate a copy of curl.exe and gzip.exe (a previous Leela release package
@@ -28,12 +29,10 @@ and should compile. The two exes (curl.exe and gzip.exe) will also be copied to
 the output folder after the build, making it possible to run autogtp.exe
 directly.
 
-# Running
+# Running AutoGTP (to start contributing)
 
-Copy the compiled leelaz binary into the autogtp directory, and run
-autogtp.
+As explained in main page instructions, copy compiled leelaz and autogtp binaries (with cmake) from build subdirectory to autogtp subdirectory, then run autogtp to start contributing.
 
-    cp ../src/leelaz .
     ./autogtp
 
 While autogtp is running, typing q+Enter will save the processed data and exit. When autogtp runs next, autogtp will continue the game.

--- a/autogtp/README.md
+++ b/autogtp/README.md
@@ -13,7 +13,7 @@ the SGF and training data at the end of the game.
 
 ## How to compile AutoGTP - Ubuntu and macOS
 
-Just follow [main instructions](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now-main-instructions) : cmake will compile both autogtp and leelaz binaries in build subdirectory.
+Just follow [main instructions](https://github.com/wonderingabout/leela-zero#i-want-to-run-leela-zero-now-main-instructions) : cmake will compile both autogtp and leelaz binaries in build subdirectory.
 
 You don't need to do anything else.
 
@@ -40,7 +40,7 @@ directly.
 
 # Running AutoGTP (to start contributing)
 
-As explained in main page instructions, copy compiled leelaz and autogtp binaries (with cmake) from build subdirectory to autogtp subdirectory, then run autogtp to start contributing.
+As explained in [the i want to help instructions](https://github.com/wonderingabout/leela-zero#using-your-own-hardware), copy compiled leelaz and autogtp binaries (with cmake) from build subdirectory to autogtp subdirectory, then run autogtp to start contributing.
 
 While autogtp is running, typing q+Enter will save the processed data and exit. When autogtp runs next, autogtp will continue the game.
 

--- a/autogtp/README.md
+++ b/autogtp/README.md
@@ -20,7 +20,13 @@ You don't need to do anything else.
 
 ## How to compile AutoGTP using Visual Studio - Windows
 
---- NOTE FOR GCP : these instructions for windows may be outdated, i am not familiar with windows compile so i didnt modify them----
+As explained earlier [in the i want to help/windows part](https://github.com/wonderingabout/leela-zero#windows), the easiest way is to download already compiled and tested releases for Windows. If you do that, you don't have to do anything else 
+
+Else, if you want to manually compile your own leelaz/autogtp version for windows, this is what you need to do :
+
+note : you can also refer to [the main page instructions for windows](https://github.com/wonderingabout/leela-zero#example-of-compiling-and-running---windows)
+
+--- NOTE FOR GCP : the instructions for windows below may be outdated, i am not familiar with windows compile so i didnt modify them----
 
 You have to download and install Qt and Qt VS Tools. You only need QtCore to
 run. Locate a copy of curl.exe and gzip.exe (a previous Leela release package
@@ -30,6 +36,7 @@ Loading leela-zero2015.sln or leela-zero2017.sln will then load this project
 and should compile. The two exes (curl.exe and gzip.exe) will also be copied to
 the output folder after the build, making it possible to run autogtp.exe
 directly.
+
 
 # Running AutoGTP (to start contributing)
 

--- a/autogtp/README.md
+++ b/autogtp/README.md
@@ -33,6 +33,12 @@ directly.
 
 As explained in main page instructions, copy compiled leelaz and autogtp binaries (with cmake) from build subdirectory to autogtp subdirectory, then run autogtp to start contributing.
 
+## How to run AutoGTP - Ubuntu and macOS 
+
+In leela-zero/autogtp subdirectory :
+
     ./autogtp
 
-While autogtp is running, typing q+Enter will save the processed data and exit. When autogtp runs next, autogtp will continue the game.
+## How to run AutoGTP - Windows
+
+Double click on autogtp.exe (or use command line)

--- a/autogtp/README.md
+++ b/autogtp/README.md
@@ -33,6 +33,8 @@ directly.
 
 As explained in main page instructions, copy compiled leelaz and autogtp binaries (with cmake) from build subdirectory to autogtp subdirectory, then run autogtp to start contributing.
 
+While autogtp is running, typing q+Enter will save the processed data and exit. When autogtp runs next, autogtp will continue the game.
+
 ## How to run AutoGTP - Ubuntu and macOS 
 
 In leela-zero/autogtp subdirectory :

--- a/autogtp/README.md
+++ b/autogtp/README.md
@@ -13,12 +13,14 @@ the SGF and training data at the end of the game.
 
 ## How to compile AutoGTP - Ubuntu and macOS
 
-Just follow main instructions : cmake will compile both autogtp and leelaz binaries in build subdirectory.
+Just follow [main instructions](https://github.com/wonderingabout/leela-zero#i-just-want-to-run-leela-zero-right-now-main-instructions) : cmake will compile both autogtp and leelaz binaries in build subdirectory.
 
 You don't need to do anything else.
 
 
 ## How to compile AutoGTP using Visual Studio - Windows
+
+--- NOTE FOR GCP : these instructions for windows may be outdated, i am not familiar with windows compile so i didnt modify them----
 
 You have to download and install Qt and Qt VS Tools. You only need QtCore to
 run. Locate a copy of curl.exe and gzip.exe (a previous Leela release package


### PR DESCRIPTION
As many people complained to me recently how unintuitive leela-zero compile instructions are, i thought of making them clearer (and updated old qmake documentation)

general look : 
https://github.com/wonderingabout/leela-zero

There are repetitions that can be shrinked if needed, but the key point was to make compiling and running autogtp clearer and more intuitive

As it is only documentation change, i hope it can be merged into master and hopefully help everyone