### PR TITLE
Fix lz-setoption for playouts.

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -1137,7 +1137,7 @@ void GTP::execute_setoption(UCTSearch & search,
         // Note that if the playouts are changed but no
         // explicit command to set memory usage is given,
         // we will stick with the initial guess we made on startup.
-        search.set_playout_limit(cfg_max_visits);
+        search.set_playout_limit(cfg_max_playouts);
 
         gtp_printf(id, "");
     } else if (name == "lagbuffer") {


### PR DESCRIPTION
lz-setoption does not work for playouts on leelaz v0.16.

without this patch (I expected about 100 playouts. But I got 11856 playouts.):

    $ ./leelaz -g --noponder -w d351f06e446ba10697bfd2977b4be52c3de148032865eaaf9efc9796aea95a0c.gz
    Using 8 thread(s).
    RNG seed: 14466001740920320255
    BLAS Core: built-in Eigen 3.3.5 library.
    Detecting residual layers...v1...192 channels...15 blocks.
    Initializing CPU-only evaluation.
    Setting max tree size to 4324 MiB and cache size to 480 MiB.
    lz-setoption name playouts value 100
    =
    
    genmove b
    Thinking at most 36.0 seconds...
    NN eval=0.463478
    Playouts: 214, Win: 46.63%, PV: D16 D4 Q16 R4 P3 Q3 P4 R6 F3 C6 D3
    (...snip...)
    Playouts: 11812, Win: 46.51%, PV: Q4 Q16 D4 C16 E17 D17 E16 C14 O17 R14 Q17 R17
    R18 P17 Q18 P16 R16 P18 R15 Q14 K17 R6 S14 S13 S15 P12 O13 O12
    
      Q4 ->    2818 (V: 46.50%) (N: 21.72%) PV: Q4 Q16 D4 C16 E17 D17 E16 C14 O17 R1
    4 Q17 R17 R18 P17 Q18 P16 R16 P18 R15 Q14 K17 R6 S14 S13 S15 P12 O13 O12
    (...snip...)
     Q17 ->      82 (V: 46.55%) (N:  0.68%) PV: Q17 D4 Q4 D16 Q14 R3 Q3 R4 R6 R5 Q5 S6
    16.1 average depth, 36 max depth
    9422 non leaf nodes, 1.26 average children
    11857 visits, 4111877 nodes, 11856 playouts, 328 n/s
    
    = Q4

with this patch:

    $ ./leelaz -g --noponder -w d351f06e446ba10697bfd2977b4be52c3de148032865eaaf9efc9796aea95a0c.gz
    Using 8 thread(s).
    RNG seed: 8013179322225633996
    BLAS Core: built-in Eigen 3.3.5 library.
    Detecting residual layers...v1...192 channels...15 blocks.
    Initializing CPU-only evaluation.
    Setting max tree size to 4324 MiB and cache size to 480 MiB.
    lz-setoption name playouts value 100
    =
    
    genmove b
    Thinking at most 36.0 seconds...
    NN eval=0.463478
    
     Q16 ->      23 (V: 46.66%) (N: 21.98%) PV: Q16 D16 Q4 D3 C5 C4 D5 F3
    (...snip...)
     C16 ->       4 (V: 46.21%) (N:  0.74%) PV: C16 Q4 R3
    4.8 average depth, 9 max depth
    78 non leaf nodes, 1.38 average children
    109 visits, 39039 nodes, 108 playouts, 68 n/s
    
    = Q16
