### PR TITLE
Optimized out and out_in kernels

### DIFF
--- a/src/kernels/convolve3.opencl
+++ b/src/kernels/convolve3.opencl
@@ -20,6 +20,19 @@
 // literal). Comment-out this line for syntax-highlighting when developing.
 
 R"(
+
+#ifndef OUTIN_KWG
+#define OUTIN_KWG 2
+#endif
+
+#ifndef OUT_KWG
+#define OUT_KWG 32
+#endif
+
+#ifndef OUT_BWG
+#define OUT_BWG 2
+#endif
+
 __constant real Bt[WINOGRAD_ALPHA * WINOGRAD_ALPHA] = \
                    {1.0f,  0.0f,     -5.0f/2.0f,  0.0f,      1.0f, 0.0f,
                     0.0f, -SQ2,      -2.0f,       SQ2/2.0f,  1.0f, 0.0f,
@@ -141,77 +154,8 @@ __kernel void in_transform(__global net_t * restrict in, __global net_t * restri
     }
 }
 
-void __out_transform_eq(__global const net_t * restrict M, real o[WINOGRAD_M * WINOGRAD_M],
-                        int Kpad, int Ppad, int block)
-{
-
-    const int W = BOARD_SIZE;
-    const int H = BOARD_SIZE;
-    const int P = WTILES * WTILES;
-
-    const int k = get_global_id(0);
-    real temp_m[WINOGRAD_ALPHA][WINOGRAD_ALPHA];
-    real temp[WINOGRAD_M][WINOGRAD_ALPHA];
-
-
-    // M dimensions are [36, outputs, batch_size * tiles].
-    // Plus zero padding from SGEMM.
-
-    const int offset = block * Kpad + k;
-
-    for (int yn = 0; yn < WINOGRAD_ALPHA; yn++) {
-        for (int xn = 0; xn < WINOGRAD_ALPHA; xn++) {
-            temp_m[xn][yn] = vload_net_t((yn * WINOGRAD_ALPHA + xn) * Kpad * Ppad + offset, M);
-        }
-    }
-
-    // Calculates transpose(A).temp_m.A
-    for (int i = 0; i < WINOGRAD_M; i++){
-        for (int j = 0; j < WINOGRAD_ALPHA; j++) {
-#ifdef WINOGRAD_SIMD
-            real2 acc = {ZERO, ZERO};
-            real2 *x2 = (real2 *)&temp_m[j][0];
-            for (int q = 0; q < WINOGRAD_ALPHA/2; q++) {
-                real2 x1;
-                x1.x = At[i * WINOGRAD_ALPHA + 2*q];
-                x1.y = At[i * WINOGRAD_ALPHA + 2*q + 1];
-                acc += x1 * x2[q];
-            }
-            temp[i][j] = acc.x + acc.y;
-#else
-            real acc = ZERO;
-            for (int q = 0; q < WINOGRAD_ALPHA; q++) {
-                acc += At[i * WINOGRAD_ALPHA + q] * temp_m[j][q];
-            }
-            temp[i][j] = acc;
-#endif
-        }
-    }
-
-    for (int i = 0; i < WINOGRAD_M; i++){
-        for (int j = 0; j < WINOGRAD_M; j++) {
-#ifdef WINOGRAD_SIMD
-            real2 acc = {ZERO, ZERO};
-            real2 *x1 = (real2 *)&temp[i][0];
-            for (int q = 0; q < WINOGRAD_ALPHA/2; q++) {
-                real2 x2;
-                x2.x = At[j * WINOGRAD_ALPHA + 2*q];
-                x2.y = At[j * WINOGRAD_ALPHA + 2*q + 1];
-                acc += x1[q] * x2;
-            }
-            o[i * WINOGRAD_M + j] = acc.x + acc.y;
-#else
-            real acc = ZERO;
-            for (int q = 0; q < WINOGRAD_ALPHA; q++) {
-                acc += temp[i][q] * At[j * WINOGRAD_ALPHA + q];
-            }
-            o[i * WINOGRAD_M + j] = acc;
-#endif
-        }
-    }
-}
-
-__kernel void out_transform_fused_bn(__global const net_t * restrict M,
+__kernel __attribute__((reqd_work_group_size(OUT_KWG, OUT_BWG, 1)))
+void out_transform_fused_bn(__global const net_t * restrict M,
                                      __global net_t * restrict Y,
                                      const int K,
                                      const int Kpad, const int Ppad,
@@ -227,35 +171,93 @@ __kernel void out_transform_fused_bn(__global const net_t * restrict M,
     const int k = get_global_id(0);
     const int block = get_global_id(1);
 
-    const int batch = block / P;
-    const int block_x = (block - P * batch) % WTILES;
-    const int block_y = (block - P * batch) / WTILES;
+    // Adding some padding decreases bank conflicts
+    __local real out_buf[OUT_KWG][OUT_BWG][WINOGRAD_M][WINOGRAD_M + 1];
 
-    int x = WINOGRAD_M * block_x;
-    int y = WINOGRAD_M * block_y;
+    volatile int kid = get_local_id(0);
+    volatile int bid = get_local_id(1);
 
     if (k < K && block < batch_size * P) {
-        const int kHW = batch * K * NUM_INTERSECTIONS + k * NUM_INTERSECTIONS;
-
-        real o[WINOGRAD_M * WINOGRAD_M];
-        __out_transform_eq(M, o, Kpad, Ppad, block);
-
         const real mean = vload_net_t(k, means);
         const real scale_stddiv = vload_net_t(k, stddivs);
 
+        real temp[WINOGRAD_M][WINOGRAD_ALPHA];
+
+        real Atp[WINOGRAD_M * WINOGRAD_ALPHA];
+
+        for (int i = 0; i < WINOGRAD_M * WINOGRAD_ALPHA; i++) {
+            Atp[i] = At[i];
+        }
+
         for (int i = 0; i < WINOGRAD_M; i++) {
-            for (int j = 0; j < WINOGRAD_M; j++) {
-                const int in_idx = i * WINOGRAD_M + j;
-                const int out_idx = (y + i) * W + (x + j);
-                if (y + i < H && x + j < W) {
-                    o[in_idx] = scale_stddiv * (o[in_idx] - mean);
-                    if (residual) {
-                        o[in_idx] += vload_net_t(kHW + out_idx, residual);
-                    }
-                    o[in_idx] = o[in_idx] > 0 ? o[in_idx] : ZERO;
-                    vstore_net_t(o[in_idx], kHW + out_idx, Y);
+            for (int j = 0; j < WINOGRAD_ALPHA; j++) {
+                temp[i][j] = 0.0f;
+            }
+        }
+
+        // M dimensions are [36, outputs, batch_size * tiles].
+        // Plus zero padding from SGEMM.
+        const int offset = block * Kpad + k;
+
+        for (int xn = 0; xn < WINOGRAD_ALPHA; xn++) {
+            for (int yn = 0; yn < WINOGRAD_ALPHA; yn++) {
+                real temp_m = vload_net_t((yn * WINOGRAD_ALPHA + xn) * Kpad * Ppad + offset, M);
+
+                // Calculates transpose(A).temp_m
+                for (int i = 0; i < WINOGRAD_M; i++){
+                    temp[i][xn] += Atp[i * WINOGRAD_ALPHA + yn] * temp_m;
                 }
             }
+        }
+
+        // Calculates temp.A
+        for (int i = 0; i < WINOGRAD_M; i++){
+            for (int j = 0; j < WINOGRAD_M; j++) {
+                real acc = ZERO;
+                for (int q = 0; q < WINOGRAD_ALPHA; q++) {
+                    acc += temp[i][q] * Atp[j * WINOGRAD_ALPHA + q];
+                }
+                acc = scale_stddiv * (acc - mean);
+                out_buf[kid][bid][i][j] = acc;
+            }
+        }
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (int idx = get_local_id(0) + get_local_size(0) * get_local_id(1); idx < OUT_BWG * OUT_KWG * WINOGRAD_M * WINOGRAD_M; idx += get_local_size(0) * get_local_size(1)) {
+        // Calculate indexing for coalesced memory access.
+        // This should be simplified somehow.
+        const int k_local = idx / (OUT_BWG * WINOGRAD_M * WINOGRAD_M);
+
+        const int idx_block = (idx - k_local * OUT_BWG * WINOGRAD_M * WINOGRAD_M);
+
+        const int row = idx_block / (WINOGRAD_M * OUT_BWG);
+        const int col = (idx_block - row * WINOGRAD_M * OUT_BWG);
+        const int block_local = col / WINOGRAD_M;
+
+        const int j = col % WINOGRAD_M;
+        const int i = row % WINOGRAD_M;
+
+        const int blockt = get_group_id(1) * get_local_size(1) + block_local;
+        const int kt = get_group_id(0) * get_local_size(0) + k_local;
+
+        const int batch = blockt / P;
+        const int blockt_x = (blockt - P * batch) % WTILES;
+        const int blockt_y = (blockt - P * batch) / WTILES;
+
+        const int x = WINOGRAD_M * blockt_x;
+        const int y = WINOGRAD_M * blockt_y;
+        const int out_idx = batch * K * NUM_INTERSECTIONS + kt * NUM_INTERSECTIONS + (y + i) * W + (x + j);
+
+        if (kt < K && blockt < batch_size * P && y + i < H && x + j < W) {
+            real acc = out_buf[k_local][block_local][i][j];
+            if (residual) {
+                acc += vload_net_t(out_idx, residual);
+            }
+            acc = acc > ZERO ? acc : ZERO;
+
+            vstore_net_t(acc, out_idx, Y);
         }
     }
 }
@@ -268,8 +270,7 @@ __kernel void out_transform_fused_bn_in(
                                      const int Kpad, const int Ppad, const int Cpad,
                                      __global const net_t * restrict residual,
                                      __constant const net_t * restrict means,
-                                     __constant const net_t * restrict stddivs,
-                                     __local real * ybuf) {
+                                     __constant const net_t * restrict stddivs) {
 
     const int W = BOARD_SIZE;
     const int H = BOARD_SIZE;
@@ -283,41 +284,89 @@ __kernel void out_transform_fused_bn_in(
     const int block_x = block % WTILES;
     const int block_y = block / WTILES;
 
-    const int yin = WINOGRAD_M * block_y - 1;
-    const int xin = WINOGRAD_M * block_x - 1;
-
     const int x = WINOGRAD_M * block_x;
     const int y = WINOGRAD_M * block_y;
 
-    if (k < K && block < P) {
-        const int kHW = batch * K * NUM_INTERSECTIONS + k * NUM_INTERSECTIONS;
+    const int kHW = batch * K * NUM_INTERSECTIONS + k * NUM_INTERSECTIONS;
 
-        real o[WINOGRAD_M * WINOGRAD_M];
-        __out_transform_eq(M, o, Kpad, Ppad, block + P * batch);
+    __local real ybuf[OUTIN_KWG * NUM_INTERSECTIONS];
+
+    if (k < K && block < P) {
 
         const real mean = vload_net_t(k, means);
         const real scale_stddiv = vload_net_t(k, stddivs);
 
+        real temp_m[WINOGRAD_ALPHA][WINOGRAD_ALPHA];
+        real Atp[WINOGRAD_M * WINOGRAD_ALPHA];
+        real temp[WINOGRAD_ALPHA];
+
+        // M dimensions are [36, outputs, batch_size * tiles].
+        // Plus zero padding from SGEMM.
+
+        const int offset = block * Kpad + k;
+
+        for (int i = 0; i < WINOGRAD_M * WINOGRAD_ALPHA; i++) {
+            Atp[i] = At[i];
+        }
+
+        for (int yn = 0; yn < WINOGRAD_ALPHA; yn++) {
+            for (int xn = 0; xn < WINOGRAD_ALPHA; xn++) {
+                temp_m[xn][yn] = vload_net_t((yn * WINOGRAD_ALPHA + xn) * Kpad * Ppad + offset, M);
+            }
+        }
+
+        // Calculates transpose(A).temp_m.A
         for (int i = 0; i < WINOGRAD_M; i++) {
+            for (int j = 0; j < WINOGRAD_ALPHA; j++) {
+                real acc = ZERO;
+                for (int q = 0; q < WINOGRAD_ALPHA; q++) {
+                    acc += Atp[i * WINOGRAD_ALPHA + q] * temp_m[j][q];
+                }
+                temp[j] = acc;
+            }
+
             for (int j = 0; j < WINOGRAD_M; j++) {
-                const int in_idx = i * WINOGRAD_M + j;
+                real acc = ZERO;
+                for (int q = 0; q < WINOGRAD_ALPHA; q++) {
+                    acc += temp[q] * Atp[j * WINOGRAD_ALPHA + q];
+                }
+
                 const int out_idx = (y + i) * W + (x + j);
+                acc = scale_stddiv * (acc - mean);
                 if (y + i < H && x + j < W) {
-                    o[in_idx] = scale_stddiv * (o[in_idx] - mean);
-                    if (residual) {
-                        o[in_idx] += vload_net_t(kHW + out_idx, residual);
-                    }
-                    o[in_idx] = o[in_idx] > 0 ? o[in_idx] : ZERO;
-                    ybuf[kg * NUM_INTERSECTIONS + out_idx] = o[in_idx];
-                    if (Y) {
-                        vstore_net_t(o[in_idx], kHW + out_idx, Y);
-                    }
+                    ybuf[kg * NUM_INTERSECTIONS + out_idx] = acc;
                 }
             }
         }
     }
 
     barrier(CLK_LOCAL_MEM_FENCE);
+
+    const int ks = get_local_size(0);
+    const int k0 = get_group_id(0) * get_local_size(0);
+
+    for (int x = get_local_id(0) + ks * get_local_id(1); x < ks * NUM_INTERSECTIONS; x += get_local_size(1) * get_local_size(0)) {
+        const int kx = x / NUM_INTERSECTIONS;
+        const int idx = x - kx * NUM_INTERSECTIONS;
+
+        const int kHWx = batch * K * NUM_INTERSECTIONS + (k0 + kx) * NUM_INTERSECTIONS;
+
+        real acc = ybuf[kx * NUM_INTERSECTIONS + idx];
+        if (residual) {
+            acc += vload_net_t(kHWx + idx, residual);
+        }
+        acc = acc > ZERO ? acc : ZERO;
+
+        if (Y) {
+            vstore_net_t(acc, kHWx + idx, Y);
+        }
+        ybuf[kx * NUM_INTERSECTIONS + idx] = acc;
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    const int yin = WINOGRAD_M * block_y - 1;
+    const int xin = WINOGRAD_M * block_x - 1;
 
     if (block < P && k < K) {
         const int CPpad = Ppad * Cpad;


### PR DESCRIPTION
Very minor speedup of about 2% with batch size of 1. With batch size of 5 I get speedup of about 5% with half precision and 12% with single precision.

Out transformation memory accesses are almost completely coalesced with the new kernel. In transformation has still very bad memory access pattern when loading the input from memory but I didn't find any improvement to it yet.

With these changes OpenCL backend using batch size of 5 is faster than cudnn with batch size of 32 on my PC.