### PR TITLE
Convolve in/out performance optimization

### DIFF
--- a/src/kernels/convolve3.opencl
+++ b/src/kernels/convolve3.opencl
@@ -40,12 +40,60 @@ __constant real Bt[WINOGRAD_ALPHA * WINOGRAD_ALPHA] = \
                     0.0f, -SQ2/2.0f, -1.0f/2.0f,  SQ2,       1.0f, 0.0f,
                     0.0f,  SQ2/2.0f, -1.0f/2.0f, -SQ2,       1.0f, 0.0f,
                     0.0f,  1.0f,      0.0f,      -5.0f/2.0f, 0.0f, 1.0f};
+void multiply_bt(
+    real * o0, real * o1, real * o2, real * o3, real * o4, real * o5,
+    real i0, real i1, real i2, real i3, real i4, real i5
+) {
+    real i3m1 = i1 * -SQ2 + i3 * (SQ2 / 2.0f);
+    real i4m2 = i2 * -2.0f + i4 * 1.0f;
+
+    *o0 = i0 + i2 * (-5.0f/2.0f) + i4;
+    *o1 = i3m1 + i4m2;
+    *o2 = -i3m1 + i4m2;
+
+    real i3m1_2 = i3 * (SQ2) + i1 * (-SQ2/2.0f);
+    real i4m2_2 = i2 * (-1.0f/2.0f) + i4;
+
+    *o3 = i3m1_2 + i4m2_2;
+    *o4 = -i3m1_2 + i4m2_2;
+
+    *o5 = i1 + i3 * (-5.0f/2.0f) + i5;
+}
+
 
 __constant real At[WINOGRAD_M * WINOGRAD_ALPHA] = \
                    {1.0f, 1.0f,      1.0f,       1.0f,      1.0f,     0.0f,
                     0.0f, SQ2/2.0f, -SQ2/2.0f,   SQ2,      -SQ2,      0.0f,
                     0.0f, 1.0f/2.0f, 1.0f/2.0f,  2.0f,      2.0f,     0.0f,
                     0.0f, SQ2/4.0f, -SQ2/4.0f,   2.0f*SQ2, -2.0f*SQ2, 1.0f};
+void multiply_atv(
+    real4 * o,
+    real i0, real i1, real i2, real i3, real i4, real i5
+) {
+    real t1p2 = (i1 + i2) * (1.0f / 2.0f);
+    real t1m2 = (i1 - i2) * (SQ2/4.0f);
+    real t3p4 = i3 + i4;
+    real t3m4 = (i3 - i4) * (SQ2);
+
+    (*o).x = i0 + t1p2 + t1p2 + t3p4;
+    (*o).y = t1m2 + t1m2 + t3m4;
+    (*o).z = t1p2 + t3p4 + t3p4;
+    (*o).w = t1m2 + t3m4 + t3m4 + i5;
+}
+
+
+void multiply_at(
+    real * o0, real * o1, real * o2, real * o3,
+    real i0, real i1, real i2, real i3, real i4, real i5
+) {
+    real4 o;
+    multiply_atv(&o, i0, i1, i2, i3, i4, i5);
+
+    *o0 = o.x;
+    *o1 = o.y;
+    *o2 = o.z;
+    *o3 = o.w;
+}
 
 void __in_transform_eq(real x[WINOGRAD_ALPHA][WINOGRAD_ALPHA], __global net_t * restrict V, int offset, int CPpad) {
 
@@ -57,9 +105,9 @@ void __in_transform_eq(real x[WINOGRAD_ALPHA][WINOGRAD_ALPHA], __global net_t * 
     real T2[WINOGRAD_ALPHA][WINOGRAD_ALPHA];
 
     // Calculates transpose(B).x.B
+#ifdef WINOGRAD_SIMD
     for (int i = 0; i < WINOGRAD_ALPHA; i++){
         for (int j = 0; j < WINOGRAD_ALPHA; j++) {
-#ifdef WINOGRAD_SIMD
             real2 acc = {ZERO, ZERO};
             real2 *x2 = (real2 *)&x[j][0];
             for (int k = 0; k < WINOGRAD_ALPHA/2; k++) {
@@ -69,19 +117,20 @@ void __in_transform_eq(real x[WINOGRAD_ALPHA][WINOGRAD_ALPHA], __global net_t * 
                 acc += x1 * x2[k];
             }
             T1[i][j] = acc.x + acc.y;
-#else
-            real acc = ZERO;
-            for (int k = 0; k < WINOGRAD_ALPHA; k++) {
-                acc += Bt[i * WINOGRAD_ALPHA + k] * x[j][k];
-            }
-            T1[i][j] = acc;
-#endif
         }
     }
+#else
+    for (int j = 0; j < WINOGRAD_ALPHA; j++) {
+        multiply_bt(
+            &(T1[0][j]), &(T1[1][j]), &(T1[2][j]), &(T1[3][j]), &(T1[4][j]), &(T1[5][j]),
+            x[j][0], x[j][1], x[j][2], x[j][3], x[j][4], x[j][5]
+        );
+    }
+#endif
 
+#ifdef WINOGRAD_SIMD
     for (int i = 0; i < WINOGRAD_ALPHA; i++){
         for (int j = 0; j < WINOGRAD_ALPHA; j++) {
-#ifdef WINOGRAD_SIMD
             real2 acc = {ZERO, ZERO};
             real2 *x1 = (real2 *)&T1[i][0];
             for (int k = 0; k < WINOGRAD_ALPHA/2; k++) {
@@ -91,15 +140,16 @@ void __in_transform_eq(real x[WINOGRAD_ALPHA][WINOGRAD_ALPHA], __global net_t * 
                 acc += x1[k] * x2;
             }
             T2[i][j] = acc.x + acc.y;
-#else
-            real acc = ZERO;
-            for (int k = 0; k < WINOGRAD_ALPHA; k++) {
-                acc += T1[i][k] * Bt[j * WINOGRAD_ALPHA + k];
-            }
-            T2[i][j] = acc;
-#endif
         }
     }
+#else
+    for (int i = 0; i < WINOGRAD_ALPHA; i++){
+        multiply_bt(
+            &(T2[i][0]),  &(T2[i][1]),  &(T2[i][2]),  &(T2[i][3]),  &(T2[i][4]),  &(T2[i][5]),
+            T1[i][0], T1[i][1], T1[i][2], T1[i][3], T1[i][4], T1[i][5]
+        );
+    }
+#endif
 
     // Scatter each sub element in tile to separate matrices
     for (int i = 0; i < WINOGRAD_ALPHA; i++) {
@@ -183,43 +233,37 @@ void out_transform_fused_bn(__global const net_t * restrict M,
 
         real temp[WINOGRAD_M][WINOGRAD_ALPHA];
 
-        real Atp[WINOGRAD_M * WINOGRAD_ALPHA];
-
-        for (int i = 0; i < WINOGRAD_M * WINOGRAD_ALPHA; i++) {
-            Atp[i] = At[i];
-        }
-
-        for (int i = 0; i < WINOGRAD_M; i++) {
-            for (int j = 0; j < WINOGRAD_ALPHA; j++) {
-                temp[i][j] = 0.0f;
-            }
-        }
-
         // M dimensions are [36, outputs, batch_size * tiles].
         // Plus zero padding from SGEMM.
         const int offset = block * Kpad + k;
 
+        // Calculates transpose(A).temp_m
         for (int xn = 0; xn < WINOGRAD_ALPHA; xn++) {
-            for (int yn = 0; yn < WINOGRAD_ALPHA; yn++) {
-                real temp_m = vload_net_t((yn * WINOGRAD_ALPHA + xn) * Kpad * Ppad + offset, M);
-
-                // Calculates transpose(A).temp_m
-                for (int i = 0; i < WINOGRAD_M; i++){
-                    temp[i][xn] += Atp[i * WINOGRAD_ALPHA + yn] * temp_m;
-                }
-            }
+            real temp_m0 = vload_net_t((0 * WINOGRAD_ALPHA + xn) * Kpad * Ppad + offset, M);
+            real temp_m1 = vload_net_t((1 * WINOGRAD_ALPHA + xn) * Kpad * Ppad + offset, M);
+            real temp_m2 = vload_net_t((2 * WINOGRAD_ALPHA + xn) * Kpad * Ppad + offset, M);
+            real temp_m3 = vload_net_t((3 * WINOGRAD_ALPHA + xn) * Kpad * Ppad + offset, M);
+            real temp_m4 = vload_net_t((4 * WINOGRAD_ALPHA + xn) * Kpad * Ppad + offset, M);
+            real temp_m5 = vload_net_t((5 * WINOGRAD_ALPHA + xn) * Kpad * Ppad + offset, M);
+            multiply_at(
+                &(temp[0][xn]), &(temp[1][xn]), &(temp[2][xn]), &(temp[3][xn]),
+                temp_m0, temp_m1, temp_m2, temp_m3, temp_m4, temp_m5
+            );
         }
 
         // Calculates temp.A
         for (int i = 0; i < WINOGRAD_M; i++){
-            for (int j = 0; j < WINOGRAD_M; j++) {
-                real acc = ZERO;
-                for (int q = 0; q < WINOGRAD_ALPHA; q++) {
-                    acc += temp[i][q] * Atp[j * WINOGRAD_ALPHA + q];
-                }
-                acc = scale_stddiv * (acc - mean);
-                out_buf[kid][bid][i][j] = acc;
-            }
+            real4 r;
+            multiply_atv(
+                &r,
+                temp[i][0], temp[i][1], temp[i][2], temp[i][3], temp[i][4], temp[i][5]
+            );
+
+            r = (r - mean) * scale_stddiv;
+            out_buf[kid][bid][i][0] = r.x;
+            out_buf[kid][bid][i][1] = r.y;
+            out_buf[kid][bid][i][2] = r.z;
+            out_buf[kid][bid][i][3] = r.w;
         }
     }
 
@@ -296,46 +340,52 @@ __kernel void out_transform_fused_bn_in(
         const real mean = vload_net_t(k, means);
         const real scale_stddiv = vload_net_t(k, stddivs);
 
-        real temp_m[WINOGRAD_ALPHA][WINOGRAD_ALPHA];
-        real Atp[WINOGRAD_M * WINOGRAD_ALPHA];
-        real temp[WINOGRAD_ALPHA];
+        real temp[WINOGRAD_M][WINOGRAD_ALPHA];
 
         // M dimensions are [36, outputs, batch_size * tiles].
         // Plus zero padding from SGEMM.
 
         const int offset = block * Kpad + k;
 
-        for (int i = 0; i < WINOGRAD_M * WINOGRAD_ALPHA; i++) {
-            Atp[i] = At[i];
+        // Calculates transpose(A).temp_m
+        for (int xn = 0; xn < WINOGRAD_ALPHA; xn++) {
+            real temp_m0 = vload_net_t((0 * WINOGRAD_ALPHA + xn) * Kpad * Ppad + offset, M);
+            real temp_m1 = vload_net_t((1 * WINOGRAD_ALPHA + xn) * Kpad * Ppad + offset, M);
+            real temp_m2 = vload_net_t((2 * WINOGRAD_ALPHA + xn) * Kpad * Ppad + offset, M);
+            real temp_m3 = vload_net_t((3 * WINOGRAD_ALPHA + xn) * Kpad * Ppad + offset, M);
+            real temp_m4 = vload_net_t((4 * WINOGRAD_ALPHA + xn) * Kpad * Ppad + offset, M);
+            real temp_m5 = vload_net_t((5 * WINOGRAD_ALPHA + xn) * Kpad * Ppad + offset, M);
+
+            multiply_at(
+                &(temp[0][xn]), &(temp[1][xn]), &(temp[2][xn]), &(temp[3][xn]),
+                temp_m0, temp_m1, temp_m2, temp_m3, temp_m4, temp_m5
+            );
         }
 
-        for (int yn = 0; yn < WINOGRAD_ALPHA; yn++) {
-            for (int xn = 0; xn < WINOGRAD_ALPHA; xn++) {
-                temp_m[xn][yn] = vload_net_t((yn * WINOGRAD_ALPHA + xn) * Kpad * Ppad + offset, M);
+        // Calculates temp.A
+        for (int i = 0; i < WINOGRAD_M; i++){
+            real4 r;
+            multiply_atv(
+                &r,
+                temp[i][0], temp[i][1], temp[i][2], temp[i][3], temp[i][4], temp[i][5]
+            );
+
+            r = scale_stddiv * (r - mean);
+            if (y + i < H && x + 0 < W) {
+                const int out_idx = (y + i) * W + (x + 0);
+                ybuf[kg * NUM_INTERSECTIONS + out_idx] = r.x;
             }
-        }
-
-        // Calculates transpose(A).temp_m.A
-        for (int i = 0; i < WINOGRAD_M; i++) {
-            for (int j = 0; j < WINOGRAD_ALPHA; j++) {
-                real acc = ZERO;
-                for (int q = 0; q < WINOGRAD_ALPHA; q++) {
-                    acc += Atp[i * WINOGRAD_ALPHA + q] * temp_m[j][q];
-                }
-                temp[j] = acc;
+            if (y + i < H && x + 1 < W) {
+                const int out_idx = (y + i) * W + (x + 1);
+                ybuf[kg * NUM_INTERSECTIONS + out_idx] = r.y;
             }
-
-            for (int j = 0; j < WINOGRAD_M; j++) {
-                real acc = ZERO;
-                for (int q = 0; q < WINOGRAD_ALPHA; q++) {
-                    acc += temp[q] * Atp[j * WINOGRAD_ALPHA + q];
-                }
-
-                const int out_idx = (y + i) * W + (x + j);
-                acc = scale_stddiv * (acc - mean);
-                if (y + i < H && x + j < W) {
-                    ybuf[kg * NUM_INTERSECTIONS + out_idx] = acc;
-                }
+            if (y + i < H && x + 2 < W) {
+                const int out_idx = (y + i) * W + (x + 2);
+                ybuf[kg * NUM_INTERSECTIONS + out_idx] = r.z;
+            }
+            if (y + i < H && x + 3 < W) {
+                const int out_idx = (y + i) * W + (x + 3);
+                ybuf[kg * NUM_INTERSECTIONS + out_idx] = r.w;
             }
         }
     }


### PR DESCRIPTION
Basically same as #2021.
Use hard-coded equations instead of matrix multiplication.  A 2~3% netbench improvement on my GTX 1080.