### PR TITLE
Fixed Validation -k option 

### DIFF
--- a/validation/main.cpp
+++ b/validation/main.cpp
@@ -110,6 +110,8 @@ int main(int argc, char *argv[]) {
     }
 
     QTextStream(stdout) << "validation v" << VALIDATION_VERSION << endl;
+
+    auto const keepPath = parser.value(keepSgfOption);
     if (parser.isSet(keepSgfOption)) {
         if (!QDir().mkpath(parser.value(keepSgfOption))) {
             QTextStream(stdout) << "Couldn't create output directory for self-play SGF files!"
@@ -143,8 +145,7 @@ int main(int argc, char *argv[]) {
 
     Console *cons = nullptr;
     Validation *validate = new Validation(gpusNum, gamesNum, gpusList,
-                                          engines,
-                                          parser.value(keepSgfOption), &mutex,
+                                          engines, keepPath, &mutex,
                                           h0, h1);
     QObject::connect(&app, &QCoreApplication::aboutToQuit, validate, &Validation::storeSprt);
     validate->loadSprt();


### PR DESCRIPTION
by reading its value before the parser is reused. Fixes #2018.