### PR TITLE
Refactor to allow autogtp to use Engine

### DIFF
--- a/autogtp/Game.cpp
+++ b/autogtp/Game.cpp
@@ -23,25 +23,15 @@
 #include <QFileInfo>
 #include "Game.h"
 
-Game::Game(const QString& weights, const QString& opt, const QString& binary,
-           const QStringList& commands) :
+Game::Game(const Engine& engine) :
     QProcess(),
-    m_cmdLine(""),
-    m_binary(binary),
-    m_commands(commands),
+    m_engine(engine),
     m_resignation(false),
     m_blackToMove(true),
     m_blackResigned(false),
     m_passes(0),
     m_moveNum(0)
 {
-#ifdef WIN32
-    m_binary.append(".exe");
-#endif
-    if (!QFileInfo::exists(m_binary)) {
-        m_binary.remove(0, 2); // ./leelaz -> leelaz
-    }
-    m_cmdLine = m_binary + " " + opt + " " + weights;
     m_fileName = QUuid::createUuid().toRfc4122().toHex();
 }
 
@@ -171,7 +161,7 @@ void Game::checkVersion(const VersionTuple &min_version) {
 }
 
 bool Game::gameStart(const VersionTuple &min_version) {
-    start(m_cmdLine);
+    start(m_engine.getCmdLine());
     if (!waitForStarted()) {
         error(Game::NO_LEELAZ);
         return false;
@@ -180,7 +170,7 @@ bool Game::gameStart(const VersionTuple &min_version) {
     // check any return values.
     checkVersion(min_version);
     QTextStream(stdout) << "Engine has started." << endl;
-    for (auto command : m_commands) {
+    for (auto command : m_engine.m_commands) {
         QTextStream(stdout) << command << endl;
         if (!sendGtpCommand(command))
         {
@@ -354,7 +344,7 @@ bool Game::loadSgf(const QString &fileName) {
     return sendGtpCommand(qPrintable("loadsgf " + fileName + ".sgf"));
 }
 
-bool Game::fixSgf(QString& weightFile, bool resignation) {
+bool Game::fixSgf(const QString& weightFile, const bool resignation) {
     QFile sgfFile(m_fileName + ".sgf");
     if (!sgfFile.open(QIODevice::Text | QIODevice::ReadOnly)) {
         return false;

--- a/autogtp/Game.h
+++ b/autogtp/Game.h
@@ -19,17 +19,43 @@
 #ifndef GAME_H
 #define GAME_H
 
+#include <QFileInfo>
 #include <QProcess>
 #include <tuple>
 
 using VersionTuple = std::tuple<int, int, int>;
 
+class Engine {
+public:
+    Engine(const QString& network,
+           const QString& options,
+           const QStringList& commands = QStringList("time_settings 0 1 0"),
+           const QString& binary = QString("./leelaz")) :
+        m_binary(binary), m_options(options),
+        m_network(network), m_commands(commands) {
+#ifdef WIN32
+        m_binary.append(".exe");
+#endif
+        if (!QFileInfo::exists(m_binary)) {
+            m_binary.remove(0, 2); // ./leelaz -> leelaz
+        }
+    }
+    Engine() = default;
+    QString getCmdLine(void) const {
+        return m_binary + " " + m_options + " " + m_network;
+    }
+    QString getNetworkFile(void) const {
+        return QFileInfo(m_network).baseName();
+    }
+    QString m_binary;
+    QString m_options;
+    QString m_network;
+    QStringList m_commands;
+};
+
 class Game : QProcess {
 public:
-    Game(const QString& weights,
-         const QString& opt,
-         const QString& binary = QString("./leelaz"),
-         const QStringList& commands = QStringList("time_settings 0 1 0"));
+    Game(const Engine& engine);
     ~Game() = default;
     bool gameStart(const VersionTuple& min_version);
     void move();
@@ -41,16 +67,14 @@ public:
     bool writeSgf();
     bool loadTraining(const QString &fileName);
     bool saveTraining();
-    bool fixSgf(QString& weightFile, bool resignation);
+    bool fixSgf(const QString& weightFile, const bool resignation);
     bool dumpTraining();
-    QString getCmdLine() const { return m_cmdLine; }
     bool dumpDebug();
     void gameQuit();
     QString getMove() const { return m_moveDone; }
     QString getFile() const { return m_fileName; }
     bool setMove(const QString& m);
     bool checkGameEnd();
-    void setCmdLine(const QString& cmd)  { m_cmdLine = cmd; }
     int getWinner();
     QString getWinnerName() const { return m_winner; }
     int getMovesCount() const { return m_moveNum; }
@@ -68,9 +92,7 @@ private:
         WRONG_GTP,
         LAUNCH_FAILURE
     };
-    QString m_cmdLine;
-    QString m_binary;
-    QStringList m_commands;
+    Engine m_engine;
     QString m_winner;
     QString m_fileName;
     QString m_moveDone;

--- a/autogtp/Job.cpp
+++ b/autogtp/Job.cpp
@@ -48,17 +48,21 @@ void Job::init(const Order &o) {
 }
 
 ProductionJob::ProductionJob(QString gpu, Management *parent) :
-Job(gpu, parent)
+    Job(gpu, parent),
+    m_engine(Engine(QString(), QString()))
 {
 }
 
 ValidationJob::ValidationJob(QString gpu, Management *parent) :
-Job(gpu, parent)
+    Job(gpu, parent)
 {
+    for (auto engine : m_engines) {
+        engine = Engine(QString(), QString());
+    }
 }
 
 WaitJob::WaitJob(QString gpu, Management *parent) :
-Job(gpu, parent)
+    Job(gpu, parent)
 {
 }
 

--- a/autogtp/Job.cpp
+++ b/autogtp/Job.cpp
@@ -54,11 +54,10 @@ ProductionJob::ProductionJob(QString gpu, Management *parent) :
 }
 
 ValidationJob::ValidationJob(QString gpu, Management *parent) :
-    Job(gpu, parent)
+    Job(gpu, parent),
+    m_engineFirst(Engine(QString(), QString())),
+    m_engineSecond(Engine(QString(), QString()))
 {
-    for (auto engine : m_engines) {
-        engine = Engine(QString(), QString());
-    }
 }
 
 WaitJob::WaitJob(QString gpu, Management *parent) :
@@ -133,7 +132,7 @@ void ProductionJob::init(const Order &o) {
 
 Result ValidationJob::execute(){
     Result res(Result::Error);
-    Game first(m_engines[0]);
+    Game first(m_engineFirst);
     if (!first.gameStart(m_leelazMinVersion)) {
         return res;
     }
@@ -142,7 +141,7 @@ Result ValidationJob::execute(){
         first.setMovesCount(m_moves);
         QFile::remove(m_sgfFirst + ".sgf");
     }
-    Game second(m_engines[1]);
+    Game second(m_engineSecond);
     if (!second.gameStart(m_leelazMinVersion)) {
         return res;
     }
@@ -183,7 +182,7 @@ Result ValidationJob::execute(){
             res.add("score", first.getResult());
             res.add("winner", first.getWinnerName());
             first.writeSgf();
-            first.fixSgf(m_engines[1].getNetworkFile(),
+            first.fixSgf(m_engineSecond.getNetworkFile(),
                          (res.parameters()["score"] == "B+Resign"));
             res.add("file", first.getFile());
         }
@@ -208,10 +207,10 @@ Result ValidationJob::execute(){
 
 void ValidationJob::init(const Order &o) {
     Job::init(o);
-    m_engines[0].m_network = "networks/" + o.parameters()["firstNet"] + ".gz";
-    m_engines[0].m_options = " " + o.parameters()["options"] + m_gpu + " -g -q -w ";
-    m_engines[1].m_network = "networks/" + o.parameters()["secondNet"] + ".gz";
-    m_engines[1].m_options = " " + o.parameters()["options"] + m_gpu + " -g -q -w ";
+    m_engineFirst.m_network = "networks/" + o.parameters()["firstNet"] + ".gz";
+    m_engineFirst.m_options = " " + o.parameters()["options"] + m_gpu + " -g -q -w ";
+    m_engineSecond.m_network = "networks/" + o.parameters()["secondNet"] + ".gz";
+    m_engineSecond.m_options = " " + o.parameters()["options"] + m_gpu + " -g -q -w ";
     if (o.type() == Order::RestoreMatch) {
         m_sgfFirst = o.parameters()["sgfFirst"];
         m_sgfSecond = o.parameters()["sgfSecond"];

--- a/autogtp/Job.h
+++ b/autogtp/Job.h
@@ -19,6 +19,7 @@
 #ifndef JOB_H
 #define JOB_H
 
+#include "Game.h"
 #include "Result.h"
 #include "Order.h"
 #include <QObject>
@@ -50,7 +51,6 @@ public:
 
 protected:
     QAtomicInt m_state;
-    QString m_option;
     QString m_gpu;
     int m_moves;
     VersionTuple m_leelazMinVersion;
@@ -66,7 +66,7 @@ public:
     void init(const Order &o);
     Result execute();
 private:
-    QString m_network;
+    Engine m_engine;
     QString m_sgf;
     bool m_debug;
 };
@@ -79,8 +79,7 @@ public:
     void init(const Order &o);
     Result execute();
 private:
-    QString m_firstNet;
-    QString m_secondNet;
+    Engine m_engines[2];
     QString m_sgfFirst;
     QString m_sgfSecond;
 };

--- a/autogtp/Job.h
+++ b/autogtp/Job.h
@@ -79,7 +79,8 @@ public:
     void init(const Order &o);
     Result execute();
 private:
-    Engine m_engines[2];
+    Engine m_engineFirst;
+    Engine m_engineSecond;
     QString m_sgfFirst;
     QString m_sgfSecond;
 };

--- a/validation/Validation.cpp
+++ b/validation/Validation.cpp
@@ -28,22 +28,20 @@ const VersionTuple min_leelaz_version{0, 16, 0};
 
 void ValidationWorker::run() {
     do {
-        Game first(m_engines[0].m_network, m_engines[0].m_options,
-                   m_engines[0].m_binary, m_engines[0].m_commands);
+        Game first(m_engines[0]);
         if (!first.gameStart(min_leelaz_version)) {
             emit resultReady(Sprt::NoResult, Game::BLACK);
             return;
         }
-        Game second(m_engines[1].m_network, m_engines[1].m_options,
-                    m_engines[1].m_binary, m_engines[1].m_commands);
+        Game second(m_engines[1]);
         if (!second.gameStart(min_leelaz_version)) {
             emit resultReady(Sprt::NoResult, Game::BLACK);
             return;
         }
         QTextStream(stdout) << "starting:" << endl <<
-            first.getCmdLine() << endl <<
+            m_engines[0].getCmdLine() << endl <<
             "vs" << endl <<
-            second.getCmdLine() << endl;
+            m_engines[1].getCmdLine() << endl;
 
         QString wmove = "play white ";
         QString bmove = "play black ";

--- a/validation/Validation.h
+++ b/validation/Validation.h
@@ -28,21 +28,6 @@
 #include "../autogtp/Game.h"
 #include "Results.h"
 
-class Engine {
-public:
-    Engine(const QString& network,
-           const QString& options,
-           const QStringList& commands = QStringList("time_settings 0 1 0"),
-           const QString& binary = QString("./leelaz")) :
-        m_binary(binary), m_options(options),
-        m_network(network), m_commands(commands) {}
-    Engine() = default;
-    QString m_binary;
-    QString m_options;
-    QString m_network;
-    QStringList m_commands;
-};
-
 class ValidationWorker : public QThread {
     Q_OBJECT
 public:


### PR DESCRIPTION
Engine was added in #1652 as part of allowing Validation to send GTP commands. This change expands the use of Engine to autogtp for consistency and hopefully making it easier for a later change to allow for the server to use GTP commands for self-play and/match games.

I wrote this a while ago and remember doing some quick testing but I haven't had time to go through this as thoroughly as I would like. Especially as I don't want to break autogtp! I decided to make a PR to either help me get back on it or allow someone else to reuse it. So yeah, I'd appreciate any review feedback and suggestions for testing.