### PR TITLE
Microsoft azure cloud free trial added (master branch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ Many cloud companies offer free trials (or paid solutions, not discussed here)
 that are usable for helping the leela-zero project.
 
 There are community maintained instructions available here:
-[Running Leela Zero client on a Tesla V100 GPU for free (Google Cloud Free Trial, Microsoft Azure, Oracle cloud, etc)](https://docs.google.com/document/d/1P_c-RbeLKjv1umc4rMEgvIVrUUZSeY0WAtYHjaxjD64/edit?usp=sharing)
 
+[Running Leela Zero client on a Tesla V100 GPU for free (Google Cloud Free Trial)](https://docs.google.com/document/d/1P_c-RbeLKjv1umc4rMEgvIVrUUZSeY0WAtYHjaxjD64/edit?usp=sharing) : around 390 hours of Tesla V100 computing for free
+
+[Running Leela Zero client on a Tesla V100 GPU for free (Microsoft Azure Cloud Free Trial](https://docs.google.com/document/d/1DMpi16Aq9yXXvGj0OOw7jbd7k2A9LHDUDxxWPNHIRPQ/edit?usp=sharing) : around 250 hours of Tesla V100 computing for free
 
 # I just want to play right now
 


### PR DESCRIPTION
arround 250 hours Tesla V100 computing for free

the doc is here : 
https://docs.google.com/document/d/1DMpi16Aq9yXXvGj0OOw7jbd7k2A9LHDUDxxWPNHIRPQ/edit

General display : 
https://github.com/wonderingabout/leela-zero/tree/azure-cloud-docs

i added computing time in hours for free as an incentive and indication
prices have been stable in the last years so the estimate should stay accurate

these 2 contributors have edit rights on the azure and google cloud docs,
they can also add other people to edit the doc (the people added will have the right to add people too, so better choose them wisely)

@alreadydone 
@roy7 