### PR TITLE
Clear NNCache when clear_board or loadsgf is issued.

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -361,6 +361,7 @@ void GTP::execute(GameState & game, const std::string& xinput) {
     } else if (command.find("clear_board") == 0) {
         Training::clear_training();
         game.reset_game();
+        s_network->nncache_clear();
         search = std::make_unique<UCTSearch>(game, *s_network);
         assert(UCTNodePointer::get_tree_size() == 0);
         gtp_printf(id, "");
@@ -763,6 +764,7 @@ void GTP::execute(GameState & game, const std::string& xinput) {
         } catch (const std::exception&) {
             gtp_fail_printf(id, "cannot load file");
         }
+        s_network->nncache_clear();
         return;
     } else if (command.find("kgs-chat") == 0) {
         // kgs-chat (game|private) Name Message

--- a/src/NNCache.cpp
+++ b/src/NNCache.cpp
@@ -75,6 +75,11 @@ void NNCache::resize(int size) {
     }
 }
 
+void NNCache::clear() {
+    m_cache.clear();
+    m_order.clear();
+}
+
 void NNCache::set_size_from_playouts(int max_playouts) {
     // cache hits are generally from last several moves so setting cache
     // size based on playouts increases the hit rate while balancing memory

--- a/src/NNCache.h
+++ b/src/NNCache.h
@@ -63,6 +63,7 @@ public:
 
     // Resize NNCache
     void resize(int size);
+    void clear();
 
     // Try and find an existing entry.
     bool lookup(std::uint64_t hash, Netresult & result);

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -1015,3 +1015,7 @@ size_t Network::get_estimated_cache_size() {
 void Network::nncache_resize(int max_count) {
     return m_nncache.resize(max_count);
 }
+
+void Network::nncache_clear() {
+    m_nncache.clear();
+}

--- a/src/Network.h
+++ b/src/Network.h
@@ -92,6 +92,7 @@ public:
     size_t get_estimated_size();
     size_t get_estimated_cache_size();
     void nncache_resize(int max_count);
+    void nncache_clear();
 
 private:
     std::pair<int, int> load_v1_network(std::istream& wtfile);


### PR DESCRIPTION
Hopefully fixes lack-of-variability or even duplication issues observed in https://github.com/gcp/leela-zero/issues/2044 and https://github.com/gcp/leela-zero/issues/2006#issuecomment-441488218 when using gogui-twogtp. Technically twogtp isn't using loadsgf to start games with specified openings, though, but instead issue clear_board followed by a bunch of play commands, AFAIK.