### PR TITLE
Add ability for the server to specify an sgf as the initial position for self-play and match games

### DIFF
--- a/autogtp/Game.cpp
+++ b/autogtp/Game.cpp
@@ -349,11 +349,6 @@ bool Game::loadSgf(const QString &fileName, int moves) {
     return sendGtpCommand(qPrintable("loadsgf " + fileName + ".sgf " + QString::number(moves)));
 }
 
-bool Game::loadTraining(const QString &fileName, int moves) {
-    QTextStream(stdout) << "Loading " << fileName + ".train with " << moves << " moves" << endl;
-    return sendGtpCommand(qPrintable("load_training " + fileName + ".train " + QString::number(moves)));
-}
-
 bool Game::fixSgf(const QString& weightFile, const bool resignation) {
     QFile sgfFile(m_fileName + ".sgf");
     if (!sgfFile.open(QIODevice::Text | QIODevice::ReadOnly)) {

--- a/autogtp/Game.cpp
+++ b/autogtp/Game.cpp
@@ -344,9 +344,9 @@ bool Game::loadSgf(const QString &fileName) {
     return sendGtpCommand(qPrintable("loadsgf " + fileName + ".sgf"));
 }
 
-bool Game::loadSgf(const QString &fileName, int moves) {
+bool Game::loadSgf(const QString &fileName, const int moves) {
     QTextStream(stdout) << "Loading " << fileName + ".sgf with " << moves << " moves" << endl;
-    return sendGtpCommand(qPrintable("loadsgf " + fileName + ".sgf " + QString::number(moves)));
+    return sendGtpCommand(qPrintable("loadsgf " + fileName + ".sgf " + QString::number(moves + 1)));
 }
 
 bool Game::fixSgf(const QString& weightFile, const bool resignation) {

--- a/autogtp/Game.cpp
+++ b/autogtp/Game.cpp
@@ -344,6 +344,16 @@ bool Game::loadSgf(const QString &fileName) {
     return sendGtpCommand(qPrintable("loadsgf " + fileName + ".sgf"));
 }
 
+bool Game::loadSgf(const QString &fileName, int moves) {
+    QTextStream(stdout) << "Loading " << fileName + ".sgf with " << moves << " moves" << endl;
+    return sendGtpCommand(qPrintable("loadsgf " + fileName + ".sgf " + QString::number(moves)));
+}
+
+bool Game::loadTraining(const QString &fileName, int moves) {
+    QTextStream(stdout) << "Loading " << fileName + ".train with " << moves << " moves" << endl;
+    return sendGtpCommand(qPrintable("load_training " + fileName + ".train " + QString::number(moves)));
+}
+
 bool Game::fixSgf(const QString& weightFile, const bool resignation) {
     QFile sgfFile(m_fileName + ".sgf");
     if (!sgfFile.open(QIODevice::Text | QIODevice::ReadOnly)) {

--- a/autogtp/Game.h
+++ b/autogtp/Game.h
@@ -64,8 +64,10 @@ public:
     bool nextMove();
     bool getScore();
     bool loadSgf(const QString &fileName);
+    bool loadSgf(const QString &fileName, int moves);
     bool writeSgf();
     bool loadTraining(const QString &fileName);
+    bool loadTraining(const QString &fileName, int moves);
     bool saveTraining();
     bool fixSgf(const QString& weightFile, const bool resignation);
     bool dumpTraining();

--- a/autogtp/Game.h
+++ b/autogtp/Game.h
@@ -64,7 +64,7 @@ public:
     bool nextMove();
     bool getScore();
     bool loadSgf(const QString &fileName);
-    bool loadSgf(const QString &fileName, int moves);
+    bool loadSgf(const QString &fileName, const int moves);
     bool writeSgf();
     bool loadTraining(const QString &fileName);
     bool saveTraining();

--- a/autogtp/Game.h
+++ b/autogtp/Game.h
@@ -67,7 +67,6 @@ public:
     bool loadSgf(const QString &fileName, int moves);
     bool writeSgf();
     bool loadTraining(const QString &fileName);
-    bool loadTraining(const QString &fileName, int moves);
     bool saveTraining();
     bool fixSgf(const QString& weightFile, const bool resignation);
     bool dumpTraining();

--- a/autogtp/Job.cpp
+++ b/autogtp/Job.cpp
@@ -72,12 +72,15 @@ Result ProductionJob::execute(){
         return res;
     }
     if (!m_sgf.isEmpty()) {
-        game.loadSgf(m_sgf, m_moves);
-        game.loadTraining(m_sgf, m_moves);
-        game.setMovesCount(m_moves);
         if (! m_permanent_sgf) {
+            game.loadSgf(m_sgf);
+            game.loadTraining(m_sgf);
+            game.setMovesCount(m_moves);
             QFile::remove(m_sgf + ".sgf");
             QFile::remove(m_sgf + ".train");
+        } else {
+            game.loadSgf(m_sgf, m_moves+1);
+            game.setMovesCount(m_moves);
         }
     }
     do {

--- a/autogtp/Job.cpp
+++ b/autogtp/Job.cpp
@@ -72,7 +72,7 @@ Result ProductionJob::execute(){
         return res;
     }
     if (!m_sgf.isEmpty()) {
-        if (! m_permanent_sgf) {
+        if (m_restore) {
             game.loadSgf(m_sgf);
             game.loadTraining(m_sgf);
             game.setMovesCount(m_moves);
@@ -81,6 +81,7 @@ Result ProductionJob::execute(){
         } else {
             game.loadSgf(m_sgf, m_moves+1);
             game.setMovesCount(m_moves);
+            QFile::remove(m_sgf + ".sgf");
         }
     }
     do {
@@ -128,7 +129,7 @@ void ProductionJob::init(const Order &o) {
     m_debug = o.parameters()["debug"] == "true";
     m_sgf = o.parameters()["sgf"];
     m_moves = o.parameters()["moves"].toInt();
-    m_permanent_sgf = o.type() != Order::RestoreSelfPlayed;
+    m_restore = o.type() == Order::RestoreSelfPlayed;
 }
 
 Result ValidationJob::execute(){

--- a/autogtp/Job.cpp
+++ b/autogtp/Job.cpp
@@ -79,7 +79,7 @@ Result ProductionJob::execute(){
             QFile::remove(m_sgf + ".sgf");
             QFile::remove(m_sgf + ".train");
         } else {
-            game.loadSgf(m_sgf, m_moves+1);
+            game.loadSgf(m_sgf, m_moves + 1);
             game.setMovesCount(m_moves);
             QFile::remove(m_sgf + ".sgf");
         }
@@ -139,7 +139,11 @@ Result ValidationJob::execute(){
         return res;
     }
     if (!m_sgfFirst.isEmpty()) {
-        first.loadSgf(m_sgfFirst);
+        if (m_restore) {
+            first.loadSgf(m_sgfFirst);
+        } else {
+            first.loadSgf(m_sgfFirst, m_moves + 1);
+        }
         first.setMovesCount(m_moves);
         QFile::remove(m_sgfFirst + ".sgf");
     }
@@ -148,7 +152,11 @@ Result ValidationJob::execute(){
         return res;
     }
     if (!m_sgfSecond.isEmpty()) {
-        second.loadSgf(m_sgfSecond);
+        if (m_restore) {
+            second.loadSgf(m_sgfSecond);
+        } else {
+            second.loadSgf(m_sgfSecond, m_moves + 1);
+        }
         second.setMovesCount(m_moves);
         QFile::remove(m_sgfSecond + ".sgf");
     }
@@ -216,6 +224,7 @@ void ValidationJob::init(const Order &o) {
     m_sgfFirst = o.parameters()["sgfFirst"];
     m_sgfSecond = o.parameters()["sgfSecond"];
     m_moves = o.parameters()["moves"].toInt();
+    m_restore = o.type() == Order::RestoreMatch;
 }
 
 Result WaitJob::execute(){

--- a/autogtp/Job.cpp
+++ b/autogtp/Job.cpp
@@ -109,9 +109,9 @@ Result ProductionJob::execute(){
         res.add("moves", QString::number(game.getMovesCount()));
         break;
     case STORING:
-        res.type(Result::StoreSelfPlayed);
         game.writeSgf();
         game.saveTraining();
+        res.type(Result::StoreSelfPlayed);
         res.add("sgf", game.getFile());
         res.add("moves", QString::number(game.getMovesCount()));
         break;
@@ -138,27 +138,21 @@ Result ValidationJob::execute(){
     if (!first.gameStart(m_leelazMinVersion)) {
         return res;
     }
-    if (!m_sgfFirst.isEmpty()) {
-        if (m_moves == 0) {
-            first.loadSgf(m_sgfFirst);
-        } else {
-            first.loadSgf(m_sgfFirst, m_moves);
-        }
-        first.setMovesCount(m_moves);
-        QFile::remove(m_sgfFirst + ".sgf");
-    }
     Game second(m_engineSecond);
     if (!second.gameStart(m_leelazMinVersion)) {
         return res;
     }
-    if (!m_sgfSecond.isEmpty()) {
+    if (!m_sgf.isEmpty()) {
         if (m_moves == 0) {
-            second.loadSgf(m_sgfSecond);
+            first.loadSgf(m_sgf);
+            second.loadSgf(m_sgf);
         } else {
-            second.loadSgf(m_sgfSecond, m_moves);
+            first.loadSgf(m_sgf, m_moves);
+            second.loadSgf(m_sgf, m_moves);
         }
+        first.setMovesCount(m_moves);
         second.setMovesCount(m_moves);
-        QFile::remove(m_sgfSecond + ".sgf");
+        QFile::remove(m_sgf + ".sgf");
     }
 
     QString wmove = "play white ";
@@ -186,25 +180,22 @@ Result ValidationJob::execute(){
 
     switch (m_state.load()) {
     case RUNNING:
-        res.add("moves", QString::number(first.getMovesCount()));
-       QTextStream(stdout) << "Game has ended." << endl;
+        QTextStream(stdout) << "Game has ended." << endl;
         if (first.getScore()) {
             res.add("score", first.getResult());
             res.add("winner", first.getWinnerName());
             first.writeSgf();
             first.fixSgf(m_engineSecond.getNetworkFile(),
-                         (res.parameters()["score"] == "B+Resign"));
+                (res.parameters()["score"] == "B+Resign"));
             res.add("file", first.getFile());
         }
-        // Game is finished, send the result
         res.type(Result::Win);
+        res.add("moves", QString::number(first.getMovesCount()));
         break;
     case STORING:
-        res.type(Result::StoreMatch);
         first.writeSgf();
-        second.writeSgf();
-        res.add("sgfFirst", first.getFile());
-        res.add("sgfSecond", second.getFile());
+        res.type(Result::StoreMatch);
+        res.add("sgf", first.getFile());
         res.add("moves", QString::number(first.getMovesCount()));
         break;
     default:
@@ -221,8 +212,7 @@ void ValidationJob::init(const Order &o) {
     m_engineFirst.m_options = " " + o.parameters()["options"] + m_gpu + " -g -q -w ";
     m_engineSecond.m_network = "networks/" + o.parameters()["secondNet"] + ".gz";
     m_engineSecond.m_options = " " + o.parameters()["options"] + m_gpu + " -g -q -w ";
-    m_sgfFirst = o.parameters()["sgfFirst"];
-    m_sgfSecond = o.parameters()["sgfSecond"];
+    m_sgf = o.parameters()["sgf"];
     m_moves = o.parameters()["moves"].toInt();
 }
 

--- a/autogtp/Job.cpp
+++ b/autogtp/Job.cpp
@@ -72,11 +72,13 @@ Result ProductionJob::execute(){
         return res;
     }
     if (!m_sgf.isEmpty()) {
-        game.loadSgf(m_sgf);
-        game.loadTraining(m_sgf);
+        game.loadSgf(m_sgf, m_moves);
+        game.loadTraining(m_sgf, m_moves);
         game.setMovesCount(m_moves);
-        QFile::remove(m_sgf + ".sgf");
-        QFile::remove(m_sgf + ".train");
+        if (! m_permanent_sgf) {
+            QFile::remove(m_sgf + ".sgf");
+            QFile::remove(m_sgf + ".train");
+        }
     }
     do {
         game.move();
@@ -121,13 +123,9 @@ void ProductionJob::init(const Order &o) {
     m_engine.m_network = "networks/" + o.parameters()["network"] + ".gz";
     m_engine.m_options = " " + o.parameters()["options"] + m_gpu + " -g -q -w ";
     m_debug = o.parameters()["debug"] == "true";
-    if (o.type() == Order::RestoreSelfPlayed) {
-        m_sgf = o.parameters()["sgf"];
-        m_moves = o.parameters()["moves"].toInt();
-    } else {
-        m_sgf = "";
-        m_moves = 0;
-    }
+    m_sgf = o.parameters()["sgf"];
+    m_moves = o.parameters()["moves"].toInt();
+    m_permanent_sgf = o.type() != Order::RestoreSelfPlayed;
 }
 
 Result ValidationJob::execute(){
@@ -232,5 +230,3 @@ void WaitJob::init(const Order &o) {
     Job::init(o);
     m_minutes = o.parameters()["minutes"].toInt();
 }
-
-

--- a/autogtp/Job.cpp
+++ b/autogtp/Job.cpp
@@ -72,17 +72,17 @@ Result ProductionJob::execute(){
         return res;
     }
     if (!m_sgf.isEmpty()) {
-        if (m_restore) {
+        if (m_moves == 0) {
             game.loadSgf(m_sgf);
-            game.loadTraining(m_sgf);
-            game.setMovesCount(m_moves);
-            QFile::remove(m_sgf + ".sgf");
-            QFile::remove(m_sgf + ".train");
         } else {
-            game.loadSgf(m_sgf, m_moves + 1);
-            game.setMovesCount(m_moves);
-            QFile::remove(m_sgf + ".sgf");
+            game.loadSgf(m_sgf, m_moves);
         }
+        game.setMovesCount(m_moves);
+        if (m_restore) {
+            game.loadTraining(m_sgf);
+            QFile::remove(m_sgf + ".train");
+        }
+        QFile::remove(m_sgf + ".sgf");
     }
     do {
         game.move();
@@ -139,10 +139,10 @@ Result ValidationJob::execute(){
         return res;
     }
     if (!m_sgfFirst.isEmpty()) {
-        if (m_restore) {
+        if (m_moves == 0) {
             first.loadSgf(m_sgfFirst);
         } else {
-            first.loadSgf(m_sgfFirst, m_moves + 1);
+            first.loadSgf(m_sgfFirst, m_moves);
         }
         first.setMovesCount(m_moves);
         QFile::remove(m_sgfFirst + ".sgf");
@@ -152,10 +152,10 @@ Result ValidationJob::execute(){
         return res;
     }
     if (!m_sgfSecond.isEmpty()) {
-        if (m_restore) {
+        if (m_moves == 0) {
             second.loadSgf(m_sgfSecond);
         } else {
-            second.loadSgf(m_sgfSecond, m_moves + 1);
+            second.loadSgf(m_sgfSecond, m_moves);
         }
         second.setMovesCount(m_moves);
         QFile::remove(m_sgfSecond + ".sgf");
@@ -224,7 +224,6 @@ void ValidationJob::init(const Order &o) {
     m_sgfFirst = o.parameters()["sgfFirst"];
     m_sgfSecond = o.parameters()["sgfSecond"];
     m_moves = o.parameters()["moves"].toInt();
-    m_restore = o.type() == Order::RestoreMatch;
 }
 
 Result WaitJob::execute(){

--- a/autogtp/Job.cpp
+++ b/autogtp/Job.cpp
@@ -213,15 +213,9 @@ void ValidationJob::init(const Order &o) {
     m_engineFirst.m_options = " " + o.parameters()["options"] + m_gpu + " -g -q -w ";
     m_engineSecond.m_network = "networks/" + o.parameters()["secondNet"] + ".gz";
     m_engineSecond.m_options = " " + o.parameters()["options"] + m_gpu + " -g -q -w ";
-    if (o.type() == Order::RestoreMatch) {
-        m_sgfFirst = o.parameters()["sgfFirst"];
-        m_sgfSecond = o.parameters()["sgfSecond"];
-        m_moves = o.parameters()["moves"].toInt();
-    } else {
-        m_sgfFirst = "";
-        m_sgfSecond = "";
-        m_moves = 0;
-    }
+    m_sgfFirst = o.parameters()["sgfFirst"];
+    m_sgfSecond = o.parameters()["sgfSecond"];
+    m_moves = o.parameters()["moves"].toInt();
 }
 
 Result WaitJob::execute(){

--- a/autogtp/Job.h
+++ b/autogtp/Job.h
@@ -84,6 +84,7 @@ private:
     Engine m_engineSecond;
     QString m_sgfFirst;
     QString m_sgfSecond;
+    bool m_restore;
 };
 
 class WaitJob : public Job {

--- a/autogtp/Job.h
+++ b/autogtp/Job.h
@@ -69,7 +69,7 @@ private:
     Engine m_engine;
     QString m_sgf;
     bool m_debug;
-    bool m_permanent_sgf;
+    bool m_restore;
 };
 
 class ValidationJob : public Job {

--- a/autogtp/Job.h
+++ b/autogtp/Job.h
@@ -84,7 +84,6 @@ private:
     Engine m_engineSecond;
     QString m_sgfFirst;
     QString m_sgfSecond;
-    bool m_restore;
 };
 
 class WaitJob : public Job {

--- a/autogtp/Job.h
+++ b/autogtp/Job.h
@@ -69,6 +69,7 @@ private:
     Engine m_engine;
     QString m_sgf;
     bool m_debug;
+    bool m_permanent_sgf;
 };
 
 class ValidationJob : public Job {

--- a/autogtp/Job.h
+++ b/autogtp/Job.h
@@ -82,8 +82,7 @@ public:
 private:
     Engine m_engineFirst;
     Engine m_engineSecond;
-    QString m_sgfFirst;
-    QString m_sgfSecond;
+    QString m_sgf;
 };
 
 class WaitJob : public Job {

--- a/autogtp/Management.cpp
+++ b/autogtp/Management.cpp
@@ -34,6 +34,8 @@
 constexpr int RETRY_DELAY_MIN_SEC = 30;
 constexpr int RETRY_DELAY_MAX_SEC = 60 * 60;  // 1 hour
 constexpr int MAX_RETRIES = 3;           // Stop retrying after 3 times
+
+const QString server_url = "https://zero.sjeng.org/";
 const QString Leelaz_min_version = "0.12";
 
 Management::Management(const int gpus,
@@ -324,7 +326,7 @@ Order Management::getWorkInternal(bool tuning) {
     prog_cmdline.append(".exe");
 #endif
     prog_cmdline.append(" -s -J");
-    prog_cmdline.append(" https://zero.sjeng.org/get-task/");
+    prog_cmdline.append(" "+server_url+"get-task/");
     if (tuning) {
         prog_cmdline.append("0");
     } else {
@@ -533,7 +535,7 @@ void Management::fetchNetwork(const QString &net, const QString &hash) {
     // Use the filename from the server.
     prog_cmdline.append(" -s -J -o " + name + " ");
     prog_cmdline.append(" -w %{filename_effective}");
-    prog_cmdline.append(" https://zero.sjeng.org/" + name);
+    prog_cmdline.append(" "+server_url + name);
 
     QProcess curl;
     curl.start(prog_cmdline);
@@ -697,7 +699,7 @@ bool Management::sendCurl(const QStringList &lines) {
 -F options_hash=c2e3
 -F random_seed=0
 -F sgf=@file
-http://zero.sjeng.org/submit-match
+https://zero.sjeng.org/submit-match
 */
 
 void Management::uploadResult(const QMap<QString,QString> &r, const QMap<QString,QString> &l) {
@@ -720,7 +722,7 @@ void Management::uploadResult(const QMap<QString,QString> &r, const QMap<QString
     prog_cmdline.append("-F options_hash="+ l["optHash"]);
     prog_cmdline.append("-F random_seed="+ l["rndSeed"]);
     prog_cmdline.append("-F sgf=@"+ r["file"] + ".sgf.gz");
-    prog_cmdline.append("https://zero.sjeng.org/submit-match");
+    prog_cmdline.append(server_url+"submit-match");
 
     bool sent = false;
     for (auto retries = 0; retries < MAX_RETRIES; retries++) {
@@ -756,7 +758,7 @@ void Management::uploadResult(const QMap<QString,QString> &r, const QMap<QString
 -F random_seed=1
 -F sgf=@file
 -F trainingdata=@data_file
-http://zero.sjeng.org/submit
+https://zero.sjeng.org/submit
 */
 
 void Management::uploadData(const QMap<QString,QString> &r, const QMap<QString,QString> &l) {
@@ -772,7 +774,7 @@ void Management::uploadData(const QMap<QString,QString> &r, const QMap<QString,Q
     prog_cmdline.append("-F random_seed="+ l["rndSeed"]);
     prog_cmdline.append("-F sgf=@" + r["file"] + ".sgf.gz");
     prog_cmdline.append("-F trainingdata=@" + r["file"] + ".txt.0.gz");
-    prog_cmdline.append("https://zero.sjeng.org/submit");
+    prog_cmdline.append(server_url+"submit");
 
     bool sent = false;
     for (auto retries = 0; retries < MAX_RETRIES; retries++) {

--- a/autogtp/Management.cpp
+++ b/autogtp/Management.cpp
@@ -578,13 +578,8 @@ QString Management::fetchGameData(const QString &name, const QString &extension)
 #ifdef WIN32
     prog_cmdline.append(".exe");
 #endif
-    const auto templateName = name + "-XXXXXX." + extension;
-    QTemporaryFile file(templateName);
-    if (!file.open()) {
-        throw NetworkException("Unable to generate temporary file for game data");
-    }
-    file.setAutoRemove(false);
-    const auto fileName = QFileInfo(file.fileName()).baseName();
+
+    const auto fileName = QUuid::createUuid().toRfc4122().toHex();
 
     // Be quiet, but output the real file name we saved.
     // Use the filename from the server.

--- a/autogtp/Management.cpp
+++ b/autogtp/Management.cpp
@@ -408,7 +408,11 @@ Order Management::getWorkInternal(bool tuning) {
         fetchNetwork(net, gzipHash);
         o.type(Order::Production);
         parameters["network"] = net;
-        parameters["sgf"] = ob.contains("sgfhash") ? ob.value("sgfhash").toString() : "";
+        parameters["sgf"] = ob.contains("sgfhash") ? "sgfs/" + ob.value("sgfhash").toString() : "";
+        if (ob.contains("sgfhash")) {
+            fetchSgfOrTrain(ob.value("sgfhash").toString() + ".sgf");
+            fetchSgfOrTrain(ob.value("sgfhash").toString() + ".train");
+        }
         parameters["moves"] = ob.contains("movescount") ? ob.value("movescount").toString() : "0";
         o.parameters(parameters);
         if (m_delNetworks &&
@@ -556,6 +560,68 @@ void Management::fetchNetwork(const QString &net, const QString &hash) {
     return;
 }
 
+bool Management::sgfOrTrainExists(const QString &name) {
+    QStringRef extension = name.midRef(name.lastIndexOf(QChar('.'))+1);
+    QString realHash = name;
+    realHash.remove(0,name.lastIndexOf(QChar('/'))+1);
+    realHash.remove(realHash.lastIndexOf(QChar('.')), realHash.length());
+    if (QFileInfo::exists(name)) {
+        QFile f(name);
+        if (f.open(QFile::ReadOnly)) {
+            QCryptographicHash hash(QCryptographicHash::Sha256);
+            if (!hash.addData(&f)) {
+                throw NetworkException("Reading " + extension.toUtf8().toStdString() + " file failed.");
+            }
+            QString result = hash.result().toHex();
+
+            if (extension != "sgf" || result == realHash) {
+                return true;
+            }
+        } else {
+            QTextStream(stdout)
+                << "Unable to open " << extension << " sgf file for reading." << endl;
+            if (f.remove()) {
+                return false;
+            }
+            throw NetworkException("Unable to delete " + extension.toUtf8().toStdString() + " file."
+                                   " Check permissions.");
+        }
+        QTextStream(stdout) << "Downloaded " << extension << " hash doesn't match." << endl;
+        f.remove();
+    }
+    return false;
+}
+
+void Management::fetchSgfOrTrain(const QString &sgf) {
+    QString name = "sgfs/" + sgf;
+    if (sgfOrTrainExists(name)) {
+        return;
+    }
+
+    QString prog_cmdline("curl");
+#ifdef WIN32
+    prog_cmdline.append(".exe");
+#endif
+    // Be quiet, but output the real file name we saved.
+    // Use the filename from the server.
+    prog_cmdline.append(" -s -J -o " + name);
+    prog_cmdline.append(" -w %{filename_effective}");
+    prog_cmdline.append(" "+server_url + "viewgame/" + sgf);
+        QTextStream(stdout) << prog_cmdline << endl;
+
+    QProcess curl;
+    curl.start(prog_cmdline);
+    curl.waitForFinished(-1);
+
+    if (curl.exitCode()) {
+        throw NetworkException("Curl returned non-zero exit code "
+                               + std::to_string(curl.exitCode()));
+    }
+    if (! sgfOrTrainExists(name))
+        throw NetworkException("Failed to fetch the network");
+
+    return;
+}
 
 void Management::archiveFiles(const QString &fileName) {
     if (!m_keepPath.isEmpty()) {

--- a/autogtp/Management.cpp
+++ b/autogtp/Management.cpp
@@ -293,9 +293,12 @@ Order Management::getWorkInternal(bool tuning) {
        resignation_percent : "3",
        noise : "true",
        randomcnt : "30"
-    }
-    white_hash_gzip_hash: "23c29bf777e446b5c3fb0e6e7fa4d53f15b99cc0c25798b70b57877b55bf1638"
-    black_hash_gzip_hash: "ccfe6023456aaaa423c29bf777e4aab481245289aaaabb70b7b5380992377aa8"
+    },
+    white_hash_gzip_hash: "23c29bf777e446b5c3fb0e6e7fa4d53f15b99cc0c25798b70b57877b55bf1638",
+    black_hash_gzip_hash: "ccfe6023456aaaa423c29bf777e4aab481245289aaaabb70b7b5380992377aa8",
+    black_hash_sgf_hash: "7dbccc5ad9eb38f0135ff7ec860f0e81157f47dfc0a8375cef6bf1119859e537",
+    white_hash_sgf_hash: "7dbccc5ad9eb38f0135ff7ec860f0e81157f47dfc0a8375cef6bf1119859e537",
+    moves_count: "92"
 }
 
 {
@@ -311,8 +314,10 @@ Order Management::getWorkInternal(bool tuning) {
        resignation_percent : "3",
        noise : "true",
        randomcnt : "30"
-    }
-    hash_gzip_hash: "23c29bf777e446b5c3fb0e6e7fa4d53f15b99cc0c25798b70b57877b55bf1638"
+    },
+    hash_gzip_hash: "23c29bf777e446b5c3fb0e6e7fa4d53f15b99cc0c25798b70b57877b55bf1638",
+    hash_sgf_hash: "7dbccc5ad9eb38f0135ff7ec860f0e81157f47dfc0a8375cef6bf1119859e537",
+    moves_count: "92"
 }
 
 {
@@ -408,8 +413,10 @@ Order Management::getWorkInternal(bool tuning) {
         fetchNetwork(net, gzipHash);
         o.type(Order::Production);
         parameters["network"] = net;
-        parameters["sgf"] = ob.contains("sgfhash") ? fetchGameData(ob.value("sgfhash").toString(), "sgf") : "" ;
-        parameters["moves"] = ob.contains("movescount") ? ob.value("movescount").toString() : "0";
+        parameters["sgf"] = ob.contains("hash_sgf_hash") ?
+            fetchGameData(ob.value("hash_sgf_hash").toString(), "sgf") : "" ;
+        parameters["moves"] = ob.contains("moves_count") ?
+            ob.value("moves_count").toString() : "0";
         o.parameters(parameters);
         if (m_delNetworks &&
             m_fallBack.parameters()["network"] != net) {
@@ -429,6 +436,14 @@ Order Management::getWorkInternal(bool tuning) {
         fetchNetwork(net2, gzipHash2);
         parameters["firstNet"] = net1;
         parameters["secondNet"] = net2;
+        parameters["sgfFirst"] = ob.contains("black_hash_sgf_hash") ?
+            fetchGameData(ob.value("black_hash_sgf_hash").toString(), "sgf") :
+            "";
+        parameters["sgfSecond"] = ob.contains("white_hash_sgf_hash") ?
+            fetchGameData(ob.value("white_hash_sgf_hash").toString(), "sgf") :
+            "";
+        parameters["moves"] = ob.contains("moves_count") ?
+            ob.value("moves_count").toString() : "0";
         o.parameters(parameters);
         if (m_delNetworks) {
             if (m_lastMatch.parameters()["firstNet"] != net1 &&

--- a/autogtp/Management.cpp
+++ b/autogtp/Management.cpp
@@ -408,9 +408,7 @@ Order Management::getWorkInternal(bool tuning) {
         fetchNetwork(net, gzipHash);
         o.type(Order::Production);
         parameters["network"] = net;
-        parameters["sgf"] = ob.contains("sgfhash") ? ob.value("sgfhash").toString() : "";
-        if (ob.contains("sgfhash"))
-            fetchGameData(ob.value("sgfhash").toString()+".sgf");
+        parameters["sgf"] = ob.contains("sgfhash") ? fetchGameData(ob.value("sgfhash").toString(), "sgf") : "" ;
         parameters["moves"] = ob.contains("movescount") ? ob.value("movescount").toString() : "0";
         o.parameters(parameters);
         if (m_delNetworks &&
@@ -558,16 +556,18 @@ void Management::fetchNetwork(const QString &net, const QString &hash) {
     return;
 }
 
-void Management::fetchGameData(const QString &name) {
+QString Management::fetchGameData(const QString &name, const QString &extension) {
     QString prog_cmdline("curl");
 #ifdef WIN32
     prog_cmdline.append(".exe");
 #endif
+    QString fileName =  QString::fromStdString(std::tmpnam(nullptr));
+
     // Be quiet, but output the real file name we saved.
     // Use the filename from the server.
-    prog_cmdline.append(" -s -J -o " + name);
+    prog_cmdline.append(" -s -J -o " + fileName + "." + extension);
     prog_cmdline.append(" -w %{filename_effective}");
-    prog_cmdline.append(" "+server_url + "viewgame/" + name);
+    prog_cmdline.append(" "+server_url + "view/" + name + "." + extension);
 
     QProcess curl;
     curl.start(prog_cmdline);
@@ -578,7 +578,7 @@ void Management::fetchGameData(const QString &name) {
                                + std::to_string(curl.exitCode()));
     }
 
-    return;
+    return fileName;
 }
 
 void Management::archiveFiles(const QString &fileName) {

--- a/autogtp/Management.cpp
+++ b/autogtp/Management.cpp
@@ -561,7 +561,7 @@ void Management::fetchNetwork(const QString &net, const QString &hash) {
 }
 
 bool Management::sgfOrTrainExists(const QString &name) {
-    QStringRef extension = name.midRef(name.lastIndexOf(QChar('.'))+1);
+    QString extension = name.mid(name.lastIndexOf(QChar('.'))+1);
     QString realHash = name;
     realHash.remove(0,name.lastIndexOf(QChar('/'))+1);
     realHash.remove(realHash.lastIndexOf(QChar('.')), realHash.length());

--- a/autogtp/Management.cpp
+++ b/autogtp/Management.cpp
@@ -408,6 +408,8 @@ Order Management::getWorkInternal(bool tuning) {
         fetchNetwork(net, gzipHash);
         o.type(Order::Production);
         parameters["network"] = net;
+        parameters["sgf"] = ob.contains("sgfhash") ? ob.value("sgfhash").toString() : "";
+        parameters["moves"] = ob.contains("movescount") ? ob.value("movescount").toString() : "0";
         o.parameters(parameters);
         if (m_delNetworks &&
             m_fallBack.parameters()["network"] != net) {

--- a/autogtp/Management.h
+++ b/autogtp/Management.h
@@ -95,7 +95,7 @@ private:
     QFileInfo getNextStored();
     bool networkExists(const QString &name, const QString &gzipHash);
     void fetchNetwork(const QString &net, const QString &hash);
-    void fetchGameData(const QString &name);
+    QString fetchGameData(const QString &name, const QString &extension);
     void printTimingInfo(float duration);
     void runTuningProcess(const QString &tuneCmdLine);
     void gzipFile(const QString &fileName);

--- a/autogtp/Management.h
+++ b/autogtp/Management.h
@@ -95,8 +95,7 @@ private:
     QFileInfo getNextStored();
     bool networkExists(const QString &name, const QString &gzipHash);
     void fetchNetwork(const QString &net, const QString &hash);
-    bool sgfOrTrainExists(const QString &fiename);
-    void fetchSgfOrTrain(const QString &name);
+    void fetchGameData(const QString &name);
     void printTimingInfo(float duration);
     void runTuningProcess(const QString &tuneCmdLine);
     void gzipFile(const QString &fileName);

--- a/autogtp/Management.h
+++ b/autogtp/Management.h
@@ -95,6 +95,8 @@ private:
     QFileInfo getNextStored();
     bool networkExists(const QString &name, const QString &gzipHash);
     void fetchNetwork(const QString &net, const QString &hash);
+    bool sgfOrTrainExists(const QString &fiename);
+    void fetchSgfOrTrain(const QString &name);
     void printTimingInfo(float duration);
     void runTuningProcess(const QString &tuneCmdLine);
     void gzipFile(const QString &fileName);

--- a/autogtp/Worker.cpp
+++ b/autogtp/Worker.cpp
@@ -91,12 +91,10 @@ void Worker::run() {
     } while (m_state == RUNNING);
     if (m_state == STORING) {
         m_todo.add("moves", res.parameters()["moves"]);
+        m_todo.add("sgf", res.parameters()["sgf"]);
         if (res.type() == Result::StoreMatch) {
-            m_todo.add("sgfFirst", res.parameters()["sgfFirst"]);
-            m_todo.add("sgfSecond", res.parameters()["sgfSecond"]);
             m_todo.type(Order::RestoreMatch);
         } else {
-            m_todo.add("sgf", res.parameters()["sgf"]);
             m_todo.type(Order::RestoreSelfPlayed);
         }
         QString unique = QUuid::createUuid().toRfc4122().toHex();

--- a/autogtp/main.cpp
+++ b/autogtp/main.cpp
@@ -140,6 +140,11 @@ int main(int argc, char *argv[]) {
              << endl;
         return EXIT_FAILURE;
     }
+    if (!QDir().mkpath("sgfs")) {
+        cerr << "Couldn't create the directory for the sgf files!"
+             << endl;
+        return EXIT_FAILURE;
+    }
     Management *boss = new Management(gpusNum, gamesNum, gpusList, AUTOGTP_VERSION, maxNum,
                                       parser.isSet(eraseOption), parser.value(keepSgfOption),
                                       parser.value(keepDebugOption));

--- a/autogtp/main.cpp
+++ b/autogtp/main.cpp
@@ -140,11 +140,6 @@ int main(int argc, char *argv[]) {
              << endl;
         return EXIT_FAILURE;
     }
-    if (!QDir().mkpath("sgfs")) {
-        cerr << "Couldn't create the directory for the sgf files!"
-             << endl;
-        return EXIT_FAILURE;
-    }
     Management *boss = new Management(gpusNum, gamesNum, gpusList, AUTOGTP_VERSION, maxNum,
                                       parser.isSet(eraseOption), parser.value(keepSgfOption),
                                       parser.value(keepDebugOption));


### PR DESCRIPTION
I've cherry-picked some of @amato-gianluca's commits from SAI (I hope that's ok?). Specifically those to allow the server to start self-play games from an sgf (i.e. some of those listed here https://github.com/sai-dev/sai/commits/sai-0.15/autogtp/Management.cpp). I've then extended this to also cover match games.

See https://github.com/sai-dev/sai/issues/7 for a possible use for this in self-play. I think allowing similar functionality for match games could be useful and is a small change, so why not.

If these are accepted as sound enough reasons for including this PR then I'll raise a server issue asking @roy7 for help testing. All I can do and have done so far is get a couple of self-play games (based on existing server responses) and they look like they ran fine.
http://zero.sjeng.org/view/0808e80c508107b8cdb7c5b3ca5a11c5d3b1f9569a50fb2cb14de910d3af2ac8?viewer=wgo
http://zero.sjeng.org/view/c658b51e65892faf440c11ed85b76502641bc7de385fff473eafa45980f3bfa3?viewer=wgo [with a store and restore partway through]

The basic idea is to allow for optionally adding this to the JSON:
```
    hash_sgf_hash: "7dbccc5ad9eb38f0135ff7ec860f0e81157f47dfc0a8375cef6bf1119859e537",
    moves_count: "92"
```
Thoughts?