### PR TITLE
Add ability for LZ to maintain a chosen winrate against any opponent of any strength

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -62,6 +62,7 @@ int cfg_noise;
 int cfg_random_cnt;
 int cfg_random_min_visits;
 float cfg_random_temp;
+int cfg_winrate_target;
 std::uint64_t cfg_rng_seed;
 bool cfg_dumbpass;
 #ifdef USE_OPENCL
@@ -144,6 +145,7 @@ void GTP::setup_default_parameters() {
     cfg_random_cnt = 0;
     cfg_random_min_visits = 1;
     cfg_random_temp = 1.0f;
+	cfg_winrate_target = 100;
     cfg_dumbpass = false;
     cfg_logfile_handle = nullptr;
     cfg_quiet = false;

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -45,6 +45,7 @@ extern int cfg_noise;
 extern int cfg_random_cnt;
 extern int cfg_random_min_visits;
 extern float cfg_random_temp;
+extern int cfg_winrate_target;
 extern std::uint64_t cfg_rng_seed;
 extern bool cfg_dumbpass;
 #ifdef USE_OPENCL

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -112,6 +112,11 @@ static void parse_commandline(int argc, char *argv[]) {
         ("randomtemp",
             po::value<float>()->default_value(cfg_random_temp),
             "Temperature to use for random move selection.")
+		("winratetarget",
+            po::value<int>()->default_value(cfg_winrate_target),
+            "Require engine to play weaker moves to maintain a winrate of x%, regardless of the strength of the engine's opponent. Valid arguments are any integer from 0 to 100.\n"
+			"100 is unmodified search, playing strongest moves as usual.\n"
+			"50 forces a perfectly tied 50% winrate game against its opponent.")
         ;
 #ifdef USE_TUNER
     po::options_description tuner_desc("Tuning options");
@@ -329,6 +334,10 @@ static void parse_commandline(int argc, char *argv[]) {
     if (vm.count("randomtemp")) {
         cfg_random_temp = vm["randomtemp"].as<float>();
     }
+
+	if (vm.count("winratetarget")) {
+		cfg_winrate_target = vm["winratetarget"].as<int>();
+	}
 
     if (vm.count("timemanage")) {
         auto tm = vm["timemanage"].as<std::string>();

--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -51,7 +51,7 @@ public:
     const std::vector<UCTNodePointer>& get_children() const;
     void sort_children(int color);
     UCTNode& get_best_root_child(int color);
-    UCTNode* uct_select_child(int color, bool is_root);
+    UCTNode* uct_select_child(int color, bool is_root, bool is_opponent_move);
 
     size_t count_nodes_and_clear_expand_state();
     bool first_visit() const;

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -40,6 +40,7 @@
 using namespace Utils;
 
 constexpr int UCTSearch::UNLIMITED_PLAYOUTS;
+bool is_pondering_now = false;
 
 class OutputAnalysisData {
 public:
@@ -224,8 +225,16 @@ SearchResult UCTSearch::play_simulation(GameState & currstate,
         }
     }
 
+	auto depth =
+		int(currstate.get_movenum() - m_rootstate.get_movenum());
+	auto apparent_depth = depth;
+	if (is_pondering_now == true) { // Adjust depth by 1 to account for thinking/pondering during opponent's turn
+		apparent_depth =
+			(1 + int(currstate.get_movenum() - m_rootstate.get_movenum()));
+	}
+
     if (node->has_children() && !result.valid()) {
-        auto next = node->uct_select_child(color, node == m_root.get());
+        auto next = node->uct_select_child(color, node == m_root.get(), ((apparent_depth % 2) != 0));
         auto move = next->get_move();
 
         currstate.play_move(move);
@@ -778,6 +787,7 @@ int UCTSearch::think(int color, passflag_t passflag) {
 }
 
 void UCTSearch::ponder() {
+	is_pondering_now = true;
     update_root();
 
     m_root->prepare_root_node(m_network, m_rootstate.board.get_to_move(),
@@ -818,6 +828,7 @@ void UCTSearch::ponder() {
     dump_stats(m_rootstate, *m_root);
 
     myprintf("\n%d visits, %d nodes\n\n", m_root->get_visits(), m_nodes.load());
+	is_pondering_now = false;
 
     // Copy the root state. Use to check for tree re-use in future calls.
     m_last_rootstate = std::make_unique<GameState>(m_rootstate);


### PR DESCRIPTION
This may or may not fit within the intended scope of `gcp/leela-zero`, so no harm if it ends up not being accepted, though many people have expressed interest in a function like this for practicing against LZ without being destroyed in every game. This is my first substantive PR for the project, so hopefully we can at least take the time to bring the code up to standard so I know what to expect when I submit additional PRs shortly down the road.

This PR adds the ability for custom winrate targeting using the new command-line option `--winratetarget x` where `x` is an integer ranging from 0 to 100 percent. The engine will attempt to play moves on its turns to force the board state into always maintaining a certain winrate throughout the game, regardless of how skillfully or poorly its opponent plays. During reading and pondering, LZ always assumes its opponent will play each of its moves optimally at full strength. If the opponent "surprises" LZ by playing a weaker move than expected, LZ's search automatically compensates by guiding it towards weaker PVs that bring the board state back to the user's desired winrate. In practice, this works *very* well.

The basic MCTS implementation that balances exploration vs exploitation with `value = winrate + puct` remains absolutely unchanged. Instead, `winrate` in the value function for LZ's turns is calculated based on *how close LZ's assessed winrate was to the user's desired winrate*. The magic happens on just two lines of UCTNode.cpp., right after `auto value = winrate + puct;`:

```
		if (!unmodified_search && !is_opponent_move) {
			value = (1 - abs(winrate_target_value - winrate)) + puct;
		}
```

(The `unmodified_search` bool guarantees no change in `uct_select_child` behavior unless the user has input a valid value for `--winratetarget`)

There is also some relevant support code in UCTSearch.cpp to take care of the following:

- New bool "is_opponent_move" passed to uct_select_child to indicate whether a visit being made at any arbitrary depth is an "engine move" or an "opponent move" (essentially whether `depth` is odd or even). This is what decides whether to use the "winrate-targeting value function" for the engine's own moves, or the "full strength, regular LZ search" for its opponent's moves.
- New bool "is_pondering_now" is true/false depending on whether engine is pondering during opponent's turn. Used to adjust the odd/even `depth` determination to return the proper bool value for "is_opponent_move" during pondering.