### PR TITLE
Add O(sqrt(log(n))) scaling to tree search

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -73,6 +73,8 @@ precision_t cfg_precision;
 #endif
 #endif
 float cfg_puct;
+float cfg_logpuct;
+float cfg_logconst;
 float cfg_softmax_temp;
 float cfg_fpu_reduction;
 float cfg_fpu_root_reduction;
@@ -134,7 +136,9 @@ void GTP::setup_default_parameters() {
     cfg_precision = precision_t::AUTO;
 #endif
 #endif
-    cfg_puct = 0.8f;
+    cfg_puct = 0.5f;
+    cfg_logpuct = 0.015f;
+    cfg_logconst = 1.7f;
     cfg_softmax_temp = 1.0f;
     cfg_fpu_reduction = 0.25f;
     // see UCTSearch::should_resign

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -59,6 +59,8 @@ extern precision_t cfg_precision;
 #endif
 #endif
 extern float cfg_puct;
+extern float cfg_logpuct;
+extern float cfg_logconst;
 extern float cfg_softmax_temp;
 extern float cfg_fpu_reduction;
 extern float cfg_fpu_root_reduction;

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -117,6 +117,8 @@ static void parse_commandline(int argc, char *argv[]) {
     po::options_description tuner_desc("Tuning options");
     tuner_desc.add_options()
         ("puct", po::value<float>())
+        ("logpuct", po::value<float>())
+        ("logconst", po::value<float>())
         ("softmax_temp", po::value<float>())
         ("fpu_reduction", po::value<float>())
         ;
@@ -181,6 +183,12 @@ static void parse_commandline(int argc, char *argv[]) {
 #ifdef USE_TUNER
     if (vm.count("puct")) {
         cfg_puct = vm["puct"].as<float>();
+    }
+    if (vm.count("logpuct")) {
+        cfg_logpuct = vm["logpuct"].as<float>();
+    }
+    if (vm.count("logconst")) {
+        cfg_logconst = vm["logconst"].as<float>();
     }
     if (vm.count("softmax_temp")) {
         cfg_softmax_temp = vm["softmax_temp"].as<float>();

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -251,7 +251,8 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
         }
     }
 
-    const auto numerator = std::sqrt(double(parentvisits) * std::log(cfg_logpuct * parentvisits + cfg_logconst));
+    const auto numerator = std::sqrt(double(parentvisits) *
+            std::log(cfg_logpuct * double(parentvisits) + cfg_logconst));
     const auto fpu_reduction = (is_root ? cfg_fpu_root_reduction : cfg_fpu_reduction) * std::sqrt(total_visited_policy);
     // Estimated eval for unknown nodes = original parent NN eval - reduction
     const auto fpu_eval = get_net_eval(color) - fpu_reduction;

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -251,7 +251,7 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
         }
     }
 
-    const auto numerator = std::sqrt(double(parentvisits));
+    const auto numerator = std::sqrt(double(parentvisits) * std::log(cfg_logpuct * parentvisits + cfg_logconst));
     const auto fpu_reduction = (is_root ? cfg_fpu_root_reduction : cfg_fpu_reduction) * std::sqrt(total_visited_policy);
     // Estimated eval for unknown nodes = original parent NN eval - reduction
     const auto fpu_eval = get_net_eval(color) - fpu_reduction;


### PR DESCRIPTION
At 100 visits puct of 0.5 seems to be much better than the default puct of 0.8:

```
lz_puct_0.5 v lz_puct_0.8 (135/400 games)
board size: 19   komi: 7.5
              wins              black         white       avg cpu
lz_puct_0.5     84 62.22%       49 72.06%     35 52.24%     14.82
lz_puct_0.8     51 37.78%       32 47.76%     19 27.94%     15.84
                                81 60.00%     54 40.00%
```

But puct of 0.5 is not better than 0.8 at 1600 visits:

```
lz_puct_05 v lz_puct_08 (84/400 games)
board size: 19   komi: 7.5
             wins              black         white       avg cpu
lz_puct_05     40 47.62%       16 38.10%     24 57.14%    129.23
lz_puct_08     44 52.38%       18 42.86%     26 61.90%    144.67
                               34 40.48%     50 59.52%
```

These results suggests that scaling of the `sqrt(n)/(ni + 1)` term in tree search is not correct. I made a toy multi-armed bandit example that draws rewards from beta distribution with policy generated using monte carlo simulation such that policy of the move equals probability that it's the best move. Finding the optimal puct in the toy example gives following plot as function of arm pulls:

![puct_fitted](https://user-images.githubusercontent.com/544240/49648240-b01d9080-fa2d-11e8-8995-8ad80b5deea6.png)

There are many functions that could be fitted to it, but I chose to fit `puct * sqrt(log(a * n + b))` function with motivation being that then the asymptotic behaviour of the mcts equation is equal to UCB1 (`sqrt(log(n)/ni)`) and the fit was okay.

I clopped the optimal values for the last 15x192 network using command line parameters `-t 2 -v 1600 -d -r 5 --noponder` and got the optimum parameters around the ones in this PR.

I ran several matches using the last 15x192 network with different visits and got the results:

```
100 visits:

lz_logpuct v lz_next (200/200 games)
board size: 19   komi: 7.5
             wins              black         white        avg cpu
lz_logpuct    122 61.00%       59 59.00%     63  63.00%     14.50
lz_next        78 39.00%       37 37.00%     41  41.00%     15.69
                               96 48.00%     104 52.00%

1600 visits:

lz_logpuct v lz_next (400/400 games)
board size: 19   komi: 7.5
             wins              black          white        avg cpu
lz_logpuct    216 54.00%       91  45.50%     125 62.50%    172.43
lz_next       184 46.00%       75  37.50%     109 54.50%    176.54
                               166 41.50%     234 58.50%

3200 visits:

lz_logpuct v lz_next (400/400 games)
board size: 19   komi: 7.5
             wins              black          white        avg cpu
lz_logpuct    221 55.25%       100 50.00%     121 60.50%    378.73
lz_next       179 44.75%       79  39.50%     100 50.00%    379.23
                               179 44.75%     221 55.25%

6400 visits:

lz_logpuct v lz_next (100/100 games)
board size: 19   komi: 7.5
             wins              black         white       avg cpu
lz_logpuct     54 54.00%       24 48.00%     30 60.00%    748.88
lz_next        46 46.00%       20 40.00%     26 52.00%    731.10
                               44 44.00%     56 56.00%

```

At 100 and 3200 visits it's better with >95% confidence. 1600 visits is not quite 95% but close. 6400 takes too long to run enough games, but the results so far line up with lower visit tests.