### PR TITLE
AutoGTP: Allow specifying initial GTP commands. 

### DIFF
--- a/autogtp/Game.cpp
+++ b/autogtp/Game.cpp
@@ -177,6 +177,9 @@ bool Game::gameStart(const VersionTuple &min_version) {
             QTextStream(stdout) << "GTP failed on: " << command << endl;
             exit(EXIT_FAILURE);
         }
+        if (command.contains("handicap")) {
+            m_blackToMove = false;
+        }
     }
     QTextStream(stdout) << "Thinking time set." << endl;
     return true;
@@ -196,7 +199,11 @@ void Game::move() {
 
 void Game::setMovesCount(int moves) {
     m_moveNum = moves;
-    m_blackToMove = (moves % 2) == 0;
+    //The game always starts at move 0 (GTP state that handicap stones are not part
+    //of the move history), so if there is no handicap then black moves on even
+    //numbered turns but if there is handicap then black moves on odd numbered turns.
+    const auto handicap_in_use = !m_engine.m_commands.filter("handicap").isEmpty();
+    m_blackToMove = (moves % 2) == (handicap_in_use ? 1 : 0);
 }
 
 bool Game::waitReady() {

--- a/autogtp/Game.h
+++ b/autogtp/Game.h
@@ -101,6 +101,7 @@ private:
     QString m_fileName;
     QString m_moveDone;
     QString m_result;
+    bool m_isHandicap;
     bool m_resignation;
     bool m_blackToMove;
     bool m_blackResigned;

--- a/autogtp/Game.h
+++ b/autogtp/Game.h
@@ -80,6 +80,7 @@ public:
     QString getWinnerName() const { return m_winner; }
     int getMovesCount() const { return m_moveNum; }
     void setMovesCount(int moves);
+    int getToMove() const { return m_blackToMove ? BLACK : WHITE; }
     QString getResult() const { return m_result.trimmed(); }
     enum {
         BLACK = 0,

--- a/autogtp/Game.h
+++ b/autogtp/Game.h
@@ -57,7 +57,9 @@ class Game : QProcess {
 public:
     Game(const Engine& engine);
     ~Game() = default;
-    bool gameStart(const VersionTuple& min_version);
+    bool gameStart(const VersionTuple& min_version,
+                   const QString &sgf = QString(),
+                   const int moves = 0);
     void move();
     bool waitForMove() { return waitReady(); }
     bool readMove();

--- a/autogtp/Job.cpp
+++ b/autogtp/Job.cpp
@@ -158,30 +158,30 @@ Result ValidationJob::execute(){
         QFile::remove(m_sgf + ".sgf");
     }
 
-    QString wmove = "play white ";
-    QString bmove = "play black ";
+    const QString stringWhite = "white";
+    const QString stringBlack = "black";
+    //Start with the side to move set to the opposite of the expected way around
+    //because the game playing loop swaps the sides at the start of each iteration.
+    //This avoids having to test which side is to move on every iteration of the loop.
+    auto gameToMove = &second;
+    auto colorToMove = &stringWhite;
+    auto gameOpponent = &first;
+    auto colorOpponent = &stringBlack;
+    if (first.getToMove() == Game::WHITE) {
+        std::swap(gameToMove, gameOpponent);
+        std::swap(colorToMove, colorOpponent);
+    }
     do {
-        if (first.getToMove() == Game::BLACK) {
-            first.move();
-            if (!first.waitForMove()) {
-                return res;
-            }
-            first.readMove();
-            m_boss->incMoves();
-            if (first.checkGameEnd()) {
-                break;
-            }
-            second.setMove(bmove + first.getMove());
-            first.nextMove();
-        }
-        second.move();
-        if (!second.waitForMove()) {
+        std::swap(gameToMove, gameOpponent);
+        std::swap(colorToMove, colorOpponent);
+        gameToMove->move();
+        if (!gameToMove->waitForMove()) {
             return res;
         }
-        second.readMove();
+        gameToMove->readMove();
         m_boss->incMoves();
-        first.setMove(wmove + second.getMove());
-    } while (second.nextMove() && m_state.load() == RUNNING);
+        gameOpponent->setMove("play " + *colorToMove + " " + gameToMove->getMove());
+    } while (gameToMove->nextMove() && m_state.load() == RUNNING);
 
     switch (m_state.load()) {
     case RUNNING:

--- a/autogtp/Job.cpp
+++ b/autogtp/Job.cpp
@@ -68,21 +68,15 @@ WaitJob::WaitJob(QString gpu, Management *parent) :
 Result ProductionJob::execute(){
     Result res(Result::Error);
     Game game(m_engine);
-    if (!game.gameStart(m_leelazMinVersion)) {
+    if (!game.gameStart(m_leelazMinVersion, m_sgf, m_moves)) {
         return res;
     }
     if (!m_sgf.isEmpty()) {
-        if (m_moves == 0) {
-            game.loadSgf(m_sgf);
-        } else {
-            game.loadSgf(m_sgf, m_moves);
-        }
-        game.setMovesCount(m_moves);
+        QFile::remove(m_sgf + ".sgf");
         if (m_restore) {
             game.loadTraining(m_sgf);
             QFile::remove(m_sgf + ".train");
         }
-        QFile::remove(m_sgf + ".sgf");
     }
     do {
         game.move();
@@ -138,23 +132,14 @@ void ProductionJob::init(const Order &o) {
 Result ValidationJob::execute(){
     Result res(Result::Error);
     Game first(m_engineFirst);
-    if (!first.gameStart(m_leelazMinVersion)) {
+    if (!first.gameStart(m_leelazMinVersion, m_sgf, m_moves)) {
         return res;
     }
     Game second(m_engineSecond);
-    if (!second.gameStart(m_leelazMinVersion)) {
+    if (!second.gameStart(m_leelazMinVersion, m_sgf, m_moves)) {
         return res;
     }
     if (!m_sgf.isEmpty()) {
-        if (m_moves == 0) {
-            first.loadSgf(m_sgf);
-            second.loadSgf(m_sgf);
-        } else {
-            first.loadSgf(m_sgf, m_moves);
-            second.loadSgf(m_sgf, m_moves);
-        }
-        first.setMovesCount(m_moves);
-        second.setMovesCount(m_moves);
         QFile::remove(m_sgf + ".sgf");
     }
 

--- a/autogtp/Management.cpp
+++ b/autogtp/Management.cpp
@@ -22,11 +22,13 @@
 #include <QThread>
 #include <QList>
 #include <QCryptographicHash>
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QLockFile>
 #include <QUuid>
 #include <QRegularExpression>
+#include <QVariant>
 #include "Management.h"
 #include "Game.h"
 
@@ -274,6 +276,14 @@ QString Management::getOptionsString(const QJsonObject &opt, const QString &rnd)
     return options;
 }
 
+QString Management::getGtpCommandsString(const QJsonValue &gtpCommands) {
+    const auto gtpCommandsJsonDoc = QJsonDocument(gtpCommands.toArray());
+    const auto gtpCommandsJson = gtpCommandsJsonDoc.toJson(QJsonDocument::Compact);
+    auto gtpCommandsString = QVariant(gtpCommandsJson).toString();
+    gtpCommandsString.remove(QRegularExpression("[\\[\\]\"]"));
+    return gtpCommandsString;
+}
+
 Order Management::getWorkInternal(bool tuning) {
     Order o(Order::Error);
 
@@ -304,7 +314,9 @@ Order Management::getWorkInternal(bool tuning) {
     white_hash_gzip_hash: "23c29bf777e446b5c3fb0e6e7fa4d53f15b99cc0c25798b70b57877b55bf1638",
     black_hash_gzip_hash: "ccfe6023456aaaa423c29bf777e4aab481245289aaaabb70b7b5380992377aa8",
     hash_sgf_hash: "7dbccc5ad9eb38f0135ff7ec860f0e81157f47dfc0a8375cef6bf1119859e537",
-    moves_count: "92"
+    moves_count: "92",
+    gtp_commands : [ "time_settings 600 30 1", "komi 0.5", "fixed_handicap 2" ],
+    white_gtp_commands : [ "time_settings 0 10 1", "komi 0.5", "fixed_handicap 2" ],
 }
 
 {
@@ -323,7 +335,8 @@ Order Management::getWorkInternal(bool tuning) {
     },
     hash_gzip_hash: "23c29bf777e446b5c3fb0e6e7fa4d53f15b99cc0c25798b70b57877b55bf1638",
     hash_sgf_hash: "7dbccc5ad9eb38f0135ff7ec860f0e81157f47dfc0a8375cef6bf1119859e537",
-    moves_count: "92"
+    moves_count: "92",
+    gtp_commands : [ "time_settings 600 30 1", "komi 0.5", "fixed_handicap 4" ],
 }
 
 {
@@ -408,6 +421,9 @@ Order Management::getWorkInternal(bool tuning) {
         parameters["optHash"] = ob.value("options_hash").toString();
         parameters["options"] = getOptionsString(ob.value("options").toObject(), rndSeed);
     }
+    if (ob.contains("gtp_commands")) {
+        parameters["gtpCommands"] = getGtpCommandsString(ob.value("gtp_commands"));
+    }
     if (ob.contains("hash_sgf_hash")) {
         parameters["sgf"] = fetchGameData(ob.value("hash_sgf_hash").toString(), "sgf");
         parameters["moves"] = ob.contains("moves_count") ?
@@ -448,6 +464,11 @@ Order Management::getWorkInternal(bool tuning) {
         parameters["optionsSecond"] = ob.contains("white_options") ?
             getOptionsString(ob.value("white_options").toObject(), rndSeed) :
             parameters["options"];
+        if (ob.contains("gtp_commands")) {
+            parameters["gtpCommandsSecond"] = ob.contains("white_gtp_commands") ?
+                getGtpCommandsString(ob.value("white_gtp_commands")) :
+                parameters["gtpCommands"];
+        }
 
         o.type(Order::Validation);
         o.parameters(parameters);

--- a/autogtp/Management.h
+++ b/autogtp/Management.h
@@ -90,6 +90,7 @@ private:
     QString getOption(const QJsonObject &ob, const QString &key, const QString &opt, const QString &defValue);
     QString getBoolOption(const QJsonObject &ob, const QString &key, const QString &opt, bool defValue);
     QString getOptionsString(const QJsonObject &opt, const QString &rnd);
+    QString getGtpCommandsString(const QJsonValue &gtpCommands);
     void sendAllGames();
     void checkStoredGames();
     QFileInfo getNextStored();

--- a/autogtp/Order.cpp
+++ b/autogtp/Order.cpp
@@ -42,14 +42,14 @@ void Order::load(const QString &file) {
         return;
     }
     QTextStream in(&f);
-    in >>  m_type;
+    in >> m_type;
     int count;
     in >> count;
     QString key;
     for (int i = 0; i < count; i++) {
         in >> key;
-        if (key == "options" || key == "optionsSecond") {
-            m_parameters[key] = in.readLine();
+        if (key.contains("options") || key.contains("gtpCommands")) {
+            m_parameters[key] = in.readLine().remove(0, 1);
         } else {
             in >> m_parameters[key];
         }


### PR DESCRIPTION
Allows for the server to optionally add something like this to the JSON for self-play and match jobs:
```
    gtp_commands : [ "time_settings 600 30 1", "komi 0.5", "fixed_handicap 2" ],
```
and additionally optional for match jobs:
```
    white_gtp_commands : [ "time_settings 0 10 1", "komi 0.5", "fixed_handicap 2" ],
```

No separate hash has been added; I propose that the existing `options_hash` is calculated over `options [+ white_options] [+ gtp_commands [+ white_gtp_commands]]`.

Also add support for white taking the first move in handicapped job games.

Tested by locally modifying the the JSON inputs for orders to produce both self-play and match games. Confirmed they worked ok and saving and restoring still works.
I did pick up on one existing issue/missing feature that leelaz doesn't parse sgf time properties for a `loadsgf` GTP command. `printsgf` also doesn't write time or stones remaining for either side. I'll raise a separate issue for that though.

I think this may be useful for the server performing time controlled test matches (the range of hardware would mean a large variety for the number of playouts achieved but the two sides should have approximately equal strength on any given machine) and for producing training games with komi and/or handicap.