### PR TITLE
Make sure analysis for 'info move' line is printed at least once

### DIFF
--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -744,6 +744,10 @@ int UCTSearch::think(int color, passflag_t passflag) {
         keeprunning &= have_alternate_moves(elapsed_centis, time_for_move);
     } while (keeprunning);
 
+    if (last_output == 0) {
+        output_analysis(m_rootstate, *m_root);
+    }
+
     // stop the search
     m_run = false;
     tg.wait_all();
@@ -808,6 +812,10 @@ void UCTSearch::ponder() {
         keeprunning  = is_running();
         keeprunning &= !stop_thinking(0, 1);
     } while (!Utils::input_pending() && keeprunning);
+
+    if (last_output == 0) {
+        output_analysis(m_rootstate, *m_root);
+    }
 
     // stop the search
     m_run = false;


### PR DESCRIPTION
For move analysis make sure to output the "info move ..." line at least once. This is useful for client programs expecting/parsing the info move line.

When you do an analysis with a limited number of visits it will finish and put it in the cache.  Re-running the analysis with the same move will finish the analysis before the interval to output the "info move ..."  line so the user/client never gets the easy to parse/read info move line from ::output_analysis.

This fix makes sure to output the analysis if it not outputted after the automatic interval period.