### PR TITLE
Building for Mac OS X updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ by adding -DUSE_CPU_ONLY=1 to the cmake command line.
     git submodule update --init --recursive
 
     # Install build depedencies
-    brew install boost cmake
+    brew install boost cmake zlib qt5
 
     # Use stand alone directory to keep source dir clean
     mkdir build && cd build


### PR DESCRIPTION
I went through the Mac part today and had to brew install zlib and qt5 also to make cmake happy. I've added these two to the list.