### PR TITLE
Fixed leelaz_file on Android

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -177,7 +177,7 @@ size_t Utils::ceilMultiple(size_t a, size_t b) {
 }
 
 const std::string Utils::leelaz_file(std::string file) {
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__ANDROID__)
     boost::filesystem::path dir(boost::filesystem::current_path());
 #else
     // https://stackoverflow.com/a/26696759


### PR DESCRIPTION
Currently Android is treated the same way as everything not-Windows, but this function fails as LZ tries to create the ~/.local/share/leela-zero directory.

There isn't an obvious generic place to use, so defaulting to the current directory as with Windows is probably the safest option.

With this change, the only additions to Leela Zero needed to work on Android are to set up the right compiler toolchain in the Makefile, as discussed at https://github.com/gcp/leela-zero/issues/779.