### PR TITLE
CPU-only option and output fix

### DIFF
--- a/autogtp/Management.cpp
+++ b/autogtp/Management.cpp
@@ -128,7 +128,7 @@ void Management::giveAssignments() {
                 myGpu = m_gpusList.at(gpu);
             }
             QTextStream(stdout) << "Starting thread " << game + 1 ;
-            QTextStream(stdout) << " on GPU " << gpu << endl;
+            QTextStream(stdout) << " on device " << gpu << endl;
             m_gamesThreads[thread_index] = new Worker(thread_index, myGpu, this);
             connect(m_gamesThreads[thread_index],
                     &Worker::resultReady,

--- a/autogtp/main.cpp
+++ b/autogtp/main.cpp
@@ -49,11 +49,11 @@ int main(int argc, char *argv[]) {
 
     QCommandLineOption gamesNumOption(
         {"g", "gamesNum"},
-              "Play 'gamesNum' games on one GPU at the same time.",
+              "Play 'gamesNum' games on one device (GPU/CPU) at the same time.",
               "num", "1");
     QCommandLineOption gpusOption(
         {"u", "gpus"},
-              "Index of the GPU to use for multiple GPUs support.",
+              "Index of the device(s) to use for multiple devices support.",
               "num");
     QCommandLineOption keepSgfOption(
         {"k", "keepSgf" },
@@ -119,7 +119,7 @@ int main(int argc, char *argv[]) {
     // Map streams
     QTextStream cerr(stderr, QIODevice::WriteOnly);
     cerr << "AutoGTP v" << AUTOGTP_VERSION << endl;
-    cerr << "Using " << gamesNum << " thread(s) for GPU(s)." << endl;
+    cerr << "Using " << gamesNum << " game thread(s) per device." << endl;
     if (parser.isSet(keepSgfOption)) {
         if (!QDir().mkpath(parser.value(keepSgfOption))) {
             cerr << "Couldn't create output directory for self-play SGF files!"

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -93,10 +93,12 @@ static void parse_commandline(int argc, char *argv[]) {
         ("noponder", "Disable thinking on opponent's time.")
         ("benchmark", "Test network and exit. Default args:\n-v3200 --noponder "
                       "-m0 -t1 -s1.")
-        ("cpu-only", "Use CPU-only implementation and do not use GPU.")
+#ifndef USE_CPU_ONLY
+        ("cpu-only", "Use CPU-only implementation and do not use OpenCL device(s).")
+#endif
         ;
 #ifdef USE_OPENCL
-    po::options_description gpu_desc("GPU options");
+    po::options_description gpu_desc("OpenCL device options");
     gpu_desc.add_options()
         ("gpu",  po::value<std::vector<int> >(),
                 "ID of the OpenCL device(s) to use (disables autodetection).")
@@ -305,9 +307,11 @@ static void parse_commandline(int argc, char *argv[]) {
         cfg_dumbpass = true;
     }
 
+#ifndef USE_CPU_ONLY
     if (vm.count("cpu-only")) {
         cfg_cpu_only = true;
     }
+#endif
 
     if (vm.count("playouts")) {
         cfg_max_playouts = vm["playouts"].as<int>();

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -666,7 +666,7 @@ void Network::compare_net_outputs(const Netresult& data,
     error = std::sqrt(error);
 
     if (error > max_error || std::isnan(error)) {
-        printf("Error in OpenCL calculation: Update your GPU drivers "
+        printf("Error in OpenCL calculation: Update your device's OpenCL drivers "
                "or reduce the amount of games played simultaneously.\n");
         throw std::runtime_error("OpenCL self-check mismatch.");
     }

--- a/validation/main.cpp
+++ b/validation/main.cpp
@@ -62,11 +62,11 @@ int main(int argc, char *argv[]) {
             "lower:upper", "0.0:35.0");
     QCommandLineOption gamesNumOption(
         {"g", "gamesNum"},
-            "Play 'gamesNum' games on one GPU at the same time.",
+            "Play 'gamesNum' games on one device (GPU/CPU) at the same time.",
             "num", "1");
     QCommandLineOption gpusOption(
         {"u", "gpus"},
-            "Index of the GPU to use for multiple GPUs support.",
+            "Index of the device(s) to use for multiple devices support.",
             "num");
     QCommandLineOption keepSgfOption(
         {"k", "keepSgf" },


### PR DESCRIPTION
Removed --cpu-only option from USE_CPU_ONLY build and generalised output displayed in cases where potentially referring to a CPU instead of or as well as a GPU.
Fixes #593.