### PR TITLE
Add gomill-explain_last_move for additional output in ringmaster

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -213,6 +213,7 @@ const std::string GTP::s_commands[] = {
     "lz-genmove_analyze",
     "lz-memory_report",
     "lz-setoption",
+    "gomill-explain_last_move",
     ""
 };
 
@@ -651,7 +652,7 @@ void GTP::execute(GameState & game, const std::string& xinput) {
         } while (game.get_passes() < 2 && !game.has_resigned());
 
         return;
-    } else if (command.find("go") == 0) {
+    } else if (command.find("go") == 0 && command.size() < 6) {
         int move = search->think(game.get_to_move());
         game.play_move(move);
 
@@ -970,6 +971,9 @@ void GTP::execute(GameState & game, const std::string& xinput) {
         return;
     } else if (command.find("lz-setoption") == 0) {
         return execute_setoption(*search.get(), id, command);
+    } else if (command.find("gomill-explain_last_move") == 0) {
+        gtp_printf(id, "%s\n", search->explain_last_think().c_str());
+        return;
     }
     gtp_fail_printf(id, "unknown command");
     return;

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -114,6 +114,7 @@ public:
     void ponder();
     bool is_running() const;
     void increment_playouts();
+    std::string explain_last_think() const;
     SearchResult play_simulation(GameState& currstate, UCTNode* const node);
 
 private:
@@ -121,7 +122,7 @@ private:
     void dump_stats(FastState& state, UCTNode& parent);
     void tree_stats(const UCTNode& node);
     std::string get_pv(FastState& state, UCTNode& parent);
-    void dump_analysis(int playouts);
+    std::string get_analysis();
     bool should_resign(passflag_t passflag, float besteval);
     bool have_alternate_moves(int elapsed_centis, int time_for_move);
     int est_playouts_left(int elapsed_centis, int time_for_move) const;
@@ -141,6 +142,7 @@ private:
     std::atomic<bool> m_run{false};
     int m_maxplayouts;
     int m_maxvisits;
+    std::string m_think_output;
 
     std::list<Utils::ThreadGroup> m_delete_futures;
 


### PR DESCRIPTION
This enable me to plot the evaluation across the game

There are other uses of boost::format in the code but I'm open to rewrite this if you prefer something else.

[LZ vs ELF](lz vs 
https://cloudygo.com/ringmaster/minigo-converted-v-elf.games/mg-c-v15-19x19_001005-modeste_v_lz-ELF_V1_d13c40_p1600_99.sgf/)
![screenshot from 2019-01-26 18-48-36](https://user-images.githubusercontent.com/10172976/51795597-063fc200-219b-11e9-818e-7c9839c675a8.png)

