### PR TITLE
Increase default thread count.

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -307,10 +307,10 @@ void GTP::setup_default_parameters() {
     cfg_allow_pondering = true;
     cfg_max_threads = std::max(1, std::min(SMP::get_num_cpus(), MAX_CPUS));
 #ifdef USE_OPENCL
-    // If we will be GPU limited, using many threads won't help much.
-    // Multi-GPU is a different story, but we will assume that those people
-    // who do those stuff will know what they are doing.
-    cfg_num_threads = std::min(2, cfg_max_threads);
+    // The ideal value is likely driver and card dependant,
+    // but at least on large cards we continue to scale up
+    // quickly at least till 8 threads.
+    cfg_num_threads = std::min(8, cfg_max_threads);
 #else
     cfg_num_threads = cfg_max_threads;
 #endif


### PR DESCRIPTION
Benchmarking on modern hardware (aka RTX 2080 card) indicates that we're
no longer saturing the GPU with 2 threads, far from it in fact. I see
substantial scaling past 2 threads, with even a small increase going
from 8 to 16, showing that our scaling improvements have been
successful.

On the other hand, older hardware and drivers might not scale as well,
and the search does get less efficient because MCTS scaling is not
perfect.

So change the default from 2 to 8 threads, capped by the number of
hardware threads.